### PR TITLE
Fix bug preventing `CommunityForm` from being resubmitted after error

### DIFF
--- a/src/shared/components/community/community-form.tsx
+++ b/src/shared/components/community/community-form.tsx
@@ -21,7 +21,7 @@ interface CommunityFormProps {
   onCancel?(): any;
   onUpsertCommunity(form: CreateCommunity | EditCommunity): void;
   enableNsfw?: boolean;
-  isLoading?: boolean;
+  loading?: boolean;
 }
 
 interface CommunityFormState {
@@ -88,7 +88,7 @@ export class CommunityForm extends Component<
       <form onSubmit={linkEvent(this, this.handleCreateCommunitySubmit)}>
         <NavigationPrompt
           when={
-            !this.props.isLoading &&
+            !this.props.loading &&
             !!(
               this.state.form.name ||
               this.state.form.title ||
@@ -241,9 +241,9 @@ export class CommunityForm extends Component<
             <button
               type="submit"
               className="btn btn-secondary mr-2"
-              disabled={this.props.isLoading}
+              disabled={this.props.loading}
             >
-              {this.props.isLoading ? (
+              {this.props.loading ? (
                 <Spinner />
               ) : this.props.community_view ? (
                 capitalizeFirstLetter(i18n.t("save"))

--- a/src/shared/components/community/community-form.tsx
+++ b/src/shared/components/community/community-form.tsx
@@ -21,6 +21,7 @@ interface CommunityFormProps {
   onCancel?(): any;
   onUpsertCommunity(form: CreateCommunity | EditCommunity): void;
   enableNsfw?: boolean;
+  isLoading?: boolean;
 }
 
 interface CommunityFormState {
@@ -34,7 +35,6 @@ interface CommunityFormState {
     posting_restricted_to_mods?: boolean;
     discussion_languages?: number[];
   };
-  loading: boolean;
   submitted: boolean;
 }
 
@@ -46,7 +46,6 @@ export class CommunityForm extends Component<
 
   state: CommunityFormState = {
     form: {},
-    loading: false,
     submitted: false,
   };
 
@@ -80,7 +79,6 @@ export class CommunityForm extends Component<
           posting_restricted_to_mods: cv.community.posting_restricted_to_mods,
           discussion_languages: this.props.communityLanguages,
         },
-        loading: false,
       };
     }
   }
@@ -90,7 +88,7 @@ export class CommunityForm extends Component<
       <form onSubmit={linkEvent(this, this.handleCreateCommunitySubmit)}>
         <NavigationPrompt
           when={
-            !this.state.loading &&
+            !this.props.isLoading &&
             !!(
               this.state.form.name ||
               this.state.form.title ||
@@ -243,9 +241,9 @@ export class CommunityForm extends Component<
             <button
               type="submit"
               className="btn btn-secondary mr-2"
-              disabled={this.state.loading}
+              disabled={this.props.isLoading}
             >
-              {this.state.loading ? (
+              {this.props.isLoading ? (
                 <Spinner />
               ) : this.props.community_view ? (
                 capitalizeFirstLetter(i18n.t("save"))
@@ -270,7 +268,7 @@ export class CommunityForm extends Component<
 
   handleCreateCommunitySubmit(i: CommunityForm, event: any) {
     event.preventDefault();
-    i.setState({ loading: true, submitted: true });
+    i.setState({ submitted: true });
     const cForm = i.state.form;
     const auth = myAuthRequired();
 

--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -47,7 +47,7 @@ export class CreateCommunity extends Component<any, CreateCommunityState> {
               allLanguages={this.state.siteRes.all_languages}
               siteLanguages={this.state.siteRes.discussion_languages}
               communityLanguages={this.state.siteRes.discussion_languages}
-              isLoading={this.state.loading}
+              loading={this.state.loading}
             />
           </div>
         </div>

--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -11,12 +11,14 @@ import { CommunityForm } from "./community-form";
 
 interface CreateCommunityState {
   siteRes: GetSiteResponse;
+  loading: boolean;
 }
 
 export class CreateCommunity extends Component<any, CreateCommunityState> {
   private isoData = setIsoData(this.context);
   state: CreateCommunityState = {
     siteRes: this.isoData.site_res,
+    loading: false,
   };
   constructor(props: any, context: any) {
     super(props, context);
@@ -45,6 +47,7 @@ export class CreateCommunity extends Component<any, CreateCommunityState> {
               allLanguages={this.state.siteRes.all_languages}
               siteLanguages={this.state.siteRes.discussion_languages}
               communityLanguages={this.state.siteRes.discussion_languages}
+              isLoading={this.state.loading}
             />
           </div>
         </div>
@@ -53,10 +56,15 @@ export class CreateCommunity extends Component<any, CreateCommunityState> {
   }
 
   async handleCommunityCreate(form: CreateCommunityI) {
+    this.setState({ loading: true });
+
     const res = await HttpService.client.createCommunity(form);
+
     if (res.state === "success") {
       const name = res.data.community_view.community.name;
       this.props.history.replace(`/c/${name}`);
+    } else {
+      this.setState({ loading: false });
     }
   }
 }


### PR DESCRIPTION
Currently there's a bug preventing `CommunityForm` from being resubmitted after error. This PR handles the `loading` state on the parent component, properly setting `loading` back to `false` in case of an error.

https://github.com/LemmyNet/lemmy-ui/assets/35377827/c18b563f-c98e-43b2-ab55-2f6de5f93586

https://github.com/LemmyNet/lemmy-ui/assets/35377827/63688ea5-d8f0-4a5f-8a42-c694ae6d4f4d