### PR TITLE
Add legal information (fixes #652)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "import-sort-style-module": "^6.0.0",
-    "lemmy-js-client": "0.16.4-rc.1",
+    "lemmy-js-client": "git+https://github.com/LemmyNet/lemmy-js-client.git#legal-info",
     "lint-staged": "^12.4.1",
     "mini-css-extract-plugin": "^2.6.0",
     "node-fetch": "^2.6.1",

--- a/src/shared/components/app/footer.tsx
+++ b/src/shared/components/app/footer.tsx
@@ -32,6 +32,13 @@ export class Footer extends Component<FooterProps, any> {
                 {i18n.t("modlog")}
               </NavLink>
             </li>
+            {this.props.site.site_view.site.legal_information && (
+              <li className="nav-item">
+                <NavLink className="nav-link" to="/legal">
+                  {i18n.t("legal_information")}
+                </NavLink>
+              </li>
+            )}
             {this.props.site.federated_instances && (
               <li class="nav-item">
                 <NavLink className="nav-link" to="/instances">

--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -2,6 +2,7 @@ import autosize from "autosize";
 import { Component, linkEvent } from "inferno";
 import {
   BannedPersonsResponse,
+  EditSite,
   GetBannedPersons,
   GetSiteConfig,
   GetSiteConfigResponse,
@@ -36,6 +37,7 @@ interface AdminSettingsState {
   siteRes: GetSiteResponse;
   siteConfigRes: GetSiteConfigResponse;
   siteConfigHjson: string;
+  legalInfo: string;
   loading: boolean;
   banned: PersonViewSafe[];
   siteConfigLoading: boolean;
@@ -44,11 +46,13 @@ interface AdminSettingsState {
 
 export class AdminSettings extends Component<any, AdminSettingsState> {
   private siteConfigTextAreaId = `site-config-${randomStr()}`;
+  private legalInfoTextAreaId = `legal-info-${randomStr()}`;
   private isoData = setIsoData(this.context);
   private subscription: Subscription;
   private emptyState: AdminSettingsState = {
     siteRes: this.isoData.site_res,
     siteConfigHjson: null,
+    legalInfo: null,
     siteConfigRes: {
       config_hjson: null,
     },
@@ -70,6 +74,8 @@ export class AdminSettings extends Component<any, AdminSettingsState> {
     if (this.isoData.path == this.context.router.route.match.url) {
       this.state.siteConfigRes = this.isoData.routeData[0];
       this.state.siteConfigHjson = this.state.siteConfigRes.config_hjson;
+      this.state.legalInfo =
+        this.state.siteRes.site_view.site.legal_information;
       this.state.banned = this.isoData.routeData[1].banned;
       this.state.siteConfigLoading = false;
       this.state.loading = false;
@@ -195,7 +201,7 @@ export class AdminSettings extends Component<any, AdminSettingsState> {
     return (
       <div>
         <h5>{i18n.t("admin_settings")}</h5>
-        <form onSubmit={linkEvent(this, this.handleSiteConfigSubmit)}>
+        <form onSubmit={linkEvent(this, this.handleAdminSettingsSubmit)}>
           <div class="form-group row">
             <label
               class="col-12 col-form-label"
@@ -208,6 +214,23 @@ export class AdminSettings extends Component<any, AdminSettingsState> {
                 id={this.siteConfigTextAreaId}
                 value={this.state.siteConfigHjson}
                 onInput={linkEvent(this, this.handleSiteConfigHjsonChange)}
+                class="form-control text-monospace"
+                rows={3}
+              />
+            </div>
+          </div>
+          <div class="form-group row">
+            <label
+              class="col-12 col-form-label"
+              htmlFor={this.legalInfoTextAreaId}
+            >
+              {i18n.t("legal_information")}
+            </label>
+            <div class="col-12">
+              <textarea
+                id={this.legalInfoTextAreaId}
+                value={this.state.legalInfo}
+                onInput={linkEvent(this, this.handleLegalInfoChange)}
                 class="form-control text-monospace"
                 rows={3}
               />
@@ -229,19 +252,34 @@ export class AdminSettings extends Component<any, AdminSettingsState> {
     );
   }
 
-  handleSiteConfigSubmit(i: AdminSettings, event: any) {
+  handleAdminSettingsSubmit(i: AdminSettings, event: any) {
     event.preventDefault();
     i.state.siteConfigLoading = true;
-    let form: SaveSiteConfig = {
-      config_hjson: this.state.siteConfigHjson,
+
+    // save config
+    let form1: SaveSiteConfig = {
+      config_hjson: i.state.siteConfigHjson,
       auth: authField(),
     };
-    WebSocketService.Instance.send(wsClient.saveSiteConfig(form));
+    WebSocketService.Instance.send(wsClient.saveSiteConfig(form1));
+
+    // save legal info
+    let form2: EditSite = {
+      legal_information: i.state.legalInfo,
+      auth: authField(),
+    };
+    WebSocketService.Instance.send(wsClient.editSite(form2));
+
     i.setState(i.state);
   }
 
   handleSiteConfigHjsonChange(i: AdminSettings, event: any) {
     i.state.siteConfigHjson = event.target.value;
+    i.setState(i.state);
+  }
+
+  handleLegalInfoChange(i: AdminSettings, event: any) {
+    i.state.legalInfo = event.target.value;
     i.setState(i.state);
   }
 

--- a/src/shared/components/home/legal.tsx
+++ b/src/shared/components/home/legal.tsx
@@ -1,0 +1,32 @@
+import { Component } from "inferno";
+import { GetSiteResponse } from "lemmy-js-client";
+import { i18n } from "../../i18next";
+import { md, setIsoData } from "../../utils";
+
+interface LegalState {
+  siteRes: GetSiteResponse;
+}
+
+export class Legal extends Component<any, LegalState> {
+  private isoData = setIsoData(this.context);
+  private emptyState: LegalState = {
+    siteRes: this.isoData.site_res,
+  };
+
+  constructor(props: any, context: any) {
+    super(props, context);
+    this.state = this.emptyState;
+  }
+
+  get documentTitle(): string {
+    return i18n.t("legal_information");
+  }
+
+  render() {
+    return (
+      <div class="container">
+        {md(this.state.siteRes.site_view.site.legal_information)}
+      </div>
+    );
+  }
+}

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -39,6 +39,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
       application_question: null,
       private_instance: null,
       default_theme: null,
+      legal_information: null,
       auth: authField(false),
     },
     loading: false,
@@ -76,6 +77,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
         application_question: site.application_question,
         private_instance: site.private_instance,
         default_theme: site.default_theme,
+        legal_information: site.legal_information,
         auth: authField(false),
       };
     }

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -5,6 +5,7 @@ import { CreateCommunity } from "./components/community/create-community";
 import { AdminSettings } from "./components/home/admin-settings";
 import { Home } from "./components/home/home";
 import { Instances } from "./components/home/instances";
+import { Legal } from "./components/home/legal";
 import { Login } from "./components/home/login";
 import { Setup } from "./components/home/setup";
 import { Signup } from "./components/home/signup";
@@ -154,4 +155,5 @@ export const routes: IRoutePropsWithFetch[] = [
     component: VerifyEmail,
   },
   { path: `/instances`, component: Instances },
+  { path: `/legal`, component: Legal },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4813,10 +4813,9 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lemmy-js-client@0.16.4-rc.1:
-  version "0.16.4-rc.1"
-  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.16.4-rc.1.tgz#dfa94a152a7abe75f50f2599a8d9b40c143f37ff"
-  integrity sha512-94Xh7A/WDywRaJ0GPXPaXZhyXqMzK0gAISNSB8m++2mC1WJalOqfjR72q/7PmLGxfjYO88/aWSz4Sk0SXWJjCw==
+"lemmy-js-client@git+https://github.com/LemmyNet/lemmy-js-client.git#legal-info":
+  version "0.17.0-rc.9"
+  resolved "git+https://github.com/LemmyNet/lemmy-js-client.git#43def4db22e9068ddcee558f4cd5c1b3bd407f31"
 
 levn@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This should work as far as i can tell, but there are two problems:
- legal information field on /admin is not populated when browsing from another page (its populated fine after reload)
- /legal page fails to load with error "TypeError: _utils__WEBPACK_IMPORTED_MODULE_3__.md is not a function"
- initial setup seems to be broken by this change (says `404: TypeError: Cannot read properties of null (reading 'site')` but i cant figure out why)