### PR TITLE
Add title to pictrs-image

### DIFF
--- a/src/shared/components/common/pictrs-image.tsx
+++ b/src/shared/components/common/pictrs-image.tsx
@@ -29,6 +29,7 @@ export class PictrsImage extends Component<PictrsImageProps, any> {
         <img
           src={this.props.src}
           alt={this.alt()}
+          title={this.alt()}
           loading="lazy"
           className={classNames({
             "img-fluid": !this.props.icon && !this.props.iconOverlay,


### PR DESCRIPTION
This adds a title tag to images, uses the alt tag value. This improves accessibility for sighted users and screen readers.