### PR TITLE
Prevent non-admins from accessing `/setup`

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -161,6 +161,10 @@ server.get("/*", async (req, res) => {
       }
 
       if (site) {
+        if (path === "/setup" && !site.my_user?.local_user_view.person.admin) {
+          return res.redirect("/");
+        }
+
         const initialFetchReq: InitialFetchRequest = {
           client,
           auth,

--- a/src/shared/components/home/setup.tsx
+++ b/src/shared/components/home/setup.tsx
@@ -9,7 +9,7 @@ import {
 import { i18n } from "../../i18next";
 import { UserService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
-import { amAdmin, fetchThemeList, setIsoData } from "../../utils";
+import { fetchThemeList, setIsoData } from "../../utils";
 import { Spinner } from "../common/icon";
 import { SiteForm } from "./site-form";
 
@@ -51,10 +51,6 @@ export class Setup extends Component<any, State> {
   }
 
   async componentDidMount() {
-    if (!amAdmin()) {
-      return this.props.history.replace("/");
-    }
-
     this.setState({ themeList: await fetchThemeList() });
   }
 

--- a/src/shared/components/home/setup.tsx
+++ b/src/shared/components/home/setup.tsx
@@ -77,7 +77,6 @@ export class Setup extends Component<any, State> {
                 onSaveSite={this.handleCreateSite}
                 siteRes={this.state.siteRes}
                 themeList={this.state.themeList}
-                loading={false}
               />
             )}
           </div>

--- a/src/shared/components/home/setup.tsx
+++ b/src/shared/components/home/setup.tsx
@@ -9,7 +9,7 @@ import {
 import { i18n } from "../../i18next";
 import { UserService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
-import { fetchThemeList, setIsoData } from "../../utils";
+import { amAdmin, fetchThemeList, setIsoData } from "../../utils";
 import { Spinner } from "../common/icon";
 import { SiteForm } from "./site-form";
 
@@ -51,6 +51,10 @@ export class Setup extends Component<any, State> {
   }
 
   async componentDidMount() {
+    if (!amAdmin()) {
+      return this.props.history.replace("/");
+    }
+
     this.setState({ themeList: await fetchThemeList() });
   }
 
@@ -73,6 +77,7 @@ export class Setup extends Component<any, State> {
                 onSaveSite={this.handleCreateSite}
                 siteRes={this.state.siteRes}
                 themeList={this.state.themeList}
+                loading={false}
               />
             )}
           </div>

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1469,7 +1469,7 @@ export function getQueryString<T extends Record<string, string | undefined>>(
 }
 
 export function isAuthPath(pathname: string) {
-  return /create_.*|inbox|settings|admin|reports|registration_applications/g.test(
+  return /create_.*|inbox|settings|setup|admin|reports|registration_applications/g.test(
     pathname
   );
 }


### PR DESCRIPTION
Hey Lemdevs!

In this PR:

- Prevent non-admins from accessing `/setup`. This isn't much of a big concern, but non-admins really have no business seeing this form on an established site, eg: https://lemmy.ml/setup
- Add `/setup` to list of auth-required routes

Resolves #897.

Thanks so much!