### PR TITLE
Left-align comment collapse/expand button

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -240,11 +240,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 aria-label={this.expandText}
                 data-tippy-content={this.expandText}
               >
-                {this.state.collapsed ? (
-                  <Icon icon="plus-square" classes="icon-inline" />
-                ) : (
-                  <Icon icon="minus-square" classes="icon-inline" />
-                )}
+                <Icon icon={`${this.state.collapsed ? "plus" : "minus"}-square`} classes="icon-inline" />
               </button>
               <span className="mr-2">
                 <PersonListing person={cv.creator} />

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -234,6 +234,18 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
             })}
           >
             <div className="d-flex flex-wrap align-items-center text-muted small">
+              <button
+                className="btn btn-sm text-muted mr-2"
+                onClick={linkEvent(this, this.handleCommentCollapse)}
+                aria-label={this.expandText}
+                data-tippy-content={this.expandText}
+              >
+                {this.state.collapsed ? (
+                  <Icon icon="plus-square" classes="icon-inline" />
+                ) : (
+                  <Icon icon="minus-square" classes="icon-inline" />
+                )}
+              </button>
               <span className="mr-2">
                 <PersonListing person={cv.creator} />
               </span>
@@ -270,18 +282,6 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                   </Link>
                 </>
               )}
-              <button
-                className="btn btn-sm text-muted"
-                onClick={linkEvent(this, this.handleCommentCollapse)}
-                aria-label={this.expandText}
-                data-tippy-content={this.expandText}
-              >
-                {this.state.collapsed ? (
-                  <Icon icon="plus-square" classes="icon-inline" />
-                ) : (
-                  <Icon icon="minus-square" classes="icon-inline" />
-                )}
-              </button>
               {this.linkBtn(true)}
               {cv.comment.language_id !== 0 && (
                 <span className="badge d-none d-sm-inline mr-2">


### PR DESCRIPTION
Hi all!

Here's a quick PR to left-align the collapse/expand button on comment nodes. 

This is a pain point especially noticeable on mobile, when collapsing comments –different username lengths lead to the button being at different locations– forcing the user to hunt for the collapse button. It's very fatiguing. Having it left-aligned keeps it in the same place regardless of the other dynamic element widths.

<img width="640" alt="Screenshot 2023-06-11 at 9 53 30 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/798f9d77-4f2c-4b8d-87f1-3ccedc37b64a">

Thanks so much!
