### PR TITLE
Set html lang attr to the interface language

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -346,7 +346,7 @@ async function createSsrHtml(root: string, isoData: IsoDataOptionalSite) {
 
   return `
   <!DOCTYPE html>
-  <html ${helmet.htmlAttributes.toString()} lang="en">
+  <html ${helmet.htmlAttributes.toString()}>
   <head>
   <script>window.isoData = ${sanitize(JSON.stringify(isoData))}</script>
   <script>window.lemmyConfig = ${serialize(config)}</script>

--- a/src/shared/components/common/html-tags.tsx
+++ b/src/shared/components/common/html-tags.tsx
@@ -2,7 +2,7 @@ import { htmlToText } from "html-to-text";
 import { Component } from "inferno";
 import { Helmet } from "inferno-helmet";
 import { httpExternalPath } from "../../env";
-import { md } from "../../utils";
+import { getLanguages, md } from "../../utils";
 
 interface HtmlTagsProps {
   title: string;
@@ -17,9 +17,12 @@ export class HtmlTags extends Component<HtmlTagsProps, any> {
     const url = httpExternalPath(this.props.path);
     const desc = this.props.description;
     const image = this.props.image;
+    const lang = getLanguages()[0];
 
     return (
       <Helmet title={this.props.title}>
+        <html lang={lang == "browser" ? "en" : lang} />
+
         {["title", "og:title", "twitter:title"].map(t => (
           <meta key={t} property={t} content={this.props.title} />
         ))}


### PR DESCRIPTION
Fixes #1168

As there are issues with running the main branch with the current backend repo, I tested this by cherry-picking to `use_http_client_2`. 

My change fixes the linked issue by setting the `lang` attribute of the `html` tag properly in accordance to the lemmy user preferences or user-agent preferences. If the lemmy user has a UI language other than "Browser" set, then the response from the server will already have the correct `lang` set. Otherwise the attr is set on the client side according to the language settings in the browser. If any of this fails, it falls back to English. 