### PR TITLE
fix: Remove inline styles and use Bootstrap classes

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -146,18 +146,8 @@ export class MarkdownTextArea extends Component<
         />
         <div className="form-group row">
           <div className="col-12">
-            <div
-              className="rounded bg-light overflow-hidden"
-              style={{
-                border: "1px solid var(--medium-light)",
-              }}
-            >
-              <div
-                className="d-flex flex-wrap"
-                style={{
-                  "border-bottom": "1px solid var(--medium-light)",
-                }}
-              >
+            <div className="rounded bg-light border border-light">
+              <div className="d-flex flex-wrap border-bottom border-light">
                 {this.getFormatButton("bold", this.handleInsertBold)}
                 {this.getFormatButton("italic", this.handleInsertItalic)}
                 {this.getFormatButton("link", this.handleInsertLink)}
@@ -219,9 +209,12 @@ export class MarkdownTextArea extends Component<
               <div>
                 <textarea
                   id={this.id}
-                  className={classNames("form-control border-0 rounded-0", {
-                    "d-none": this.state.previewMode,
-                  })}
+                  className={classNames(
+                    "form-control border-0 rounded-bottom",
+                    {
+                      "d-none": this.state.previewMode,
+                    }
+                  )}
                   value={this.state.content}
                   onInput={linkEvent(this, this.handleContentChange)}
                   onPaste={linkEvent(this, this.handleImageUploadPaste)}


### PR DESCRIPTION
Per conversation #863, definitely should not be using inline `style` attributes, even though the Bootstrap colors don't quite work here. Should be fixed on the theming side, not by brute-forcing inline styles.