### PR TITLE
Fix infinite spinner for login that results in failure

### DIFF
--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -160,38 +160,42 @@ export class Login extends Component<any, State> {
     if (username_or_email && password) {
       i.setState({ loginRes: { state: "loading" } });
 
-      const loginRes = await HttpService.client.login({
-        username_or_email,
-        password,
-        totp_2fa_token,
-      });
-      switch (loginRes.state) {
-        case "failed": {
-          if (loginRes.msg === "missing_totp_token") {
-            i.setState({ showTotp: true });
-            toast(i18n.t("enter_two_factor_code"), "info");
+      try {
+        const loginRes = await HttpService.client.login({
+          username_or_email,
+          password,
+          totp_2fa_token,
+        });
+        switch (loginRes.state) {
+          case "failed": {
+            if (loginRes.msg === "missing_totp_token") {
+              i.setState({ showTotp: true });
+              toast(i18n.t("enter_two_factor_code"), "info");
+            }
+
+            i.setState({ loginRes: { state: "empty" } });
+            break;
           }
 
-          i.setState({ loginRes: { state: "empty" } });
-          break;
-        }
+          case "success": {
+            UserService.Instance.login(loginRes.data);
+            const site = await HttpService.client.getSite({
+              auth: myAuth(),
+            });
 
-        case "success": {
-          UserService.Instance.login(loginRes.data);
-          const site = await HttpService.client.getSite({
-            auth: myAuth(),
-          });
+            if (site.state === "success") {
+              UserService.Instance.myUserInfo = site.data.my_user;
+            }
 
-          if (site.state === "success") {
-            UserService.Instance.myUserInfo = site.data.my_user;
+            i.props.history.action === "PUSH"
+              ? i.props.history.back()
+              : i.props.history.replace("/");
+
+            break;
           }
-
-          i.props.history.action === "PUSH"
-            ? i.props.history.back()
-            : i.props.history.replace("/");
-
-          break;
         }
+      } catch (error) {
+        i.setState({ loginRes: { state: "failed", msg: error.message } });
       }
     }
   }

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -160,42 +160,38 @@ export class Login extends Component<any, State> {
     if (username_or_email && password) {
       i.setState({ loginRes: { state: "loading" } });
 
-      try {
-        const loginRes = await HttpService.client.login({
-          username_or_email,
-          password,
-          totp_2fa_token,
-        });
-        switch (loginRes.state) {
-          case "failed": {
-            if (loginRes.msg === "missing_totp_token") {
-              i.setState({ showTotp: true });
-              toast(i18n.t("enter_two_factor_code"), "info");
-            }
-
-            i.setState({ loginRes: { state: "empty" } });
-            break;
+      const loginRes = await HttpService.client.login({
+        username_or_email,
+        password,
+        totp_2fa_token,
+      });
+      switch (loginRes.state) {
+        case "failed": {
+          if (loginRes.msg === "missing_totp_token") {
+            i.setState({ showTotp: true });
+            toast(i18n.t("enter_two_factor_code"), "info");
           }
 
-          case "success": {
-            UserService.Instance.login(loginRes.data);
-            const site = await HttpService.client.getSite({
-              auth: myAuth(),
-            });
-
-            if (site.state === "success") {
-              UserService.Instance.myUserInfo = site.data.my_user;
-            }
-
-            i.props.history.action === "PUSH"
-              ? i.props.history.back()
-              : i.props.history.replace("/");
-
-            break;
-          }
+          i.setState({ loginRes: { state: "failed", msg: loginRes.msg } });
+          break;
         }
-      } catch (error) {
-        i.setState({ loginRes: { state: "failed", msg: error.message } });
+
+        case "success": {
+          UserService.Instance.login(loginRes.data);
+          const site = await HttpService.client.getSite({
+            auth: myAuth(),
+          });
+
+          if (site.state === "success") {
+            UserService.Instance.myUserInfo = site.data.my_user;
+          }
+
+          i.props.history.action === "PUSH"
+            ? i.props.history.back()
+            : i.props.history.replace("/");
+
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
![Animation](https://github.com/LemmyNet/lemmy-ui/assets/266545/405e7ed8-250b-4e28-afca-28a3f8f261a6)

Added error handling to the login form, so it doesn't just "spin infinitely" when there is an error. Error is surfaced as a toast using existing code, just calling i.setState() in the catch block.