### PR TITLE
Added additional keybinds

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -435,28 +435,28 @@ export class MarkdownTextArea extends Component<
   handleKeyBinds(i: MarkdownTextArea, event: KeyboardEvent) {
     if (event.ctrlKey) {
       switch (event.key) {
-        case "k": // Insert link
+        case "k":
           i.handleInsertLink(i, event);
           break;
-        case "b": // Insert bold
+        case "b":
           i.handleInsertBold(i, event);
           break;
-        case "i": // Insert italic
+        case "i":
           i.handleInsertItalic(i, event);
           break;
-        case "e": // Insert code
+        case "e":
           i.handleInsertCode(i, event);
           break;
-        case "8": // Insert unordered list
+        case "8":
           i.handleInsertList(i, event);
           break;
-        case "s": // Insert spoiler
+        case "s":
           i.handleInsertSpoiler(i, event);
           break;
-        case "p": // Move to preview view
+        case "p":
           if (i.state.content) i.handlePreviewToggle(i, event);
           break;
-        case ".": // Insert quote
+        case ".":
           i.handleInsertQuote(i, event);
           break;
       }

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -431,13 +431,34 @@ export class MarkdownTextArea extends Component<
   }
 
   // Keybind handler
+  // Keybinds inspired by github comment area
   handleKeyBinds(i: MarkdownTextArea, event: KeyboardEvent) {
     if (event.ctrlKey) {
       switch (event.key) {
-        case "k": {
-          // Currently only one case but will support further keybinds
+        case "k": // Insert link
           i.handleInsertLink(i, event);
-        }
+          break;
+        case "b": // Insert bold
+          i.handleInsertBold(i, event);
+          break;
+        case "i": // Insert italic
+          i.handleInsertItalic(i, event);
+          break;
+        case "e": // Insert code
+          i.handleInsertCode(i, event);
+          break;
+        case "8": // Insert unordered list
+          i.handleInsertList(i, event);
+          break;
+        case "s": // Insert spoiler
+          i.handleInsertSpoiler(i, event);
+          break;
+        case "p": // Move to preview view
+          if (i.state.content) i.handlePreviewToggle(i, event);
+          break;
+        case ".": // Insert quote
+          i.handleInsertQuote(i, event);
+          break;
       }
     }
   }
@@ -578,7 +599,7 @@ export class MarkdownTextArea extends Component<
 
   handleInsertList(i: MarkdownTextArea, event: any) {
     event.preventDefault();
-    i.simpleBeginningofLine("-");
+    i.simpleBeginningofLine(`-${i.getSelectedText() ? " " : ""}`);
   }
 
   handleInsertQuote(i: MarkdownTextArea, event: any) {


### PR DESCRIPTION
Added additional keybinds following #1136 and based on [Github md editor binds](https://docs.github.com/en/get-started/using-github/keyboard-shortcuts#comments).
I also made sure that when creating a list while text is selected, an additional space is added to make sure it is formatted correctly. This functionality is disabled when text is not selected so as to not change the current experience