### PR TITLE
Dont allow community urls like /c/{id} (fixes #611)

### DIFF
--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -166,10 +166,8 @@ export class Community extends Component<any, State> {
     let pathSplit = req.path.split("/");
     let promises: Promise<any>[] = [];
 
-    let idOrName = pathSplit[2];
-    let name_ = idOrName;
-
-    let communityForm: GetCommunity = { name: name_ };
+    let communityName = pathSplit[2];
+    let communityForm: GetCommunity = { name: communityName };
     setOptionalAuth(communityForm, req.auth);
     promises.push(req.client.getCommunity(communityForm));
 
@@ -197,7 +195,7 @@ export class Community extends Component<any, State> {
         saved_only: false,
       };
       setOptionalAuth(getPostsForm, req.auth);
-      this.setName(getPostsForm, name_);
+      this.setName(getPostsForm, communityName);
       promises.push(req.client.getPosts(getPostsForm));
     } else {
       let getCommentsForm: GetComments = {
@@ -207,7 +205,7 @@ export class Community extends Component<any, State> {
         type_: ListingType.Community,
         saved_only: false,
       };
-      this.setName(getCommentsForm, name_);
+      this.setName(getCommentsForm, communityName);
       setOptionalAuth(getCommentsForm, req.auth);
       promises.push(req.client.getComments(getCommentsForm));
     }

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -166,17 +166,10 @@ export class Community extends Component<any, State> {
     let pathSplit = req.path.split("/");
     let promises: Promise<any>[] = [];
 
-    // It can be /c/main, or /c/1
     let idOrName = pathSplit[2];
-    let id: number;
-    let name_: string;
-    if (isNaN(Number(idOrName))) {
-      name_ = idOrName;
-    } else {
-      id = Number(idOrName);
-    }
+    let name_ = idOrName;
 
-    let communityForm: GetCommunity = id ? { id } : { name: name_ };
+    let communityForm: GetCommunity = { name: name_ };
     setOptionalAuth(communityForm, req.auth);
     promises.push(req.client.getCommunity(communityForm));
 

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -154,6 +154,7 @@ export class Profile extends Component<any, ProfileState> {
     let pathSplit = req.path.split("/");
     let promises: Promise<any>[] = [];
 
+    let username = pathSplit[2];
     let view = this.getViewFromProps(pathSplit[4]);
     let sort = this.getSortTypeFromProps(pathSplit[6]);
     let page = this.getPageFromProps(Number(pathSplit[8]));
@@ -163,10 +164,10 @@ export class Profile extends Component<any, ProfileState> {
       saved_only: view === PersonDetailsView.Saved,
       page,
       limit: fetchLimit,
-      username: pathSplit[2],
+      username: username,
     };
     setOptionalAuth(form, req.auth);
-    form.username;
+    form.username = username;
     promises.push(req.client.getPersonDetails(form));
     return promises;
   }

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -154,16 +154,6 @@ export class Profile extends Component<any, ProfileState> {
     let pathSplit = req.path.split("/");
     let promises: Promise<any>[] = [];
 
-    // It can be /u/me, or /username/1
-    let idOrName = pathSplit[2];
-    let person_id: number;
-    let username: string;
-    if (isNaN(Number(idOrName))) {
-      username = idOrName;
-    } else {
-      person_id = Number(idOrName);
-    }
-
     let view = this.getViewFromProps(pathSplit[4]);
     let sort = this.getSortTypeFromProps(pathSplit[6]);
     let page = this.getPageFromProps(Number(pathSplit[8]));
@@ -173,19 +163,12 @@ export class Profile extends Component<any, ProfileState> {
       saved_only: view === PersonDetailsView.Saved,
       page,
       limit: fetchLimit,
+      username: pathSplit[2],
     };
     setOptionalAuth(form, req.auth);
-    this.setIdOrName(form, person_id, username);
+    form.username;
     promises.push(req.client.getPersonDetails(form));
     return promises;
-  }
-
-  static setIdOrName(obj: any, id: number, name_: string) {
-    if (id) {
-      obj.person_id = id;
-    } else {
-      obj.username = name_;
-    }
   }
 
   componentDidMount() {

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -167,7 +167,6 @@ export class Profile extends Component<any, ProfileState> {
       username: username,
     };
     setOptionalAuth(form, req.auth);
-    form.username = username;
     promises.push(req.client.getPersonDetails(form));
     return promises;
   }


### PR DESCRIPTION
If the community identifier in url can be interpreted as a valid integer, lemmy-ui considers it as community id, which breaks things if a community has a name with only numbers.