### PR TITLE
hardcoded node version due to bug "Text file busy" error introduced in node 20.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine as builder
+FROM node:20.2-alpine as builder
 RUN apk update && apk add curl yarn python3 build-base gcc wget git --no-cache
 RUN curl -sf https://gobinaries.com/tj/node-prune | sh
 

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine as builder
+FROM node:20.2-alpine as builder
 RUN apk update && apk add curl yarn python3 build-base gcc wget git --no-cache
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
This is an error I occured during building my own lemm-ui docker container from `dev.docker` due to not being able to use the ARM version right now (this is a separated issue, see https://github.com/LemmyNet/lemmy/issues/3102).

The error was:
```
#0 383.3 Arguments: 
#0 383.3 Directory: /usr/src/app/node_modules/inferno
#0 383.3 Output:
#0 383.3 env: can't execute 'node': Text file busy
#0 383.3 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
failed to solve: executor failed running [/bin/sh -c yarn --prefer-offline --pure-lockfile]: exit code: 126
```

To fix this error, we have to downgrade to Node 20.2 rather than 20.3 (see: https://forums.docker.com/t/getting-error-when-running-container-env-cant-execute-node-text-file-busy/136409). This PR is also helpful as it keeps docker builds reproducable rather than automatically downloading the latest image (risking bugs with newer versions such as this one in the process).