### PR TITLE
Add missing tooltip for `cross-post` button on `PostListing`

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -835,6 +835,8 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           search: "",
         }}
         title={i18n.t("cross_post")}
+        data-tippy-content={i18n.t("cross_post")}
+        aria-label={i18n.t("cross_post")}
       >
         <Icon icon="copy" inline />
       </Link>


### PR DESCRIPTION
- Add missing tooltip for `cross-post` button on `PostListing`

<img width="611" alt="Screenshot 2023-06-14 at 10 04 11 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/4c30db17-d4e3-4452-97a0-714c64a6adba">

Partially resolves #1238.