### PR TITLE
Fix workaround for broken logout

### DIFF
--- a/src/shared/services/UserService.ts
+++ b/src/shared/services/UserService.ts
@@ -52,7 +52,7 @@ export class UserService {
     this.jwtInfo = None;
     this.myUserInfo = None;
     IsomorphicCookie.remove("jwt"); // TODO is sometimes unreliable for some reason
-    document.cookie = "jwt=; Max-Age=0; path=/; domain=" + location.host;
+    document.cookie = "jwt=; Max-Age=0; path=/; domain=" + location.hostname;
     location.reload();
   }
 


### PR DESCRIPTION
Use hostname without port for setting empty cookie, avoids error in browser:  Cookie “jwt” has been rejected for invalid domain. Fixes https://github.com/LemmyNet/lemmy-ui/issues/819