### PR TITLE
Add content warning to modlog and fix modlog routing bug

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -99,7 +99,7 @@
   border-bottom: 2px solid var(--dark);
 }
 
-.md-div table tbody+tbody {
+.md-div table tbody + tbody {
   border-top: 2px solid var(--dark);
 }
 
@@ -140,8 +140,8 @@
 }
 
 .icon-emoji-admin {
-  max-width: 24px; 
-  max-height: 24px; 
+  max-width: 24px;
+  max-height: 24px;
   display: inline-block;
 }
 
@@ -164,7 +164,7 @@
     left: 0;
   }
 
-  .emoji-picker-container>section {
+  .emoji-picker-container > section {
     width: 100% !important;
   }
 }
@@ -175,7 +175,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, .3);
+  background-color: rgba(0, 0, 0, 0.3);
   z-index: 999;
 }
 
@@ -254,6 +254,10 @@ hr {
 .text-wrap-truncate {
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.text-xs-center {
+  text-align: center;
 }
 
 .overflow-wrap-anywhere {
@@ -435,6 +439,6 @@ br.big {
 .lang-select-action:focus {
   width: auto;
 }
-em-emoji-picker{
-  width:100%;
+em-emoji-picker {
+  width: 100%;
 }

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -251,7 +251,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
         <li className="list-inline-item">
           <Link
             className="badge badge-primary"
-            to={`/modlog/community/${this.props.community_view.community.id}`}
+            to={`/modlog/${this.props.community_view.community.id}`}
           >
             {i18n.t("modlog")}
           </Link>

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -1,5 +1,6 @@
 import { NoOptionI18nKeys } from "i18next";
 import { Component, linkEvent } from "inferno";
+import { T } from "inferno-i18next-dess";
 import { Link } from "inferno-router";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import {
@@ -791,8 +792,9 @@ export class Modlog extends Component<
               inline
               classes="mr-sm-2 mx-auto d-sm-inline d-block"
             />
-            <strong>CONTENT WARNING</strong>: Some deleted posts may contain
-            disturbing or adult material. Proceed with caution.
+            <T i18nKey="modlog_content_warning" class="d-inline">
+              #<strong>#</strong>#
+            </T>
           </div>
           <h5>
             {communityName && (

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -57,7 +57,7 @@ import {
   wsSubscribe,
 } from "../utils";
 import { HtmlTags } from "./common/html-tags";
-import { Spinner } from "./common/icon";
+import { Icon, Spinner } from "./common/icon";
 import { MomentTime } from "./common/moment-time";
 import { Paginator } from "./common/paginator";
 import { SearchableSelect } from "./common/searchable-select";
@@ -782,6 +782,18 @@ export class Modlog extends Component<
         />
 
         <div>
+          <div
+            className="alert alert-warning text-sm-start text-xs-center"
+            role="alert"
+          >
+            <Icon
+              icon="alert-triangle"
+              inline
+              classes="mr-sm-2 mx-auto d-sm-inline d-block"
+            />
+            <strong>CONTENT WARNING</strong>: Some deleted posts may contain
+            disturbing or adult material. Proceed with caution.
+          </div>
           <h5>
             {communityName && (
               <Link className="text-body" to={`/c/${communityName}`}>

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -92,12 +92,12 @@ export const routes: IRoutePropsWithFetch[] = [
     component: Settings,
   },
   {
-    path: `/modlog`,
+    path: `/modlog/:communityId`,
     component: Modlog,
     fetchInitialData: Modlog.fetchInitialData,
   },
   {
-    path: `/modlog/:communityId`,
+    path: `/modlog`,
     component: Modlog,
     fetchInitialData: Modlog.fetchInitialData,
   },


### PR DESCRIPTION
This is the PR for #991. 

This is what it looks like on a desktop:
![modlog-pc](https://user-images.githubusercontent.com/28871516/235954422-205c02ca-b10b-4546-9845-f74fb824854d.png)


This is what it looks like on mobile:
![modlog-mobile](https://user-images.githubusercontent.com/28871516/235954568-cf593f7a-0e14-45ab-b550-89f6cf59c21c.png)

Translation PR will be made soon.

In addition to the content warning, I also fixed a bug I introduced in the query param PR regarding routing for community specific modlogs.