### PR TITLE
Footer: Use `target="_blank"` for all external links, refactor Github-related links

### DIFF
--- a/src/shared/components/app/footer.tsx
+++ b/src/shared/components/app/footer.tsx
@@ -21,13 +21,13 @@ export class Footer extends Component<FooterProps, any> {
           <ul className="navbar-nav ml-auto">
             {this.props.site?.version !== VERSION && (
               <li className="nav-item">
-                <a className="nav-link" href={frontendRepoUrl} target="_blank">
+                <a className="nav-link" href={frontendRepoUrl} target="_blank" rel="noreferrer">
                   UI: {VERSION}
                 </a>
               </li>
             )}
             <li className="nav-item">
-              <a className="nav-link" href={backendRepoUrl} target="_blank">
+              <a className="nav-link" href={backendRepoUrl} target="_blank" rel="noreferrer">
                 BE: {this.props.site?.version}
               </a>
             </li>
@@ -51,17 +51,17 @@ export class Footer extends Component<FooterProps, any> {
               </li>
             )}
             <li className="nav-item">
-              <a className="nav-link" href={docsUrl} target="_blank">
+              <a className="nav-link" href={docsUrl} target="_blank" rel="noreferrer">
                 {i18n.t("docs")}
               </a>
             </li>
             <li className="nav-item">
-              <a className="nav-link" href={githubOrgUrl} target="_blank">
+              <a className="nav-link" href={githubOrgUrl} target="_blank" rel="noreferrer">
                 {i18n.t("code")}
               </a>
             </li>
             <li className="nav-item">
-              <a className="nav-link" href={joinLemmyUrl} target="_blank">
+              <a className="nav-link" href={joinLemmyUrl} target="_blank" rel="noreferrer">
                 {i18n.t("join_lemmy")}
               </a>
             </li>

--- a/src/shared/components/app/footer.tsx
+++ b/src/shared/components/app/footer.tsx
@@ -2,7 +2,7 @@ import { Component } from "inferno";
 import { NavLink } from "inferno-router";
 import { GetSiteResponse } from "lemmy-js-client";
 import { i18n } from "../../i18next";
