### PR TITLE
I18 quality of life change

### DIFF
--- a/src/shared/components/app/no-match.tsx
+++ b/src/shared/components/app/no-match.tsx
@@ -1,11 +1,11 @@
-import { I18nKeys } from "i18next";
+import { NoOptionI18nKeys } from "i18next";
 import { Component } from "inferno";
 import { i18n } from "../../i18next";
 
 export class NoMatch extends Component<any, any> {
   private errCode = new URLSearchParams(this.props.location.search).get(
     "err"
-  ) as I18nKeys;
+  ) as NoOptionI18nKeys;
 
   constructor(props: any, context: any) {
     super(props, context);

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -1,5 +1,5 @@
 import { Options, passwordStrength } from "check-password-strength";
-import { I18nKeys } from "i18next";
+import { NoOptionI18nKeys } from "i18next";
 import { Component, linkEvent } from "inferno";
 import { T } from "inferno-i18next-dess";
 import {
@@ -231,7 +231,7 @@ export class Signup extends Component<any, State> {
             />
             {this.state.form.password && (
               <div className={this.passwordColorClass}>
-                {i18n.t(this.passwordStrength as I18nKeys)}
+                {i18n.t(this.passwordStrength as NoOptionI18nKeys)}
               </div>
             )}
           </div>


### PR DESCRIPTION
While working on a translation issue, I thought it would be helpful for Typescript to say which parameters are needed for an i18 translation. 

Translations that don't require parameters are the same as before. However, if a translation needs parameters, Typescript will show an error if it's not getting them. In addition to that, Typescript will show which properties are needed on the parameter object. This screenshot shows an example:
![translation option error](https://user-images.githubusercontent.com/28871516/229298411-caa08cb9-3fc3-4a53-9315-36780bf1996c.png)

As you can see, the `cake_day_info` translation requires a `creator_name` property to work.