### PR TITLE
Specify package manager version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "typescript": "^5.0.4",
     "webpack-dev-server": "4.15.0"
   },
+  "packageManager": "yarn@1.22.19",
   "engines": {
     "node": ">=8.9.0"
   },


### PR DESCRIPTION
This setting is picked up by Corepack, and it's a way for others to concretely know which package manager they should use.
