### PR TITLE
Add posting restricted to mods

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "import-sort-style-module": "^6.0.0",
-    "lemmy-js-client": "0.17.0-rc.5",
+    "lemmy-js-client": "0.16.4-rc.2",
     "lint-staged": "^12.4.1",
     "mini-css-extract-plugin": "^2.6.0",
     "node-fetch": "^2.6.1",

--- a/src/shared/components/community/community-form.tsx
+++ b/src/shared/components/community/community-form.tsx
@@ -14,7 +14,6 @@ import {
   authField,
   capitalizeFirstLetter,
   randomStr,
-  toast,
   wsClient,
   wsJsonToRes,
   wsSubscribe,
@@ -51,6 +50,7 @@ export class CommunityForm extends Component<
       nsfw: false,
       icon: null,
       banner: null,
+      posting_restricted_to_mods: false,
       auth: authField(false),
     },
     loading: false,
@@ -79,6 +79,7 @@ export class CommunityForm extends Component<
         nsfw: cv.community.nsfw,
         icon: cv.community.icon,
         banner: cv.community.banner,
+        posting_restricted_to_mods: cv.community.posting_restricted_to_mods,
         auth: authField(),
       };
     }
@@ -228,6 +229,25 @@ export class CommunityForm extends Component<
             </div>
           )}
           <div class="form-group row">
+            <legend class="col-form-label col-6 pt-0">
+              {i18n.t("only_mods_can_post_in_community")}
+            </legend>
+            <div class="col-6">
+              <div class="form-check">
+                <input
+                  class="form-check-input position-static"
+                  id="community-only-mods-can-post"
+                  type="checkbox"
+                  checked={this.state.communityForm.posting_restricted_to_mods}
+                  onChange={linkEvent(
+                    this,
+                    this.handleCommunityPostingRestrictedToMods
+                  )}
+                />
+              </div>
+            </div>
+          </div>
+          <div class="form-group row">
             <div class="col-12">
               <button
                 type="submit"
@@ -295,6 +315,11 @@ export class CommunityForm extends Component<
     i.setState(i.state);
   }
 
+  handleCommunityPostingRestrictedToMods(i: CommunityForm, event: any) {
+    i.state.communityForm.posting_restricted_to_mods = event.target.checked;
+    i.setState(i.state);
+  }
+
   handleCancel(i: CommunityForm) {
     i.props.onCancel();
   }
@@ -323,7 +348,8 @@ export class CommunityForm extends Component<
     let op = wsUserOp(msg);
     console.log(msg);
     if (msg.error) {
-      toast(i18n.t(msg.error), "danger");
+      // Errors handled by top level pages
+      // toast(i18n.t(msg.error), "danger");
       this.state.loading = false;
       this.setState(this.state);
       return;

--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -76,8 +76,7 @@ export class CreateCommunity extends Component<any, CreateCommunityState> {
 
   parseMessage(msg: any) {
     if (msg.error) {
-      // Toast errors are already handled by community-form
-      return;
+      toast(i18n.t(msg.error), "danger");
     }
   }
 }

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -537,7 +537,8 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
   get canPost(): boolean {
     return (
       !this.props.community_view.community.posting_restricted_to_mods ||
-      (this.canMod && this.canAdmin)
+      this.canMod ||
+      this.canAdmin
     );
   }
 

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -82,7 +82,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
             {this.communityTitle()}
             {this.adminButtons()}
             {this.subscribe()}
-            {this.createPost()}
+            {this.canPost && this.createPost()}
           </div>
         </div>
         <div class="card border-secondary mb-3">
@@ -250,16 +250,14 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
   }
 
   createPost() {
-    let community_view = this.props.community_view;
+    let cv = this.props.community_view;
     return (
-      community_view.subscribed && (
+      cv.subscribed && (
         <Link
           className={`btn btn-secondary btn-block mb-2 ${
-            community_view.community.deleted || community_view.community.removed
-              ? "no-click"
-              : ""
+            cv.community.deleted || cv.community.removed ? "no-click" : ""
           }`}
-          to={`/create_post?community_id=${community_view.community.id}`}
+          to={`/create_post?community_id=${cv.community.id}`}
         >
           {i18n.t("create_a_post")}
         </Link>
@@ -533,6 +531,13 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
       this.props.admins
         .map(a => a.person.id)
         .includes(UserService.Instance.myUserInfo.local_user_view.person.id)
+    );
+  }
+
+  get canPost(): boolean {
+    return (
+      !this.props.community_view.community.posting_restricted_to_mods ||
+      (this.canMod && this.canAdmin)
     );
   }
 

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -636,7 +636,8 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
     let op = wsUserOp(msg);
     console.log(msg);
     if (msg.error) {
-      toast(i18n.t(msg.error), "danger");
+      // Errors handled by top level pages
+      // toast(i18n.t(msg.error), "danger");
       this.state.loading = false;
       this.setState(this.state);
       return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4813,10 +4813,10 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lemmy-js-client@0.17.0-rc.5:
-  version "0.17.0-rc.5"
-  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.17.0-rc.5.tgz#8065ddca68acfbccc7a693ae0f31d6ab66dce972"
-  integrity sha512-IuSYaK4//KVFg+s4Av/PaxMM2tQpP3sL6G3zXfzbrZfCEtBp9ZlOEMFAu/neRgNumVh+R/koIwf8iLh4UdYCdg==
+lemmy-js-client@0.16.4-rc.2:
+  version "0.16.4-rc.2"
+  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.16.4-rc.2.tgz#849b054ff37668c242db0202070bdb35f357f069"
+  integrity sha512-7ftHxpecqhHddfTJJC02eMB6N0jrtUBZVjt6CGC74J06kplBrsBQVETBqm33G1h1/SPHRHU1mqQ+f03PwsL+Ng==
 
 levn@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This adds the setting to the community form, as well as hides the create post button on the community for non-mods if the setting is enabled.