### PR TITLE
Make community IDs more easily selectable

### DIFF
--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -1,4 +1,5 @@
 import { Component, InfernoNode, linkEvent } from "inferno";
+import { T } from "inferno-i18next-dess";
 import { Link } from "inferno-router";
 import {
   AddModToCommunity,
@@ -144,7 +145,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
             {myUSerInfo && this.blockCommunity()}
             {!myUSerInfo && (
               <div className="alert alert-info" role="alert">
-                {i18n.t("community_not_logged_in_alert")}
+                <T i18nKey="community_not_logged_in_alert">#</T>
                 <code className="user-select-all">
                   !{name}@{hostname(actor_id)}
                 </code>

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -145,10 +145,15 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
             {myUSerInfo && this.blockCommunity()}
             {!myUSerInfo && (
               <div className="alert alert-info" role="alert">
-                <T i18nKey="community_not_logged_in_alert">#</T>
-                <code className="user-select-all">
-                  !{name}@{hostname(actor_id)}
-                </code>
+                <T
+                  i18nKey="community_not_logged_in_alert"
+                  interpolation={{
+                    community: name,
+                    instance: hostname(actor_id),
+                  }}
+                >
+                  #<code className="user-select-all">#</code>#
+                </T>
               </div>
             )}
           </div>

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -144,10 +144,10 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
             {myUSerInfo && this.blockCommunity()}
             {!myUSerInfo && (
               <div className="alert alert-info" role="alert">
-                {i18n.t("community_not_logged_in_alert", {
-                  community: name,
-                  instance: hostname(actor_id),
-                })}
+                {i18n.t("community_not_logged_in_alert")}
+                <code className="user-select-all">
+                  !{name}@{hostname(actor_id)}
+                </code>
               </div>
             )}
           </div>


### PR DESCRIPTION
A simple patch so that users can more easily subscribe to communities on other platforms.

Requires https://github.com/LemmyNet/lemmy-translations/pull/59.

Before:
![firefox_su0m4BnvqE](https://github.com/LemmyNet/lemmy-ui/assets/8181990/b1efcdaf-6b12-4c09-beef-48faf6bdb4ea)

After:
![firefox_Z17P2VMF0z](https://github.com/LemmyNet/lemmy-ui/assets/8181990/62b2eb20-6aff-41ad-a341-8776d8d1ca4d)