-import { docsUrl, joinLemmyUrl, repoUrl } from "../../utils";
+import { docsUrl, joinLemmyUrl, githubOrgUrl, frontendRepoUrl, backendRepoUrl } from "../../utils";
 import { VERSION } from "../../version";
 
 interface FooterProps {
@@ -21,11 +21,15 @@ export class Footer extends Component<FooterProps, any> {
           <ul className="navbar-nav ml-auto">
             {this.props.site?.version !== VERSION && (
               <li className="nav-item">
-                <span className="nav-link">UI: {VERSION}</span>
+                <a className="nav-link" href={frontendRepoUrl} target="_blank">
+                  UI: {VERSION}
+                </a>
               </li>
             )}
             <li className="nav-item">
-              <span className="nav-link">BE: {this.props.site?.version}</span>
+              <a className="nav-link" href={backendRepoUrl} target="_blank">
+                BE: {this.props.site?.version}
+              </a>
             </li>
             <li className="nav-item">
               <NavLink className="nav-link" to="/modlog">
@@ -47,17 +51,17 @@ export class Footer extends Component<FooterProps, any> {
               </li>
             )}
             <li className="nav-item">
-              <a className="nav-link" href={docsUrl}>
+              <a className="nav-link" href={docsUrl} target="_blank">
                 {i18n.t("docs")}
               </a>
             </li>
             <li className="nav-item">
-              <a className="nav-link" href={repoUrl}>
+              <a className="nav-link" href={githubOrgUrl} target="_blank">
                 {i18n.t("code")}
               </a>
             </li>
             <li className="nav-item">
-              <a className="nav-link" href={joinLemmyUrl}>
+              <a className="nav-link" href={joinLemmyUrl} target="_blank">
                 {i18n.t("join_lemmy")}
               </a>
             </li>

--- a/src/shared/components/app/footer.tsx
+++ b/src/shared/components/app/footer.tsx
@@ -2,7 +2,13 @@ import { Component } from "inferno";
 import { NavLink } from "inferno-router";
 import { GetSiteResponse } from "lemmy-js-client";
 import { i18n } from "../../i18next";
-import { docsUrl, joinLemmyUrl, githubOrgUrl, frontendRepoUrl, backendRepoUrl } from "../../utils";
+import {
+  backendRepoUrl,
+  docsUrl,
+  frontendRepoUrl,
+  githubOrgUrl,
+  joinLemmyUrl,
+} from "../../utils";
 import { VERSION } from "../../version";
 
 interface FooterProps {
@@ -21,13 +27,23 @@ export class Footer extends Component<FooterProps, any> {
           <ul className="navbar-nav ml-auto">
             {this.props.site?.version !== VERSION && (
               <li className="nav-item">
-                <a className="nav-link" href={frontendRepoUrl} target="_blank" rel="noreferrer">
+                <a
+                  className="nav-link"
+                  href={frontendRepoUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                >
                   UI: {VERSION}
                 </a>
               </li>
             )}
             <li className="nav-item">
-              <a className="nav-link" href={backendRepoUrl} target="_blank" rel="noreferrer">
+              <a
+                className="nav-link"
+                href={backendRepoUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
                 BE: {this.props.site?.version}
               </a>
             </li>
@@ -51,17 +67,32 @@ export class Footer extends Component<FooterProps, any> {
               </li>
             )}
             <li className="nav-item">
-              <a className="nav-link" href={docsUrl} target="_blank" rel="noreferrer">
+              <a
+                className="nav-link"
+                href={docsUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
                 {i18n.t("docs")}
               </a>
             </li>
             <li className="nav-item">
-              <a className="nav-link" href={githubOrgUrl} target="_blank" rel="noreferrer">
+              <a
+                className="nav-link"
+                href={githubOrgUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
                 {i18n.t("code")}
               </a>
             </li>
             <li className="nav-item">
-              <a className="nav-link" href={joinLemmyUrl} target="_blank" rel="noreferrer">
+              <a
+                className="nav-link"
+                href={joinLemmyUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
                 {i18n.t("join_lemmy")}
               </a>
             </li>

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -240,10 +240,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 aria-label={this.expandText}
                 data-tippy-content={this.expandText}
               >
-                <Icon
-                  icon={`${this.state.collapsed ? "plus" : "minus"}-square`}
-                  classes="icon-inline"
-                />
+                <Icon icon={`${this.state.collapsed ? "plus" : "minus"}-square`} classes="icon-inline" />
               </button>
               <span className="mr-2">
                 <PersonListing person={cv.creator} />

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -240,7 +240,10 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 aria-label={this.expandText}
                 data-tippy-content={this.expandText}
               >
-                <Icon icon={`${this.state.collapsed ? "plus" : "minus"}-square`} classes="icon-inline" />
+                <Icon
+                  icon={`${this.state.collapsed ? "plus" : "minus"}-square`}
+                  classes="icon-inline"
+                />
               </button>
               <span className="mr-2">
                 <PersonListing person={cv.creator} />
@@ -376,7 +379,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                     <>
                       <button
                         className={`btn btn-link btn-animate ${
-                          this.state.my_vote === 1 ? "text-info" : "text-muted"
+                          this.state.my_vote === 1 ? "text-danger" : "text-muted"
                         }`}
                         onClick={this.handleCommentUpvote}
                         data-tippy-content={i18n.t("upvote")}
@@ -395,7 +398,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                         <button
                           className={`btn btn-link btn-animate ${
                             this.state.my_vote === -1
-                              ? "text-danger"
+                              ? "text-info"
                               : "text-muted"
                           }`}
                           onClick={this.handleCommentDownvote}
@@ -1562,9 +1565,9 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
 
   get scoreColor() {
     if (this.state.my_vote == 1) {
-      return "text-info";
-    } else if (this.state.my_vote == -1) {
       return "text-danger";
+    } else if (this.state.my_vote == -1) {
+      return "text-info";
     } else {
       return "text-muted";
     }

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -234,17 +234,6 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
             })}
           >
             <div className="d-flex flex-wrap align-items-center text-muted small">
-              <button
-                className="btn btn-sm text-muted mr-2"
-                onClick={linkEvent(this, this.handleCommentCollapse)}
-                aria-label={this.expandText}
-                data-tippy-content={this.expandText}
-              >
-                <Icon
-                  icon={`${this.state.collapsed ? "plus" : "minus"}-square`}
-                  classes="icon-inline"
-                />
-              </button>
               <span className="mr-2">
                 <PersonListing person={cv.creator} />
               </span>
@@ -281,6 +270,18 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                   </Link>
                 </>
               )}
+              <button
+                className="btn btn-sm text-muted"
+                onClick={linkEvent(this, this.handleCommentCollapse)}
+                aria-label={this.expandText}
+                data-tippy-content={this.expandText}
+              >
+                {this.state.collapsed ? (
+                  <Icon icon="plus-square" classes="icon-inline" />
+                ) : (
+                  <Icon icon="minus-square" classes="icon-inline" />
+                )}
+              </button>
               {this.linkBtn(true)}
               {cv.comment.language_id !== 0 && (
                 <span className="badge d-none d-sm-inline mr-2">
@@ -379,7 +380,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                     <>
                       <button
                         className={`btn btn-link btn-animate ${
-                          this.state.my_vote === 1 ? "text-danger" : "text-muted"
+                          this.state.my_vote === 1 ? "text-info" : "text-muted"
                         }`}
                         onClick={this.handleCommentUpvote}
                         data-tippy-content={i18n.t("upvote")}
@@ -398,7 +399,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                         <button
                           className={`btn btn-link btn-animate ${
                             this.state.my_vote === -1
-                              ? "text-info"
+                              ? "text-danger"
                               : "text-muted"
                           }`}
                           onClick={this.handleCommentDownvote}
@@ -1565,9 +1566,9 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
 
   get scoreColor() {
     if (this.state.my_vote == 1) {
-      return "text-danger";
-    } else if (this.state.my_vote == -1) {
       return "text-info";
+    } else if (this.state.my_vote == -1) {
+      return "text-danger";
     } else {
       return "text-muted";
     }

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -234,6 +234,17 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
             })}
           >
             <div className="d-flex flex-wrap align-items-center text-muted small">
+              <button
+                className="btn btn-sm text-muted mr-2"
+                onClick={linkEvent(this, this.handleCommentCollapse)}
+                aria-label={this.expandText}
+                data-tippy-content={this.expandText}
+              >
+                <Icon
+                  icon={`${this.state.collapsed ? "plus" : "minus"}-square`}
+                  classes="icon-inline"
+                />
+              </button>
               <span className="mr-2">
                 <PersonListing person={cv.creator} />
               </span>
@@ -270,18 +281,6 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                   </Link>
                 </>
               )}
-              <button
-                className="btn btn-sm text-muted"
-                onClick={linkEvent(this, this.handleCommentCollapse)}
-                aria-label={this.expandText}
-                data-tippy-content={this.expandText}
-              >
-                {this.state.collapsed ? (
-                  <Icon icon="plus-square" classes="icon-inline" />
-                ) : (
-                  <Icon icon="minus-square" classes="icon-inline" />
-                )}
-              </button>
               {this.linkBtn(true)}
               {cv.comment.language_id !== 0 && (
                 <span className="badge d-none d-sm-inline mr-2">

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -57,7 +57,9 @@ export const favIconUrl = "/static/assets/icons/favicon.svg";
 export const favIconPngUrl = "/static/assets/icons/apple-touch-icon.png";
 // TODO
 // export const defaultFavIcon = `${window.location.protocol}//${window.location.host}${favIconPngUrl}`;
-export const repoUrl = "https://github.com/LemmyNet";
+export const githubOrgUrl = "https://github.com/LemmyNet";
+export const frontendRepoUrl = "https://github.com/LemmyNet/lemmy-ui";
+export const backendRepoUrl = "https://github.com/LemmyNet/lemmy";
 export const joinLemmyUrl = "https://join-lemmy.org";
 export const donateLemmyUrl = `${joinLemmyUrl}/donate`;
 export const docsUrl = `${joinLemmyUrl}/docs/en/index.html`;


### PR DESCRIPTION
Hi, Lemmy devs!

Just a small UX tweak for the site footer – external links should open in a new tab. Also added pertinent links to the actual repos to hopefully get some more eyeballs on the OSS project. 👀

- Use `target="_blank"` for all external links
- Refactor Github-related links
- Format code to be consistent with other elements

Thanks.