### PR TITLE
Redirect form pages that require auth on logout

### DIFF
--- a/src/shared/services/UserService.ts
+++ b/src/shared/services/UserService.ts
@@ -48,7 +48,15 @@ export class UserService {
     this.myUserInfo = undefined;
     IsomorphicCookie.remove("jwt"); // TODO is sometimes unreliable for some reason
     document.cookie = "jwt=; Max-Age=0; path=/; domain=" + location.hostname;
-    location.reload();
+    if (
+      /create_.*|inbox|settings|setup|admin|reports|registration_applications/g.test(
+        location.pathname
+      )
+    ) {
+      location.replace("/");
+    } else {
+      location.reload();
+    }
   }
 
   public auth(throwErr = true): string | undefined {


### PR DESCRIPTION
I didn't make an issue for this one, but the code change does what the PR title says. Currently, if a user logs out of their account while on a page that requires auth (like /settings, /admin, /inbox, etc), they will not be navigated away from the page.