### PR TITLE
Make the community title in the sidebar link to the local community.

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -331,14 +331,16 @@ async function createSsrHtml(root: string, isoData: IsoDataOptionalSite) {
         .then(buf => buf.toString("base64"))}`
     : favIconPngUrl;
 
-  const eruda = (
-    <>
-      <script src="//cdn.jsdelivr.net/npm/eruda"></script>
-      <script>eruda.init();</script>
-    </>
-  );
+  let erudaStr = "";
 
-  const erudaStr = process.env["LEMMY_UI_DEBUG"] ? renderToString(eruda) : "";
+  if (process.env["LEMMY_UI_DEBUG"] === "true") {
+    erudaStr = renderToString(
+      <>
+        <script src="//cdn.jsdelivr.net/npm/eruda"></script>
+        <script>eruda.init();</script>
+      </>
+    );
+  }
 
   const helmet = Helmet.renderStatic();
 

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -132,7 +132,9 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
           {this.props.showIcon && !community.removed && (
             <BannerIconHeader icon={community.icon} banner={community.banner} />
           )}
-          <span className="mr-2">{community.title}</span>
+          <span className="mr-2">
+            <CommunityLink community={community} hideAvatar />
+          </span>
           {subscribed === "Subscribed" && (
             <button
               className="btn btn-secondary btn-sm mr-2"


### PR DESCRIPTION
* Makes it so that the `LEMMY_UI_DEBUG` flag toggles depending on its value, rather than its presence.
* Makes the community title into a link that goes to the local community.

The existing link to the non-local community right below the title is not as helpful as the local community link, because the user likely wants to go to the community within the instance they are on.

Feel free to close or redo, thanks!