### PR TITLE
Implement instance agnostic community linking

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -1102,7 +1102,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     const words: string[] = []
     content.split(" ").forEach(word => {
       if (word.charAt(0) == "!") {
-        words.push(this.handleCommunityLinking(word))
+        words.push(this.renderCommunityLink(word))
       } else {
         words.push(word)
       }
@@ -1110,7 +1110,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     return words.join(" ")
   }
   
-  handleCommunityLinking(text: string): string {
+  renderCommunityLink(text: string): string {
     return `[${text}](/c/${text.substring(1)})`
   }
 

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -1095,13 +1095,33 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     );
   }
 
+  renderCommentContent(content: string): string {
+    /* 
+      Iterate through all the words in a comment and provide frontend support
+      for implementation-agnostic syntactic sugar standards
+    */
+    const words: string[] = []
+    content.split(" ").forEach(word => {
+      if (word.charAt(0) == "!") {
+        words.push(this.handleCommunityLinking(word))
+      } else {
+        words.push(word)
+      }
+    })
+    return words.join(" ")
+  }
+  
+  handleCommunityLinking(text: string): string {
+    return `[${text}](/c/${text.substring(1)})`
+  }
+
   get commentUnlessRemoved(): string {
     const comment = this.props.node.comment_view.comment;
     return comment.removed
       ? `*${i18n.t("removed")}*`
       : comment.deleted
       ? `*${i18n.t("deleted")}*`
-      : comment.content;
+      : this.renderCommentContent(comment.content);
   }
 
   handleReplyClick(i: CommentNode) {

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -1101,7 +1101,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     */
     const words: string[] = []
     content.split(" ").forEach(word => {
-      if (word.charAt(0) == "!" && word.substring(2).indexOf("@") != -1) {
+      if (word.charAt(0) === "!" && word.substring(2).indexOf("@") !== -1) {
         // We start search for the asperand at index 2 to ensure that there is at least
         // one character between "!" and "@" to denote a community name
         words.push(this.renderCommunityLink(word))

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -1101,7 +1101,9 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     */
     const words: string[] = []
     content.split(" ").forEach(word => {
-      if (word.charAt(0) == "!") {
+      if (word.charAt(0) == "!" && word.substring(2).indexOf("@") != -1) {
+        // We start search for the asperand at index 2 to ensure that there is at least
+        // one character between "!" and "@" to denote a community name
         words.push(this.renderCommunityLink(word))
       } else {
         words.push(word)

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -700,7 +700,7 @@ export function setupTribute() {
         trigger: "!",
         selectTemplate: (item: any) => {
           const it: CommunityTribute = item.original;
-          return `[${it.key}](${it.view.community.actor_id})`;
+          return `[${it.key}](${it.key.replace("!", "/c/")})`;
         },
         values: debounce(async (text: string, cb: any) => {
           cb(await communitySearch(text));

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -700,7 +700,7 @@ export function setupTribute() {
         trigger: "!",
         selectTemplate: (item: any) => {
           const it: CommunityTribute = item.original;
-          return `[${it.key}](${it.key.replace("!", "/c/")})`;
+          return `[${it.key}](${"/c/" + it.key.substring(1)})`;
         },
         values: debounce(async (text: string, cb: any) => {
           cb(await communitySearch(text));

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -700,7 +700,7 @@ export function setupTribute() {
         trigger: "!",
         selectTemplate: (item: any) => {
           const it: CommunityTribute = item.original;
-          return `[${it.key}](${"/c/" + it.key.substring(1)})`;
+          return `${it.key}`;
         },
         values: debounce(async (text: string, cb: any) => {
           cb(await communitySearch(text));


### PR DESCRIPTION
Replaces the hyperlink component of the markdown link of the Tribute template with an instance agnostic way of linking to different communities.

For example, instead of autofilling !technology@beehaw.org to https://beehaw.org/c/technology, we should autofill it to /c/technology@beehaw.org. That way, we redirect users to the version of the linked community on their home instance. This makes moving around lemmy less jarring. Currently when someone whose home instance isn't beehaw clicks that link, they'll be "logged out" (even though they aren't "logged out"; they've just moved to a different website). This should be implemented because of the fact that all lemmy instances have the same UI, making what should be a pretty painless traversal kind of confusing.

I'm not sure how to spin up a local lemmy instance for testing frontend changes, so if someone could tell me how to spin one up or test this real quick for me, that would be much appreciated.

Also I'm not really acquainted with what convention the maintainers prefer for using existing types, but this seemed like the most straight forward solution. It's kind of inefficient though, since we don't use the CommunityView returned by the network response.