### PR TITLE
Fix aria-label for language select

### DIFF
--- a/src/shared/components/common/language-select.tsx
+++ b/src/shared/components/common/language-select.tsx
@@ -107,7 +107,7 @@ export class LanguageSelect extends Component<LanguageSelectProps, any> {
         )}
         id={this.id}
         onChange={linkEvent(this, this.handleLanguageChange)}
-        aria-label="action"
+        aria-label={i18n.t("language_select_placeholder")}
         multiple={this.props.multiple}
         disabled={this.props.disabled}
       >


### PR DESCRIPTION
Fix https://github.com/LemmyNet/lemmy-ui/issues/1079

I've used the existing `language_select_placeholder` as I thought "Select language" is a good fit, but happy to change it simply `language` if preferred. 