### PR TITLE
Fix comment fedilink (fixes #594)

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -867,12 +867,11 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
         >
           <Icon icon="link" classes="icon-inline" />
         </Link>
-        {/* TODO comment ap_ids are currently broken anyway, so use post.ap_id, and wait until comment tree / endpoint refactor */}
-        {!cv.comment.local && (
-          <a className={classnames} title={title} href={cv.post.ap_id}>
+        {
+          <a className={classnames} title={title} href={cv.comment.ap_id}>
             <Icon icon="fedilink" classes="icon-inline" />
           </a>
-        )}
+        }
       </>
     );
   }


### PR DESCRIPTION
Unlike what the comment says, comment ap_ids are not broken at all. The only problem is that no frontend endpoint exists for that url. But if you want to e.g. fetch a specific Lemmy comment from Mastodon and respond to it, this fedilink is the only way (as the normal link `/post/123/comment/456` doesnt work for that).