### PR TITLE
Dont preselect new post language

### DIFF
--- a/src/shared/components/comment/comment-form.tsx
+++ b/src/shared/components/comment/comment-form.tsx
@@ -17,7 +17,6 @@ import { UserService, WebSocketService } from "../../services";
 import {
   capitalizeFirstLetter,
   myAuth,
-  myFirstDiscussionLanguageId,
   wsClient,
   wsSubscribe,
 } from "../../utils";
@@ -77,21 +76,11 @@ export class CommentForm extends Component<CommentFormProps, CommentFormState> {
           : undefined
         : undefined;
 
-    let selectedLang =
-      typeof this.props.node !== "number"
-        ? this.props.node.comment_view.comment.language_id
-        : myFirstDiscussionLanguageId(
-            this.props.allLanguages,
-            this.props.siteLanguages,
-            UserService.Instance.myUserInfo
-          );
-
     return (
       <div className="mb-3">
         {UserService.Instance.myUserInfo ? (
           <MarkdownTextArea
             initialContent={initialContent}
-            initialLanguageId={selectedLang}
             showLanguage
             buttonTitle={this.state.buttonTitle}
             finished={this.state.finished}

--- a/src/shared/components/common/language-select.tsx
+++ b/src/shared/components/common/language-select.tsx
@@ -111,6 +111,11 @@ export class LanguageSelect extends Component<LanguageSelectProps, any> {
         multiple={this.props.multiple}
         disabled={this.props.disabled}
       >
+        {!this.props.multiple && (
+          <option selected disabled hidden>
+            {i18n.t("language_select_placeholder")}
+          </option>
+        )}
         {filteredLangs.map(l => (
           <option
             key={l.id}

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -29,7 +29,6 @@ import {
   ghostArchiveUrl,
   isImage,
   myAuth,
-  myFirstDiscussionLanguageId,
   pictrsDeleteToast,
   relTags,
   setupTippy,
@@ -187,13 +186,7 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
   }
 
   render() {
-    let firstLang =
-      this.state.form.language_id ??
-      myFirstDiscussionLanguageId(
-        this.props.allLanguages,
-        this.props.siteLanguages,
-        UserService.Instance.myUserInfo
-      );
+    let firstLang = this.state.form.language_id;
     let selectedLangs = firstLang ? Array.of(firstLang) : undefined;
 
     let url = this.state.form.url;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1453,20 +1453,6 @@ export function postToCommentSortType(sort: SortType): CommentSortType {
   }
 }
 
-export function myFirstDiscussionLanguageId(
-  allLanguages: Language[],
-  siteLanguages: number[],
-  myUserInfo = UserService.Instance.myUserInfo
-): number | undefined {
-  return selectableLanguages(
-    allLanguages,
-    siteLanguages,
-    false,
-    false,
-    myUserInfo
-  ).at(0)?.id;
-}
-
 export function canCreateCommunity(
   siteRes: GetSiteResponse,
   myUserInfo = UserService.Instance.myUserInfo


### PR DESCRIPTION
Lemmy-ui currently preselects the first language in the user settings when creating a new post or comment. This is a bad idea because this language might not actually be allowed in the community. It is better to pass the language as None if the user didnt specify it explicitly, because then the backend can smartly choose a language based on the overlap of user languages and community languages.

This fixes the problem described in
[this thread](https://lemmy.ml/post/1066608), where a user tries to post in a community that has only English allowed, with all languages enabled in user settings. In this case lemmy-ui preselects "undetermined language" as default, which is not allowed and results in an error. This PR fixes the issue because it lets the backend automatically select the correct language (English).

Edit: This probably fixes https://github.com/LemmyNet/lemmy-ui/issues/919 too.