### PR TITLE
Go back to previous page after login

### DIFF
--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -244,9 +244,10 @@ export class Home extends Component<any, HomeState> {
   }
 
   async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+    if (!this.state.isIsomorphic || !this.isoData.routeData.length) {
       await Promise.all([this.fetchTrendingCommunities(), this.fetchData()]);
     }
+
     setupTippy();
   }
 
@@ -456,7 +457,7 @@ export class Home extends Component<any, HomeState> {
   }
 
   trendingCommunities(isMobile = false) {
-    switch (this.state.trendingCommunitiesRes.state) {
+    switch (this.state.trendingCommunitiesRes?.state) {
       case "loading":
         return (
           <h5>
@@ -573,7 +574,7 @@ export class Home extends Component<any, HomeState> {
     const siteRes = this.state.siteRes;
 
     if (dataType === DataType.Post) {
-      switch (this.state.postsRes.state) {
+      switch (this.state.postsRes?.state) {
         case "loading":
           return (
             <h5>

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -188,7 +188,7 @@ export class Login extends Component<any, State> {
 
           i.props.history.action === "PUSH"
             ? i.props.history.back()
-            : i.props.history.push("/");
+            : i.props.history.replace("/");
 
           break;
         }

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -186,7 +186,9 @@ export class Login extends Component<any, State> {
             UserService.Instance.myUserInfo = site.data.my_user;
           }
 
-          i.props.history.replace("/");
+          i.props.history.action === "PUSH"
+            ? i.props.history.back()
+            : i.props.history.push("/");
 
           break;
         }


### PR DESCRIPTION
Hey everybody! Proposal:

- Let's check `history.action` is `PUSH` (eg. there's *some* Lemmy page to go back to) and if so, use History API to go `back()` upon successful login. This will resolve https://github.com/LemmyNet/lemmy-ui/issues/1268.

Also included bugfix:

- Fix a bug, a pretty bad one, that became very noticeable while testing this feature. It prevents the user from navigating to `/` from `/login`, if `/login` is the first loaded page in that browser tab. I don't know if this is reported. Checking if `this.isoData.routeData.length` is falsey and some optional chaining fixes this right up. This only affects `>= 0.18` and seems to be related to the HTTP migration.

https://github.com/LemmyNet/lemmy-ui/assets/35377827/95386305-dd4e-4c27-886e-d984c536e015

Reproduction steps:

- Open Incognito window to `<localhost:1234>/login`
- Click on main title on navbar, or login, to navigate to `/`.
- Notice the page doesn't change and error occurs in console.
