### PR TITLE
Feature/i18n type constraints

### DIFF
--- a/generate_translations.js
+++ b/generate_translations.js
@@ -1,27 +1,64 @@
-fs = require('fs');
+const fs = require("fs");
 
-let translationDir = 'lemmy-translations/translations/';
-let outDir = 'src/shared/translations/';
+const translationDir = "lemmy-translations/translations/";
+const outDir = "src/shared/translations/";
 fs.mkdirSync(outDir, { recursive: true });
 fs.readdir(translationDir, (_err, files) => {
   files.forEach(filename => {
-    const lang = filename.split('.')[0];
+    const lang = filename.split(".")[0];
     try {
       const json = JSON.parse(
-        fs.readFileSync(translationDir + filename, 'utf8')
+        fs.readFileSync(translationDir + filename, "utf8")
       );
-      var data = `export const ${lang} = {\n  translation: {`;
-      for (var key in json) {
+      let data = `export const ${lang} = {\n  translation: {`;
+      for (const key in json) {
         if (key in json) {
           const value = json[key].replace(/"/g, '\\"');
-          data = `${data}\n    ${key}: "${value}",`;
+          data += `\n    ${key}: "${value}",`;
         }
       }
-      data += '\n  },\n};';
-      const target = outDir + lang + '.ts';
+      data += "\n  },\n};";
+      const target = outDir + lang + ".ts";
       fs.writeFileSync(target, data);
     } catch (err) {
       console.error(err);
     }
   });
+});
+
+// generate types for i18n keys
+const baseLanguage = "en";
+
+fs.readFile(`${translationDir}${baseLanguage}.json`, "utf8", (_, fileStr) => {
+  const keys = Object.keys(JSON.parse(fileStr));
+
+  const data = `import * as i18n from "i18next";
+
+type I18nKeys = 
+${keys.map(key => `  | "${key}"`).join("\n")};
+
+declare module "i18next" {
+  export interface TFunction {
+    // basic usage
+    <
+      TResult extends TFunctionResult = string,
+      TInterpolationMap extends object = StringMap
+    >(
+      key: I18nKeys | I18nKeys[],
+      options?: TOptions<TInterpolationMap> | string
+    ): TResult;
+    // overloaded usage
+    <
+      TResult extends TFunctionResult = string,
+      TInterpolationMap extends object = StringMap
+    >(
+      key: I18nKeys | I18nKeys[],
+      defaultValue?: string,
+      options?: TOptions<TInterpolationMap> | string
+    ): TResult;
+  }
+}
+`;
+
+  fs.writeFileSync(`${outDir}i18next.d.ts`, data);
 });

--- a/generate_translations.js
+++ b/generate_translations.js
@@ -32,17 +32,17 @@ const baseLanguage = "en";
 fs.readFile(`${translationDir}${baseLanguage}.json`, "utf8", (_, fileStr) => {
   const keys = Object.keys(JSON.parse(fileStr));
 
-  const data = `import * as i18n from "i18next";
-
-type I18nKeys = 
-${keys.map(key => `  | "${key}"`).join("\n")};
+  const data = `import { i18n } from "i18next";
 
 declare module "i18next" {
-  export interface TFunction {
+  export type I18nKeys = 
+${keys.map(key => `    | "${key}"`).join("\n")};
+  
+  export interface TFunctionTyped {
     // basic usage
     <
       TResult extends TFunctionResult = string,
-      TInterpolationMap extends object = StringMap
+      TInterpolationMap extends Record<string, unknown> = StringMap
     >(
       key: I18nKeys | I18nKeys[],
       options?: TOptions<TInterpolationMap> | string
@@ -50,12 +50,16 @@ declare module "i18next" {
     // overloaded usage
     <
       TResult extends TFunctionResult = string,
-      TInterpolationMap extends object = StringMap
+      TInterpolationMap extends Record<string, unknown> = StringMap
     >(
       key: I18nKeys | I18nKeys[],
       defaultValue?: string,
       options?: TOptions<TInterpolationMap> | string
     ): TResult;
+  }
+
+  export interface i18nTyped extends i18n {
+    t: TFunctionTyped;
   }
 }
 `;

--- a/src/shared/components/no-match.tsx
+++ b/src/shared/components/no-match.tsx
@@ -1,8 +1,11 @@
+import { I18nKeys } from "i18next";
 import { Component } from "inferno";
 import { i18n } from "../i18next";
 
 export class NoMatch extends Component<any, any> {
-  private errCode = new URLSearchParams(this.props.location.search).get("err");
+  private errCode = new URLSearchParams(this.props.location.search).get(
+    "err"
+  ) as I18nKeys;
 
   constructor(props: any, context: any) {
     super(props, context);

--- a/src/shared/i18next.ts
+++ b/src/shared/i18next.ts
@@ -1,4 +1,4 @@
-import i18next from "i18next";
+import i18next, { i18nTyped } from "i18next";
 import { getLanguage } from "./utils";
 import { en } from "./translations/en";
 import { el } from "./translations/el";
@@ -82,4 +82,6 @@ i18next.init({
   interpolation: { format },
 });
 
-export { i18next as i18n, resources };
+export const i18n = i18next as i18nTyped;
+
+export { resources };


### PR DESCRIPTION
This makes the `i18n` keys strongly typed. Results in static checks of keys, and nice autocomplete of the available keys:

![image](https://user-images.githubusercontent.com/29288116/109555687-235fc100-7ad6-11eb-8540-c68aa269e7a9.png)

Running `yarn lint` found a key [`"disclaimer"`](https://github.com/LemmyNet/lemmy-ui/blob/1916483ce9eaabdc869fac424d13b5b4f1179e63/src/shared/components/private-message-form.tsx#L122) being used that is not present in the translations (this might cause the CI to fail). All other strings are correct.

Technically speaking this just generates a union type of all i18n keys and constraining i18n.t() to those keys.