### PR TITLE
Add robots.txt file

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -28,7 +28,20 @@ server.use(express.json());
 server.use(express.urlencoded({ extended: false }));
 server.use("/static", express.static(path.resolve("./dist")));
 
+const robotstxt =
+`User-Agent: *
+Disallow: /login
+Disallow: /settings
+Disallow: /create_community
+Disallow: /create_post
+Disallow: /inbox
+Disallow: /search/
+`;
 // server.use(cookieParser());
+server.get("/robots.txt", async (req, res) => {
+  res.setHeader("content-type","text/plain; charset=utf-8") 
+  res.send(robotstxt)
+});
 
 server.get("/*", async (req, res) => {
   const activeRoute = routes.find(route => matchPath(req.path, route)) || {};


### PR DESCRIPTION
Reasoning for patch:

Some search engines and crawler bots rely on the robots.txt file to know what parts of the site to crawl or not crawl. Without one, it will proceed to crawl the entire site by deafult. However, it doesn't make sense for bots to crawl parts that require a login or are user directed , like "create_community" or "login". Some poorly programmed bots will constantly hit an endpoint that doesn't make sense, causing general slowness for everyone.

Suggestions for other protected endpoints welcome.