### PR TITLE
Use urlencode for search queries (fixes #10)

### DIFF
--- a/src/shared/components/navbar.tsx
+++ b/src/shared/components/navbar.tsx
@@ -137,8 +137,9 @@ export class Navbar extends Component<NavbarProps, NavbarState> {
     if (searchParam === '') {
       this.context.router.history.push(`/search/`);
     } else {
+      const searchParamEncoded = encodeURIComponent(searchParam);
       this.context.router.history.push(
-        `/search/q/${searchParam}/type/All/sort/TopAll/page/1`
+        `/search/q/${searchParamEncoded}/type/All/sort/TopAll/page/1`
       );
     }
   }

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -84,7 +84,7 @@ export class Search extends Component<any, SearchState> {
   };
 
   static getSearchQueryFromProps(q: string): string {
-    return q || '';
+    return decodeURIComponent(q) || '';
   }
 
   static getSearchTypeFromProps(type_: string): SearchType {
@@ -504,11 +504,12 @@ export class Search extends Component<any, SearchState> {
 
   updateUrl(paramUpdates: UrlParams) {
     const qStr = paramUpdates.q || this.state.q;
+    const qStrEncoded = encodeURIComponent(qStr);
     const typeStr = paramUpdates.type_ || this.state.type_;
     const sortStr = paramUpdates.sort || this.state.sort;
     const page = paramUpdates.page || this.state.page;
     this.props.history.push(
-      `/search/q/${qStr}/type/${typeStr}/sort/${sortStr}/page/${page}`
+      `/search/q/${qStrEncoded}/type/${typeStr}/sort/${sortStr}/page/${page}`
     );
   }
 


### PR DESCRIPTION
This fixes the search for URLs like `http://lemmy-beta:8551/c/main`, and correctly displays the community in the search results. Both when searching from the navbar and from the search page.

I also tested the HTTP API using `curl "http://localhost:8540/api/v1/search?q=test%3F&type_=All&sort=TopAll"`, which is logged on the backend as `q: "test?"`, so it looks like actix is already decoding parameters for us, and we dont have to change anything there.

I think this also needs to be fixed [here in lemmy-js-client](https://github.com/LemmyNet/lemmy-js-client/blob/main/src/http.ts#L137).