### PR TITLE
Search button and input style fixes

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -306,7 +306,7 @@ pre {
 }
 
 .show-input {
-  width: 13em !important;
+  width: 13vw !important;
 }
 .hide-input {
   background: transparent !important;

--- a/src/shared/components/app/navbar.tsx
+++ b/src/shared/components/app/navbar.tsx
@@ -314,35 +314,39 @@ export class Navbar extends Component<NavbarProps, NavbarState> {
             {!this.context.router.history.location.pathname.match(
               /^\/search/
             ) && (
-              <form
-                className="form-inline mr-2"
-                onSubmit={linkEvent(this, this.handleSearchSubmit)}
-              >
-                <input
-                  id="search-input"
-                  className={`form-control mr-0 search-input ${
-                    this.state.toggleSearch ? "show-input" : "hide-input"
-                  }`}
-                  onInput={linkEvent(this, this.handleSearchParam)}
-                  value={this.state.searchParam}
-                  ref={this.searchTextField}
-                  type="text"
-                  placeholder={i18n.t("search")}
-                  onBlur={linkEvent(this, this.handleSearchBlur)}
-                ></input>
-                <label className="sr-only" htmlFor="search-input">
-                  {i18n.t("search")}
-                </label>
-                <button
-                  name="search-btn"
-                  onClick={linkEvent(this, this.handleSearchBtn)}
-                  className="px-1 btn btn-link"
-                  style="color: var(--gray)"
-                  aria-label={i18n.t("search")}
-                >
-                  <Icon icon="search" />
-                </button>
-              </form>
+              <ul className="navbar-nav">
+                <li className="nav-item">
+                  <form
+                    className="form-inline mr-2"
+                    onSubmit={linkEvent(this, this.handleSearchSubmit)}
+                  >
+                    <input
+                      id="search-input"
+                      className={`form-control mr-0 search-input ${
+                        this.state.toggleSearch ? "show-input" : "hide-input"
+                      }`}
+                      onInput={linkEvent(this, this.handleSearchParam)}
+                      value={this.state.searchParam}
+                      ref={this.searchTextField}
+                      disabled={!this.state.toggleSearch}
+                      type="text"
+                      placeholder={i18n.t("search")}
+                      onBlur={linkEvent(this, this.handleSearchBlur)}
+                    ></input>
+                    <label className="sr-only" htmlFor="search-input">
+                      {i18n.t("search")}
+                    </label>
+                    <button
+                      name="search-btn"
+                      onClick={linkEvent(this, this.handleSearchBtn)}
+                      className="px-1 btn btn-link nav-link"
+                      aria-label={i18n.t("search")}
+                    >
+                      <Icon icon="search" />
+                    </button>
+                  </form>
+                </li>
+              </ul>
             )}
             {UserService.Instance.myUserInfo.isSome() ? (
               <>

--- a/src/shared/components/app/navbar.tsx
+++ b/src/shared/components/app/navbar.tsx
@@ -317,7 +317,7 @@ export class Navbar extends Component<NavbarProps, NavbarState> {
               <ul className="navbar-nav">
                 <li className="nav-item">
                   <form
-                    className="form-inline mr-2"
+                    className="form-inline mr-1"
                     onSubmit={linkEvent(this, this.handleSearchSubmit)}
                   >
                     <input


### PR DESCRIPTION
This is a set of style fixes for the search button and its associated input fields, based on the issues brought up in #500. 

- The search input jumps out of place when expanded: I could only reproduce this one by making my browser screen as small as possible without making the search button disappear, which can technically still occur with the proposed solution. Nonetheless, I thought it could be mitigated a small bit by making the search bar width dependent on view width.
- Search button is misaligned compared to the other navbar elements: This was fixed by reducing the margin on the right of the button.
- Search button has the wrong color: This was fixed by wrapping the existing HTML in the same list tags and CSS classes as all the other navigation bar items.
- Input field still selectable and editable when hidden: This was fixed by explicitly setting the `disabled` attribute on the text input when it is hidden. This prevents it from being either selectable or editable.

Fixes #500.