### PR TITLE
Only show 'saved' tab on own profile page

### DIFF
--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -317,7 +317,7 @@ export class Profile extends Component<
         {this.getRadio(PersonDetailsView.Overview)}
         {this.getRadio(PersonDetailsView.Comments)}
         {this.getRadio(PersonDetailsView.Posts)}
-        {this.getRadio(PersonDetailsView.Saved)}
+        {this.amCurrentUser && this.getRadio(PersonDetailsView.Saved)}
       </div>
     );
   }


### PR DESCRIPTION
Users can't view saved posts of other users, therefore we can hide the 'Saved' tab on all but your own profile page.

* fixes #1090