### PR TITLE
Prevent dragging zoom on mobile

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -421,7 +421,7 @@ async function createSsrHtml(root: string, isoData: IsoDataOptionalSite) {
   <!-- Required meta tags -->
   <meta name="Description" content="Lemmy">
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no">
   <link
      id="favicon"
      rel="shortcut icon"


### PR DESCRIPTION
This has been a personal pain point for me. I'll accidentally zoom slightly on mobile and the interface suddenly becomes much more difficult to navigate – forcing me to do a reverse pinch gesture. 😅

Likely resolves https://github.com/LemmyNet/lemmy-ui/issues/1220.