### PR TITLE
Add Taglines support

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "inferno-server": "^8.0.3",
     "isomorphic-cookie": "^1.2.4",
     "jwt-decode": "^3.1.2",
-    "lemmy-js-client": "0.17.0-rc.51",
+    "lemmy-js-client": "0.17.0-rc.52",
     "markdown-it": "^13.0.1",
     "markdown-it-container": "^3.0.0",
     "markdown-it-footnote": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "inferno-server": "^8.0.3",
     "isomorphic-cookie": "^1.2.4",
     "jwt-decode": "^3.1.2",
-    "lemmy-js-client": "0.17.0-rc.52",
+    "lemmy-js-client": "0.17.0-rc.53",
     "markdown-it": "^13.0.1",
     "markdown-it-container": "^3.0.0",
     "markdown-it-footnote": "^3.0.3",

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -386,3 +386,8 @@ br.big {
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }
+
+#tagline{
+
+  padding: 0px 0px 15px 0px;
+}

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -386,8 +386,3 @@ br.big {
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }
-
-#tagline{
-
-  padding: 0px 0px 15px 0px;
-}

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -335,7 +335,10 @@ export class Home extends Component<any, HomeState> {
         {this.state.siteRes.site_view.local_site.site_setup && (
           <div className="row">
             <main role="main" className="col-12 col-md-8">
-              {this.state.tagline.isSome() && <div id="tagline" dangerouslySetInnerHTML={mdToHtml(this.state.tagline.unwrapOr(""))}></div>}
+              {this.state.tagline.match({
+                some: tagline => <div id="tagline" dangerouslySetInnerHTML={mdToHtml(tagline)}></div>,
+                none: <></>,
+              })}
               <div className="d-block d-md-none">{this.mobileView()}</div>
               {this.posts()}
             </main>

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -53,6 +53,7 @@ import {
   getSortTypeFromProps,
   isBrowser,
   isPostBlocked,
+  mdToHtml,
   notifyPost,
   nsfwCheck,
   postToCommentSortType,
@@ -94,6 +95,7 @@ interface HomeState {
   showSidebarMobile: boolean;
   subscribedCollapsed: boolean;
   loading: boolean;
+  tagline: string;
 }
 
 interface HomeProps {
@@ -137,6 +139,7 @@ export class Home extends Component<any, HomeState> {
     dataType: getDataTypeFromProps(this.props),
     sort: getSortTypeFromProps(this.props),
     page: getPageFromProps(this.props),
+    tagline: ""
   };
 
   constructor(props: any, context: any) {
@@ -170,10 +173,12 @@ export class Home extends Component<any, HomeState> {
           wsClient.communityJoin({ community_id: 0 })
         );
       }
+      const taglines = this.state.siteRes.site_view.taglines;
       this.state = {
         ...this.state,
         trendingCommunities: trendingRes.communities,
         loading: false,
+        tagline: taglines.length == 0 ? "" : taglines[Math.floor(Math.random() * taglines.length)].content,
       };
     } else {
       this.fetchTrendingCommunities();
@@ -329,6 +334,7 @@ export class Home extends Component<any, HomeState> {
         {this.state.siteRes.site_view.local_site.site_setup && (
           <div className="row">
             <main role="main" className="col-12 col-md-8">
+              <div id="tagline" dangerouslySetInnerHTML={mdToHtml(this.state.tagline)}></div>
               <div className="d-block d-md-none">{this.mobileView()}</div>
               {this.posts()}
             </main>

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -50,6 +50,7 @@ import {
   getDataTypeFromProps,
   getListingTypeFromProps,
   getPageFromProps,
+  getRandomFromList,
   getSortTypeFromProps,
   isBrowser,
   isPostBlocked,
@@ -95,7 +96,7 @@ interface HomeState {
   showSidebarMobile: boolean;
   subscribedCollapsed: boolean;
   loading: boolean;
-  tagline: string;
+  tagline: Option<string>;
 }
 
 interface HomeProps {
@@ -139,7 +140,7 @@ export class Home extends Component<any, HomeState> {
     dataType: getDataTypeFromProps(this.props),
     sort: getSortTypeFromProps(this.props),
     page: getPageFromProps(this.props),
-    tagline: ""
+    tagline: None
   };
 
   constructor(props: any, context: any) {
@@ -178,7 +179,7 @@ export class Home extends Component<any, HomeState> {
         ...this.state,
         trendingCommunities: trendingRes.communities,
         loading: false,
-        tagline: taglines.length == 0 ? "" : taglines[Math.floor(Math.random() * taglines.length)].content,
+        tagline: taglines.map(tls => getRandomFromList(tls).content)
       };
     } else {
       this.fetchTrendingCommunities();
@@ -334,7 +335,7 @@ export class Home extends Component<any, HomeState> {
         {this.state.siteRes.site_view.local_site.site_setup && (
           <div className="row">
             <main role="main" className="col-12 col-md-8">
-              <div id="tagline" dangerouslySetInnerHTML={mdToHtml(this.state.tagline)}></div>
+              {this.state.tagline.isSome() && <div id="tagline" dangerouslySetInnerHTML={mdToHtml(this.state.tagline.unwrapOr(""))}></div>}
               <div className="d-block d-md-none">{this.mobileView()}</div>
               {this.posts()}
             </main>

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -174,7 +174,7 @@ export class Home extends Component<any, HomeState> {
           wsClient.communityJoin({ community_id: 0 })
         );
       }
-      const taglines = this.state.siteRes.site_view.taglines;
+      const taglines = this.state.siteRes.taglines;
       this.state = {
         ...this.state,
         trendingCommunities: trendingRes.communities,

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -160,9 +160,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
         blocked_instances: this.props.siteRes.federated_instances.andThen(
           f => f.blocked
         ),
-        taglines: Some(
-          this.props.siteRes.site_view.taglines.map(x => x.content)
-        ),
+        taglines: this.props.siteRes.site_view.taglines.map(x => x.map(y => y.content)),
         auth: undefined,
       }),
     };
@@ -1045,7 +1043,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
                   {this.state.siteForm.taglines
                     .unwrapOr([])
                     .map((cv, index) => (
-                      <tr key={cv}>
+                      <tr key={index}>
                         <td>
                           <MarkdownTextArea
                             initialContent={Some(cv)}
@@ -1196,9 +1194,10 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
   }
 
   handleTaglineChange(i: SiteForm, index: number, val: string) {
-    let taglines = i.state.siteForm.taglines.unwrap();
-    taglines[index] = val;
-    i.state.siteForm.taglines = Some(taglines);
+    i.state.siteForm.taglines.match({
+      some: tls => { tls[index] = val; },
+      none: void 0
+    });
     i.setState(i.state);
   }
 
@@ -1208,10 +1207,14 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
     event: InfernoMouseEvent<HTMLButtonElement>
   ) {
     event.preventDefault();
-    let taglines = i.state.siteForm.taglines.unwrap();
-    taglines.splice(index, 1);
-    i.state.siteForm.taglines = Some(taglines);
-    i.setState(i.state);
+    if (i.state.siteForm.taglines.isSome()){
+      let taglines = i.state.siteForm.taglines.unwrap();
+      taglines.splice(index, 1);
+      i.state.siteForm.taglines = None; // force rerender of table rows
+      i.setState(i.state);
+      i.state.siteForm.taglines = Some(taglines);
+      i.setState(i.state);
+    }
   }
 
   handleAddTaglineClick(
@@ -1219,9 +1222,10 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
     event: InfernoMouseEvent<HTMLButtonElement>
   ) {
     event.preventDefault();
-    let taglines = i.state.siteForm.taglines.unwrap();
-    taglines.push("");
-    i.state.siteForm.taglines = Some(taglines);
+    i.state.siteForm.taglines.match({
+      some: tls => { tls.push("") },
+      none: void 0
+    });
     i.setState(i.state);
   }
 

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -1034,7 +1034,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
               />
             </div>
           </div>
-          <div className="form-group row">
+          {siteSetup && <div className="form-group row">
             <h5 className="col-12">{i18n.t("taglines")}</h5>
             <div className="table-responsive col-12">
               <table id="taglines_table" className="table table-sm table-hover">
@@ -1084,7 +1084,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
                 {i18n.t("add_tagline")}
               </button>
             </div>
-          </div>
+          </div>}
           <div className="form-group row">
             <div className="col-12">
               <button

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -1055,7 +1055,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
                               this.handleTaglineChange(this, index, s)
                             }
                             hideNavigationWarnings
-                            allLanguages={[]}
+                            allLanguages={this.props.siteRes.all_languages}
                           />
                         </td>
                         <td className="text-right">

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -1045,7 +1045,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
                   {this.state.siteForm.taglines
                     .unwrapOr([])
                     .map((cv, index) => (
-                      <tr key={index}>
+                      <tr key={cv}>
                         <td>
                           <MarkdownTextArea
                             initialContent={Some(cv)}

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -160,7 +160,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
         blocked_instances: this.props.siteRes.federated_instances.andThen(
           f => f.blocked
         ),
-        taglines: this.props.siteRes.site_view.taglines.map(x => x.map(y => y.content)),
+        taglines: this.props.siteRes.taglines.map(x => x.map(y => y.content)),
         auth: undefined,
       }),
     };
@@ -1222,10 +1222,10 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
     event: InfernoMouseEvent<HTMLButtonElement>
   ) {
     event.preventDefault();
-    i.state.siteForm.taglines.match({
-      some: tls => { tls.push("") },
-      none: void 0
-    });
+    if (i.state.siteForm.taglines.isNone()){
+      i.state.siteForm.taglines = Some([]);
+    }
+    i.state.siteForm.taglines.unwrap().push("");
     i.setState(i.state);
   }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1525,3 +1525,7 @@ export function nsfwCheck(
         .unwrapOr(false))
   );
 }
+
+export function getRandomFromList<T>(list : T[]) : T{
+  return list[Math.floor(Math.random() * list.length)];
+}


### PR DESCRIPTION
See: https://github.com/LemmyNet/lemmy/pull/2548

Adds frontend support for Taglines.

Taglines are edited and displayed as Markdown. Screenshots Below:

Homepage:
![image](https://user-images.githubusercontent.com/4389156/202321784-a4db06e3-200a-4910-8d81-65862d457334.png)
![image](https://user-images.githubusercontent.com/4389156/202321813-109e5b0e-a6f9-4b2e-8724-be776521510d.png)
![image](https://user-images.githubusercontent.com/4389156/202321914-39182a35-52ac-4ad7-a744-cdbb21c0f120.png)

Admin Settings:
![image](https://user-images.githubusercontent.com/4389156/202321955-cf448969-e77f-4743-9d27-4d6e9e7ca114.png)
