### PR TITLE
Fix `CreatePost` infinite loading bug

### DIFF
--- a/src/shared/components/post/create-post.tsx
+++ b/src/shared/components/post/create-post.tsx
@@ -224,6 +224,10 @@ export class CreatePost extends Component<
     if (res.state === "success") {
       const postId = res.data.post_view.post.id;
       this.props.history.replace(`/post/${postId}`);
+    } else {
+      this.setState({
+        loading: false,
+      });
     }
   }
 


### PR DESCRIPTION
Hi Lemdevs!

In this PR:

- Fix a bug on `CreatePost` that causes the submit button to be stuck in a loading state if the `createPost` request fails.

<img width="1158" alt="Screenshot 2023-06-15 at 2 30 02 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/2fb79d8f-6634-4759-a250-27a7eac9d7db">

Resolves https://github.com/LemmyNet/lemmy-ui/issues/1289.

Thanks!