### PR TITLE
Handle when logged out

### DIFF
--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -1,8 +1,9 @@
 import { Component } from "inferno";
+import { Redirect } from "inferno-router";
 import { CommunityView, GetSiteResponse } from "lemmy-js-client";
 import { Subscription } from "rxjs";
 import { i18n } from "../../i18next";
-import { UserService } from "../../services";
+import { UserService } from "../../services/UserService";
 import {
   enableNsfw,
   isBrowser,
@@ -32,11 +33,6 @@ export class CreateCommunity extends Component<any, CreateCommunityState> {
 
     this.parseMessage = this.parseMessage.bind(this);
     this.subscription = wsSubscribe(this.parseMessage);
-
-    if (!UserService.Instance.myUserInfo && isBrowser()) {
-      toast(i18n.t("not_logged_in"), "danger");
-      this.context.router.history.push(`/login`);
-    }
   }
 
   componentWillUnmount() {
@@ -54,6 +50,7 @@ export class CreateCommunity extends Component<any, CreateCommunityState> {
   render() {
     return (
       <div className="container-lg">
+        {!UserService.Instance.myUserInfo && <Redirect to="/login" />}
         <HtmlTags
           title={this.documentTitle}
           path={this.context.router.route.match.url}

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -105,10 +105,10 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
             {myUSerInfo && this.blockCommunity()}
             {!myUSerInfo && (
               <div className="alert alert-info" role="alert">
-                You are not logged in. However you can subscribe from another
-                Fediverse account, for example Lemmy or Mastodon. To do this,
-                paste the following into the search field of your instance: !
-                {name}@{hostname(actor_id)}
+                {i18n.t("community_not_logged_in_alert", {
+                  community: name,
+                  instance: hostname(actor_id),
+                })}
               </div>
             )}
           </div>

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -20,6 +20,7 @@ import {
   amMod,
   amTopMod,
   getUnixTime,
+  hostname,
   mdToHtml,
   myAuth,
   numToSI,
@@ -91,15 +92,25 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
   }
 
   sidebar() {
+    const myUSerInfo = UserService.Instance.myUserInfo;
+    const { name, actor_id } = this.props.community_view.community;
     return (
       <div>
         <div className="card border-secondary mb-3">
           <div className="card-body">
             {this.communityTitle()}
             {this.props.editable && this.adminButtons()}
-            {this.subscribe()}
+            {myUSerInfo && this.subscribe()}
             {this.canPost && this.createPost()}
-            {this.blockCommunity()}
+            {myUSerInfo && this.blockCommunity()}
+            {!myUSerInfo && (
+              <div className="alert alert-info" role="alert">
+                You are not logged in. However you can subscribe from another
+                Fediverse account, for example Lemmy or Mastodon. To do this,
+                paste the following into the search field of your instance: !
+                {name}@{hostname(actor_id)}
+              </div>
+            )}
           </div>
         </div>
         <div className="card border-secondary mb-3">
@@ -123,7 +134,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
             <BannerIconHeader icon={community.icon} banner={community.banner} />
           )}
           <span className="mr-2">{community.title}</span>
-          {subscribed == SubscribedType.Subscribed && (
+          {subscribed === SubscribedType.Subscribed && (
             <button
               className="btn btn-secondary btn-sm mr-2"
               onClick={linkEvent(this, this.handleUnsubscribe)}
@@ -132,7 +143,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
               {i18n.t("joined")}
             </button>
           )}
-          {subscribed == SubscribedType.Pending && (
+          {subscribed === SubscribedType.Pending && (
             <button
               className="btn btn-warning mr-2"
               onClick={linkEvent(this, this.handleUnsubscribe)}

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -532,8 +532,7 @@ export class Profile extends Component<
               </div>
               {!UserService.Instance.myUserInfo && (
                 <div className="alert alert-info" role="alert">
-                  You are not logged in. If you use a Fediverse account that is
-                  able to follow users, you can follow this user.
+                  {i18n.t("profile_not_logged_in_alert")}
                 </div>
               )}
             </div>

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -530,6 +530,12 @@ export class Profile extends Component<
                     .format("MMM DD, YYYY")}
                 </span>
               </div>
+              {!UserService.Instance.myUserInfo && (
+                <div className="alert alert-info" role="alert">
+                  You are not logged in. If you use a Fediverse account that is
+                  able to follow users, you can follow this user.
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/shared/components/post/create-post.tsx
+++ b/src/shared/components/post/create-post.tsx
@@ -1,4 +1,5 @@
 import { Component } from "inferno";
+import { Redirect } from "inferno-router";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import {
   GetCommunity,
@@ -68,11 +69,6 @@ export class CreatePost extends Component<
 
     this.parseMessage = this.parseMessage.bind(this);
     this.subscription = wsSubscribe(this.parseMessage);
-
-    if (!UserService.Instance.myUserInfo && isBrowser()) {
-      toast(i18n.t("not_logged_in"), "danger");
-      this.context.router.history.push(`/login`);
-    }
 
     // Only fetch the data if coming from another route
     if (this.isoData.path === this.context.router.route.match.url) {
@@ -149,6 +145,7 @@ export class CreatePost extends Component<
 
     return (
       <div className="container-lg">
+        {!UserService.Instance.myUserInfo && <Redirect to="/login" />}
         <HtmlTags
           title={this.documentTitle}
           path={this.context.router.route.match.url}
@@ -189,7 +186,7 @@ export class CreatePost extends Component<
       | PostFormParams
       | undefined;
 
-    this.props.history.push(
+    this.props.history.replace(
       `/create_post${getQueryString(queryParams)}`,
       locationState
     );


### PR DESCRIPTION
This is for #975.

The community sidebar shows this when logged out:
![logged out community sidebar](https://user-images.githubusercontent.com/28871516/233859263-fd9a4a26-7037-467d-a5ed-626a1426a997.png)

The profile page looks like this:
![logged out profile](https://user-images.githubusercontent.com/28871516/233859298-17b5ce2f-de02-468d-ab63-5031e79aa3d0.png)

The text being used isn't final and I'll gladly change it if anyone has any better ideas. The alerts seems somewhat bland at the moment too. Maybe there should be an icon to go with them?

I have also made a version of this PR where I hide the create post and create community buttons. I will make a separate PR for that.
