### PR TITLE
Revert "fix: Sass files don't need to refer to full node_modules path"

### DIFF
--- a/src/assets/css/themes/darkly-red.scss
+++ b/src/assets/css/themes/darkly-red.scss
@@ -1,2 +1,2 @@
 @import "variables.darkly-red";
-@import "bootstrap-v4/scss/bootstrap";
+@import "../../../../node_modules/bootstrap-v4/scss/bootstrap";

--- a/src/assets/css/themes/darkly.scss
+++ b/src/assets/css/themes/darkly.scss
@@ -1,2 +1,2 @@
 @import "variables.darkly";
-@import "bootstrap-v4/scss/bootstrap";
+@import "../../../../node_modules/bootstrap-v4/scss/bootstrap";

--- a/src/assets/css/themes/litely-red.scss
+++ b/src/assets/css/themes/litely-red.scss
@@ -1,2 +1,2 @@
 @import "variables.litely-red";
-@import "bootstrap-v4/scss/bootstrap";
+@import "../../../../node_modules/bootstrap-v4/scss/bootstrap";

--- a/src/assets/css/themes/litely.scss
+++ b/src/assets/css/themes/litely.scss
@@ -1,2 +1,2 @@
 @import "variables.litely";
-@import "bootstrap-v4/scss/bootstrap";
+@import "../../../../node_modules/bootstrap-v4/scss/bootstrap";

--- a/src/shared/components/app/styles.scss
+++ b/src/shared/components/app/styles.scss
@@ -1,6 +1,6 @@
 // Custom css
-@import "tributejs/dist/tribute.css";
-@import "toastify-js/src/toastify.css";
-@import "tippy.js/dist/tippy.css";
-@import "bootstrap/dist/css/bootstrap-utilities.min.css";
+@import "../../../../node_modules/tributejs/dist/tribute.css";
+@import "../../../../node_modules/toastify-js/src/toastify.css";
+@import "../../../../node_modules/tippy.js/dist/tippy.css";
+@import "../../../../node_modules/bootstrap/dist/css/bootstrap-utilities.min.css";
 @import "../../../assets/css/main.css";


### PR DESCRIPTION
Revert #1341