### PR TITLE
Alternative way to sanitize isoData

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -9,6 +9,7 @@ import IsomorphicCookie from "isomorphic-cookie";
 import { GetSite, GetSiteResponse, LemmyHttp, Site } from "lemmy-js-client";
 import path from "path";
 import process from "process";
+import sanitize from "sanitize-html";
 import serialize from "serialize-javascript";
 import sharp from "sharp";
 import { App } from "../shared/components/app/app";
@@ -347,9 +348,7 @@ async function createSsrHtml(root: string, isoData: IsoDataOptionalSite) {
   <!DOCTYPE html>
   <html ${helmet.htmlAttributes.toString()} lang="en">
   <head>
-  <script>window.isoData = ${JSON.stringify(isoData)
-    .split(">")
-    .join("&gt;")}</script>
+  <script>window.isoData = ${sanitize(JSON.stringify(isoData))}</script>
   <script>window.lemmyConfig = ${serialize(config)}</script>
 
   <!-- A remote debugging utility for mobile -->

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -347,10 +347,9 @@ async function createSsrHtml(root: string, isoData: IsoDataOptionalSite) {
   <!DOCTYPE html>
   <html ${helmet.htmlAttributes.toString()} lang="en">
   <head>
-  <script>window.isoData = ${JSON.stringify(isoData).replaceAll(
-    ">",
-    "&gt;"
-  )}</script>
+  <script>window.isoData = ${JSON.stringify(isoData)
+    .split(">")
+    .join("&gt;")}</script>
   <script>window.lemmyConfig = ${serialize(config)}</script>
 
   <!-- A remote debugging utility for mobile -->

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -25,7 +25,6 @@ import {
   favIconUrl,
   initializeSite,
   isAuthPath,
-  md,
 } from "../shared/utils";
 
 const server = express();
@@ -348,8 +347,9 @@ async function createSsrHtml(root: string, isoData: IsoDataOptionalSite) {
   <!DOCTYPE html>
   <html ${helmet.htmlAttributes.toString()} lang="en">
   <head>
-  <script>window.isoData = ${md.utils.escapeHtml(
-    JSON.stringify(isoData)
+  <script>window.isoData = ${JSON.stringify(isoData).replaceAll(
+    ">",
+    "&gt;"
   )}</script>
   <script>window.lemmyConfig = ${serialize(config)}</script>
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -206,11 +206,13 @@ export function hotRank(score: number, timeStr: string): number {
 }
 
 export function mdToHtml(text: string) {
-  return { __html: md.render(text) };
+  // restore '>' character to fix quotes
+  return { __html: md.render(text).split("&gt;").join(">") };
 }
 
 export function mdToHtmlNoImages(text: string) {
-  return { __html: mdNoImages.render(text) };
+  // restore '>' character to fix quotes
+  return { __html: mdNoImages.render(text).split("&gt;").join(">") };
 }
 
 export function mdToHtmlInline(text: string) {


### PR DESCRIPTION
This solution isnt very clean, but it fixes the vuln in my testing and also doesnt break quotes as you can see below.

![Screenshot_20230609_125419](https://github.com/LemmyNet/lemmy-ui/assets/1044450/01f9f6bd-1089-4474-8f85-a4f002aa6057)

Using [this approach](https://stackoverflow.com/a/56596217) as replaceAll is not available.