### PR TITLE
Fix the thumbnail size

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -168,7 +168,6 @@ blockquote {
 .thumbnail {
   object-fit: cover;
   min-height: 60px;
-  max-height: 80px;
   width: 100%;
 }
 


### PR DESCRIPTION
This commit removes the height restriction and makes
thumbnails fill up their designated place.

![lemmy](https://user-images.githubusercontent.com/17176259/124806749-49a8d800-df72-11eb-8eb1-691eb37634bd.png)