### PR TITLE
Fix formatting of description meta tags

### DIFF
--- a/src/shared/components/common/html-tags.tsx
+++ b/src/shared/components/common/html-tags.tsx
@@ -43,7 +43,10 @@ export class HtmlTags extends Component<HtmlTagsProps, any> {
               <meta
                 key={n}
                 name={n}
-                content={htmlToText(md.renderInline(desc))}
+                content={htmlToText(md.renderInline(desc), {
+                  wordwrap: false,
+                  preserveNewlines: true,
+                })}
               />
             )
         )}


### PR DESCRIPTION
Pretty simple change to fix #1259.

By default, `html-to-text` wraps lines at 80 characters. This resulted in poor compatibility with link previews in Discord (and I can imagine other platforms that don't handle this issue themselves). This change overwrites the default limit of 80 character lines (`wordwrap: false`) and retains the original post newlines (`preserveNewlines: true`). 