### PR TITLE
Post form community name using title instead of name

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1462,7 +1462,7 @@ export const choicesConfig = {
 
 export function communitySelectName(cv: CommunityView): string {
   return cv.community.local
-    ? cv.community.name
+    ? cv.community.title
     : `${hostname(cv.community.actor_id)}/${cv.community.name}`;
 }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1468,7 +1468,7 @@ export function communitySelectName(cv: CommunityView): string {
 
 export function personSelectName(pvs: PersonViewSafe): string {
   return pvs.person.local
-    ? pvs.person.display_name
+    ? pvs.person.display_name || pvs.person.name
     : `${hostname(pvs.person.actor_id)}/${pvs.person.name}`;
 }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1468,7 +1468,7 @@ export function communitySelectName(cv: CommunityView): string {
 
 export function personSelectName(pvs: PersonViewSafe): string {
   return pvs.person.local
-    ? pvs.person.name
+    ? pvs.person.display_name
     : `${hostname(pvs.person.actor_id)}/${pvs.person.name}`;
 }
 


### PR DESCRIPTION
Hi,  I deployed an instance in another language and found that when posting , the form comminity displays the  community ID instead of its display name, but it's a bit inconvenient for non-native English instances, so I submitted the PR.

I can close this PR if you don't think you need it, and it will only work for my instance.

Thanks!