### PR TITLE
Make post button disabled when no language is selected

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -132,7 +132,7 @@ export class MarkdownTextArea extends Component<
   }
 
   render() {
-    let languageId = this.state.languageId;
+    const languageId = this.state.languageId;
 
     return (
       <form id={this.formId} onSubmit={linkEvent(this, this.handleSubmit)}>
@@ -185,7 +185,7 @@ export class MarkdownTextArea extends Component<
               <button
                 type="submit"
                 className="btn btn-sm btn-secondary mr-2"
-                disabled={this.isDisabled}
+                disabled={this.isDisabled || languageId === undefined}
               >
                 {this.state.loading ? (
                   <Spinner />
@@ -644,10 +644,7 @@ export class MarkdownTextArea extends Component<
   }
 
   get isDisabled() {
-    return (
-      this.state.loading ||
-      this.props.disabled ||
-      !!this.state.imageUploadStatus
-    );
+    const { loading, imageUploadStatus, previewMode } = this.state;
+    return loading || this.props.disabled || !!imageUploadStatus || previewMode;
   }
 }

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -186,10 +186,9 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
   }
 
   render() {
-    let firstLang = this.state.form.language_id;
-    let selectedLangs = firstLang ? Array.of(firstLang) : undefined;
+    const { url, language_id } = this.state.form;
+    const selectedLangs = language_id ? Array.of(language_id) : undefined;
 
-    let url = this.state.form.url;
     return (
       <div>
         <Prompt
@@ -411,7 +410,11 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
           <div className="form-group row">
             <div className="col-sm-10">
               <button
-                disabled={!this.state.form.community_id || this.state.loading}
+                disabled={
+                  !this.state.form.community_id ||
+                  this.state.loading ||
+                  language_id === undefined
+                }
                 type="submit"
                 className="btn btn-secondary mr-2"
               >


### PR DESCRIPTION
This is for #1020. I think this is better than letting users post something that is guaranteed to cause an error, but I'm worried it won't be obvious why the button is disabled to the user.  I'm open to ideas to make the fact that languages won't be auto selected anymore noticeable to the user.