### PR TITLE
Fix <hr> being almost invisible

### DIFF
--- a/src/shared/components/post/post-listings.tsx
+++ b/src/shared/components/post/post-listings.tsx
@@ -68,7 +68,7 @@ export class PostListings extends Component<PostListingsProps, any> {
     return (
       <div>
         {this.posts.length > 0 ? (
-          this.posts.map(post_view => (
+          this.posts.map((post_view: PostView, idx: number) => (
             <>
               <PostListing
                 post_view={post_view}
@@ -96,7 +96,9 @@ export class PostListings extends Component<PostListingsProps, any> {
                 onAddAdmin={this.props.onAddAdmin}
                 onTransferCommunity={this.props.onTransferCommunity}
               />
-              <hr className="my-3" />
+              {idx + 1 !== this.posts.length && (
+                <hr className="my-3 border border-primary" />
+              )}
             </>
           ))
         ) : (

--- a/src/shared/components/post/post-listings.tsx
+++ b/src/shared/components/post/post-listings.tsx
@@ -68,7 +68,7 @@ export class PostListings extends Component<PostListingsProps, any> {
     return (
       <div>
         {this.posts.length > 0 ? (
-          this.posts.map((post_view: PostView, idx: number) => (
+          this.posts.map((post_view, idx) => (
             <>
               <PostListing
                 post_view={post_view}


### PR DESCRIPTION
Before:

<img width="569" alt="Screenshot 2023-06-15 082518" src="https://github.com/LemmyNet/lemmy-ui/assets/266545/0c1a052c-1f97-4bb7-b95c-0a2ecbfa320b">

After:

<img width="569" alt="Screenshot 2023-06-15 082435" src="https://github.com/LemmyNet/lemmy-ui/assets/266545/8f0036f2-9892-4527-a770-a4c562dae164">

Two changes:

 * Add `border border-primary` to the `<hr>` but only if it is not the last item in the listing.
 * Add typing information to `this.posts.map()` call

Fixed #533 