### PR TITLE
COPY requires / suffix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,13 @@ WORKDIR /usr/src/app
 COPY package.json yarn.lock ./
 RUN yarn install --pure-lockfile
 
-# Build 
+# Build
 COPY generate_translations.js \
   tsconfig.json \
   webpack.config.js \
   .babelrc \
-  .
+  ./
+
 COPY lemmy-translations lemmy-translations
 COPY src src
 


### PR DESCRIPTION
I got this error when building:
`When using COPY with more than one source file, the destination must be a directory and end with a /`