### PR TITLE
Add media-src * to Content-Security-Policy header to fix video posts with non-local links

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -38,7 +38,7 @@ if (!process.env["LEMMY_UI_DISABLE_CSP"] && !process.env["LEMMY_UI_DEBUG"]) {
   server.use(function (_req, res, next) {
     res.setHeader(
       "Content-Security-Policy",
-      `default-src 'self'; manifest-src *; connect-src *; img-src * data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; form-action 'self'; base-uri 'self'; frame-src *`
+      `default-src 'self'; manifest-src *; connect-src *; img-src * data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; form-action 'self'; base-uri 'self'; frame-src *; media-src *`
     );
     next();
   });


### PR DESCRIPTION
Added "media-src *" to the http Content-Security-Policy header to allow non-local video files to display without getting blocked by CSP.
closes #1091