### PR TITLE
fix: Adds ability to hide language warning

### DIFF
--- a/src/shared/components/common/language-select.tsx
+++ b/src/shared/components/common/language-select.tsx
@@ -16,6 +16,7 @@ interface LanguageSelectProps {
   showSite?: boolean;
   iconVersion?: boolean;
   disabled?: boolean;
+  hideLanguageWarning?: boolean;
 }
 
 export class LanguageSelect extends Component<LanguageSelectProps, any> {
@@ -49,7 +50,7 @@ export class LanguageSelect extends Component<LanguageSelectProps, any> {
       this.selectBtn
     ) : (
       <div>
-        {this.props.multiple && (
+        {this.props.multiple && !this.props.hideLanguageWarning && (
           <div className="alert alert-warning" role="alert">
             {i18n.t("undetermined_language_warning")}
           </div>

--- a/src/shared/components/common/language-select.tsx
+++ b/src/shared/components/common/language-select.tsx
@@ -16,7 +16,7 @@ interface LanguageSelectProps {
   showSite?: boolean;
   iconVersion?: boolean;
   disabled?: boolean;
-  hideLanguageWarning?: boolean;
+  showLanguageWarning?: boolean;
 }
 
 export class LanguageSelect extends Component<LanguageSelectProps, any> {
@@ -50,7 +50,7 @@ export class LanguageSelect extends Component<LanguageSelectProps, any> {
       this.selectBtn
     ) : (
       <div>
-        {this.props.multiple && !this.props.hideLanguageWarning && (
+        {this.props.multiple && this.props.showLanguageWarning && (
           <div className="alert alert-warning" role="alert">
             {i18n.t("undetermined_language_warning")}
           </div>

--- a/src/shared/components/community/community-form.tsx
+++ b/src/shared/components/community/community-form.tsx
@@ -265,6 +265,7 @@ export class CommunityForm extends Component<
             showSite
             selectedLanguageIds={this.state.form.discussion_languages}
             multiple={true}
+            hideLanguageWarning={true}
             onChange={this.handleDiscussionLanguageChange}
           />
           <div className="form-group row">

--- a/src/shared/components/community/community-form.tsx
+++ b/src/shared/components/community/community-form.tsx
@@ -265,7 +265,6 @@ export class CommunityForm extends Component<
             showSite
             selectedLanguageIds={this.state.form.discussion_languages}
             multiple={true}
-            hideLanguageWarning={true}
             onChange={this.handleDiscussionLanguageChange}
           />
           <div className="form-group row">

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -604,6 +604,7 @@ export class Settings extends Component<any, SettingsState> {
             siteLanguages={this.state.siteRes.discussion_languages}
             selectedLanguageIds={selectedLangs}
             multiple={true}
+            showLanguageWarning={true}
             showSite
             onChange={this.handleDiscussionLanguageChange}
           />


### PR DESCRIPTION
# Describe
Community form should not show `undetermined_language_warning` warning. Since the component is shared between multiple forms a `hideLanguageWarning` prop was added so a specific instance can hide it.

# Screenshot
![Screenshot 2023-06-08 at 19-25-16 Create Community - lemmy-dev](https://github.com/LemmyNet/lemmy-ui/assets/43147936/0ad7680d-2928-4d6f-b935-e366a1cdca4b)

# Ticket
Closes #1078 