### PR TITLE
fix: Vertically align icons in post listing

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -631,7 +631,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const post = this.postView.post;
 
     return (
-      <div className="d-flex justify-content-start flex-wrap text-muted font-weight-bold mb-1">
+      <div className="d-flex align-items-center justify-content-start flex-wrap text-muted font-weight-bold mb-1">
         {this.commentsButton}
         {canShare() && (
           <button


### PR DESCRIPTION
This vertically aligns the icons at the bottom of a post listing.

## Before

<img width="635" alt="Screenshot 2023-06-16 at 9 48 54 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/24ab701a-be49-4828-9ec7-5c0c13db55c2">


## After

<img width="634" alt="Screenshot 2023-06-16 at 9 49 50 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/6031f3a5-35a2-40f9-8c61-88a98848a1f4">
