### PR TITLE
Improve error handling (fixes #897)

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -2,7 +2,7 @@ import express from "express";
 import fs from "fs";
 import { IncomingHttpHeaders } from "http";
 import { Helmet } from "inferno-helmet";
-import { matchPath, StaticRouter } from "inferno-router";
+import { StaticRouter, matchPath } from "inferno-router";
 import { renderToString } from "inferno-server";
 import IsomorphicCookie from "isomorphic-cookie";
 import { GetSite, GetSiteResponse, LemmyHttp } from "lemmy-js-client";
@@ -141,7 +141,7 @@ server.get("/*", async (req, res) => {
 
     const routeData = await Promise.all(promises);
 
-    // Redirect to the 404 if there's an API error
+    // Handle API errors
     if (routeData[0] && routeData[0].error) {
       const error = routeData[0].error;
       console.error(error);
@@ -209,7 +209,7 @@ server.get("/*", async (req, res) => {
 
            <!-- Current theme and more -->
            ${helmet.link.toString()}
-           
+  
            </head>
 
            <body ${helmet.bodyAttributes.toString()}>
@@ -223,10 +223,17 @@ server.get("/*", async (req, res) => {
              <script defer src='/static/js/client.js'></script>
            </body>
          </html>
-`);
+  `);
   } catch (err) {
-    console.error(err);
-    return res.send(`404: ${removeAuthParam(err)}`);
+    var formatted: string;
+    if (err.status && err.message) {
+      res.status(err.status);
+      formatted = `${err.status}: ${err.message}`;
+    } else {
+      res.status(500);
+      formatted = err;
+    }
+    res.send(formatted);
   }
 });
 

--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -17,6 +17,7 @@ import { InitialFetchRequest } from "../../interfaces";
 import { WebSocketService } from "../../services";
 import {
   capitalizeFirstLetter,
+  check_auth,
   isBrowser,
   myAuth,
   randomStr,
@@ -59,6 +60,8 @@ export class AdminSettings extends Component<any, AdminSettingsState> {
 
     this.parseMessage = this.parseMessage.bind(this);
     this.subscription = wsSubscribe(this.parseMessage);
+
+    check_auth();
 
     // Only fetch the data if coming from another route
     if (this.isoData.path == this.context.router.route.match.url) {

--- a/src/shared/components/home/setup.tsx
+++ b/src/shared/components/home/setup.tsx
@@ -67,6 +67,9 @@ export class Setup extends Component<any, State> {
   }
 
   render() {
+    if (this.state.siteRes.site_view.local_site.site_setup) {
+      throw { status: 403, message: "Site is already setup" };
+    }
     return (
       <div className="container-lg">
         <Helmet title={this.documentTitle} />

--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -29,6 +29,7 @@ import { i18n } from "../../i18next";
 import { CommentViewType, InitialFetchRequest } from "../../interfaces";
 import { UserService, WebSocketService } from "../../services";
 import {
+  check_auth,
   commentsToFlatNodes,
   createCommentLikeRes,
   editCommentRes,
@@ -111,10 +112,7 @@ export class Inbox extends Component<any, InboxState> {
     this.handleSortChange = this.handleSortChange.bind(this);
     this.handlePageChange = this.handlePageChange.bind(this);
 
-    if (!UserService.Instance.myUserInfo && isBrowser()) {
-      toast(i18n.t("not_logged_in"), "danger");
-      this.context.router.history.push(`/login`);
-    }
+    check_auth();
 
     this.parseMessage = this.parseMessage.bind(this);
     this.subscription = wsSubscribe(this.parseMessage);

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1603,3 +1603,9 @@ export function getQueryString<T extends Record<string, string | undefined>>(
       "?"
     );
 }
+
+export function check_auth() {
+  if (!UserService.Instance.myUserInfo) {
+    throw { status: 401, message: "Login required" };
+  }
+}


### PR DESCRIPTION
A lot of routes are missing basic checks, for example /setup is publicly available even after the site is created. For pages which require auth, the check is handled separately each time when it could be done once at the top level. This is currently work in progress to see if Im on the right track. The same checks should be added to many more routes.