### PR TITLE
Swap upvote/downvote arrow icon colors

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -380,7 +380,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                     <>
                       <button
                         className={`btn btn-link btn-animate ${
-                          this.state.my_vote === 1 ? "text-info" : "text-muted"
+                          this.state.my_vote === 1 ? "text-danger" : "text-muted"
                         }`}
                         onClick={this.handleCommentUpvote}
                         data-tippy-content={i18n.t("upvote")}
@@ -399,7 +399,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                         <button
                           className={`btn btn-link btn-animate ${
                             this.state.my_vote === -1
-                              ? "text-danger"
+                              ? "text-info"
                               : "text-muted"
                           }`}
                           onClick={this.handleCommentDownvote}
@@ -1566,9 +1566,9 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
 
   get scoreColor() {
     if (this.state.my_vote == 1) {
-      return "text-info";
-    } else if (this.state.my_vote == -1) {
       return "text-danger";
+    } else if (this.state.my_vote == -1) {
+      return "text-info";
     } else {
       return "text-muted";
     }

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -379,7 +379,9 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                     <>
                       <button
                         className={`btn btn-link btn-animate ${
-                          this.state.my_vote === 1 ? "text-danger" : "text-muted"
+                          this.state.my_vote === 1
+                            ? "text-danger"
+                            : "text-muted"
                         }`}
                         onClick={this.handleCommentUpvote}
                         data-tippy-content={i18n.t("upvote")}

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -401,7 +401,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <div className={`vote-bar col-1 pr-0 small text-center`}>
         <button
           className={`btn-animate btn btn-link p-0 ${
-            this.state.my_vote === 1 ? "text-info" : "text-muted"
+            this.state.my_vote === 1 ? "text-danger" : "text-muted"
           }`}
           onClick={this.handlePostLike}
           data-tippy-content={i18n.t("upvote")}
@@ -423,7 +423,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         {this.props.enableDownvotes && (
           <button
             className={`btn-animate btn btn-link p-0 ${
-              this.state.my_vote === -1 ? "text-danger" : "text-muted"
+              this.state.my_vote === -1 ? "text-info" : "text-muted"
             }`}
             onClick={this.handlePostDisLike}
             data-tippy-content={i18n.t("downvote")}
@@ -692,7 +692,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         <div>
           <button
             className={`btn-animate btn py-0 px-1 ${
-              this.state.my_vote === 1 ? "text-info" : "text-muted"
+              this.state.my_vote === 1 ? "text-danger" : "text-muted"
             }`}
             {...tippy}
             onClick={this.handlePostLike}
@@ -707,7 +707,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           {this.props.enableDownvotes && (
             <button
               className={`ml-2 btn-animate btn py-0 px-1 ${
-                this.state.my_vote === -1 ? "text-danger" : "text-muted"
+                this.state.my_vote === -1 ? "text-info" : "text-muted"
               }`}
               onClick={this.handlePostDisLike}
               {...tippy}


### PR DESCRIPTION
Hi all!

Quick PR here to swap upvote/downvote colors. Currently we have `text-info` for upvote and `text-danger` for downvote, when most of us are expecting quite the opposite. I propose we swap these per r*ddit conventions.

<img width="746" alt="Screenshot 2023-06-11 at 11 34 30 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/f108c1e8-5a75-4cec-bbd5-f7790f786eee">

<img width="775" alt="Screenshot 2023-06-11 at 11 34 09 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/cdc44471-6dcd-497f-81f6-0c6ac7fb7b30">

Thanks! 🙌