### PR TITLE
Set listen host and port with environment variables

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -21,7 +21,8 @@ import { IncomingHttpHeaders } from "http";
 import { setOptionalAuth } from "../shared/utils";
 
 const server = express();
-const port = 1234;
+const hostname = process.env['LEMMY_UI_HOST'] || 'localhost'
+const port = process.env['LEMMY_UI_PORT'] || 1234;
 
 server.use(express.json());
 server.use(express.urlencoded({ extended: false }));
@@ -154,8 +155,8 @@ server.get("/*", async (req, res) => {
 `);
 });
 
-server.listen(port, () => {
-  console.log(`http://localhost:${port}`);
+server.listen(port, hostname, () => {
+  console.log(`http://${hostname}:${port}`);
 });
 
 function setForwardedHeaders(

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -155,7 +155,7 @@ server.get("/*", async (req, res) => {
 `);
 });
 
-server.listen(port, hostname, () => {
+server.listen(Number(port), hostname, () => {
   console.log(`http://${hostname}:${port}`);
 });
 


### PR DESCRIPTION
At the moment the process listens on localhost, hard coded. This makes it hard for me to deploy in Kubernetes.

So I would very much appreciate if the server could take listen host and port from environment.