### PR TITLE
Fix NPE during new site startup

### DIFF
--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -113,7 +113,7 @@ export class Home extends Component<any, HomeState> {
     listingType: getListingTypeFromProps(
       this.props,
       ListingType[
-        this.isoData.site_res.site_view.site.default_post_listing_type
+        this.isoData.site_res.site_view?.site.default_post_listing_type
       ]
     ),
     dataType: getDataTypeFromProps(this.props),


### PR DESCRIPTION
Site from scratch in *dev* mode resulted in NPE on *home.tsx* that prevented anything to show up.

```
TypeError: Cannot read properties of null (reading 'site')
    at new Home (webpack://lemmy-ui/./src/shared/components/home/home.tsx?:73:188)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:170:28)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:221:20)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:221:20)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:303:35)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:307:39)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:221:20)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:337:37)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:221:20)
    at renderVNodeToString (/tmp/lemmy-ui/node_modules/inferno-server/dist/index.cjs.js:221:20)
```