### PR TITLE
Handle when logged out - Hide create post version

### DIFF
--- a/src/shared/components/app/navbar.tsx
+++ b/src/shared/components/app/navbar.tsx
@@ -228,34 +228,38 @@ export class Navbar extends Component<NavbarProps, NavbarState> {
                   {i18n.t("communities")}
                 </NavLink>
               </li>
-              <li className="nav-item">
-                {/* TODO make sure this works: https://github.com/infernojs/inferno/issues/1608 */}
-                <NavLink
-                  to={{
-                    pathname: "/create_post",
-                    search: "",
-                    hash: "",
-                    key: "",
-                    state: { prevPath: this.currentLocation },
-                  }}
-                  className="nav-link"
-                  onMouseUp={linkEvent(this, this.handleHideExpandNavbar)}
-                  title={i18n.t("create_post")}
-                >
-                  {i18n.t("create_post")}
-                </NavLink>
-              </li>
-              {canCreateCommunity(this.props.siteRes) && (
-                <li className="nav-item">
-                  <NavLink
-                    to="/create_community"
-                    className="nav-link"
-                    onMouseUp={linkEvent(this, this.handleHideExpandNavbar)}
-                    title={i18n.t("create_community")}
-                  >
-                    {i18n.t("create_community")}
-                  </NavLink>
-                </li>
+              {person && (
+                <>
+                  <li className="nav-item">
+                    {/* TODO make sure this works: https://github.com/infernojs/inferno/issues/1608 */}
+                    <NavLink
+                      to={{
+                        pathname: "/create_post",
+                        search: "",
+                        hash: "",
+                        key: "",
+                        state: { prevPath: this.currentLocation },
+                      }}
+                      className="nav-link"
+                      onMouseUp={linkEvent(this, this.handleHideExpandNavbar)}
+                      title={i18n.t("create_post")}
+                    >
+                      {i18n.t("create_post")}
+                    </NavLink>
+                  </li>
+                  {canCreateCommunity(this.props.siteRes) && (
+                    <li className="nav-item">
+                      <NavLink
+                        to="/create_community"
+                        className="nav-link"
+                        onMouseUp={linkEvent(this, this.handleHideExpandNavbar)}
+                        title={i18n.t("create_community")}
+                      >
+                        {i18n.t("create_community")}
+                      </NavLink>
+                    </li>
+                  )}
+                </>
               )}
               <li className="nav-item">
                 <a

--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -34,8 +34,7 @@ export class CreateCommunity extends Component<any, CreateCommunityState> {
     this.subscription = wsSubscribe(this.parseMessage);
 
     if (!UserService.Instance.myUserInfo && isBrowser()) {
-      toast(i18n.t("not_logged_in"), "danger");
-      this.context.router.history.push(`/login`);
+      this.context.router.history.back();
     }
   }
 

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -20,6 +20,7 @@ import {
   amMod,
   amTopMod,
   getUnixTime,
+  hostname,
   mdToHtml,
   myAuth,
   numToSI,
@@ -91,15 +92,25 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
   }
 
   sidebar() {
+    const myUSerInfo = UserService.Instance.myUserInfo;
+    const { name, actor_id } = this.props.community_view.community;
     return (
       <div>
         <div className="card border-secondary mb-3">
           <div className="card-body">
             {this.communityTitle()}
             {this.props.editable && this.adminButtons()}
-            {this.subscribe()}
+            {myUSerInfo && this.subscribe()}
             {this.canPost && this.createPost()}
-            {this.blockCommunity()}
+            {myUSerInfo && this.blockCommunity()}
+            {!myUSerInfo && (
+              <div className="alert alert-info" role="alert">
+                You are not logged in. However you can subscribe from another
+                Fediverse account, for example Lemmy or Mastodon. To do this,
+                paste the following into the search field of your instance: !
+                {name}@{hostname(actor_id)}
+              </div>
+            )}
           </div>
         </div>
         <div className="card border-secondary mb-3">
@@ -123,7 +134,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
             <BannerIconHeader icon={community.icon} banner={community.banner} />
           )}
           <span className="mr-2">{community.title}</span>
-          {subscribed == SubscribedType.Subscribed && (
+          {subscribed === SubscribedType.Subscribed && (
             <button
               className="btn btn-secondary btn-sm mr-2"
               onClick={linkEvent(this, this.handleUnsubscribe)}
@@ -132,7 +143,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
               {i18n.t("joined")}
             </button>
           )}
-          {subscribed == SubscribedType.Pending && (
+          {subscribed === SubscribedType.Pending && (
             <button
               className="btn btn-warning mr-2"
               onClick={linkEvent(this, this.handleUnsubscribe)}

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -101,7 +101,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
             {this.communityTitle()}
             {this.props.editable && this.adminButtons()}
             {myUSerInfo && this.subscribe()}
-            {this.canPost && this.createPost()}
+            {myUSerInfo && this.canPost && this.createPost()}
             {myUSerInfo && this.blockCommunity()}
             {!myUSerInfo && (
               <div className="alert alert-info" role="alert">

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -407,6 +407,13 @@ export class Home extends Component<any, HomeState> {
                   dangerouslySetInnerHTML={mdToHtml(tagline)}
                 ></div>
               )}
+              {!UserService.Instance.myUserInfo && (
+                <div className="alert alert-info">
+                  To get the full experience, create an account or, if you have
+                  an account on another instance, try federating with some of
+                  the communities.
+                </div>
+              )}
               <div className="d-block d-md-none">{this.mobileView}</div>
               {this.posts()}
             </main>
@@ -497,12 +504,13 @@ export class Home extends Component<any, HomeState> {
             <div className="card border-secondary mb-3">
               <div className="card-body">
                 {this.trendingCommunities()}
-                {canCreateCommunity(this.state.siteRes) && (
-                  <LinkButton
-                    path="/create_community"
-                    translationKey="create_a_community"
-                  />
-                )}
+                {UserService.Instance.myUserInfo &&
+                  canCreateCommunity(this.state.siteRes) && (
+                    <LinkButton
+                      path="/create_community"
+                      translationKey="create_a_community"
+                    />
+                  )}
                 <LinkButton
                   path="/communities"
                   translationKey="explore_communities"

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -530,6 +530,12 @@ export class Profile extends Component<
                     .format("MMM DD, YYYY")}
                 </span>
               </div>
+              {!UserService.Instance.myUserInfo && (
+                <div className="alert alert-info" role="alert">
+                  You are not logged in. If you use a Fediverse account that is
+                  able to follow users, you can follow this user.
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/shared/components/post/create-post.tsx
+++ b/src/shared/components/post/create-post.tsx
@@ -70,8 +70,7 @@ export class CreatePost extends Component<
     this.subscription = wsSubscribe(this.parseMessage);
 
     if (!UserService.Instance.myUserInfo && isBrowser()) {
-      toast(i18n.t("not_logged_in"), "danger");
-      this.context.router.history.push(`/login`);
+      this.context.router.history.back();
     }
 
     // Only fetch the data if coming from another route
@@ -189,7 +188,7 @@ export class CreatePost extends Component<
       | PostFormParams
       | undefined;
 
-    this.props.history.push(
+    this.props.history.replace(
       `/create_post${getQueryString(queryParams)}`,
       locationState
     );


### PR DESCRIPTION
This is a PR for #975 and is the alternate version of #986.

This version includes the same alerts as the other version plus this alert when not signed in on the homepage:

![home page alert](https://user-images.githubusercontent.com/28871516/233859961-6a376c52-7113-4546-9d5d-be04e590c183.png)

The same points I made about the alerts on the other PR apply to this alert as well.