### PR TITLE
fix: Fix rounded top corners in markdown textarea

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -210,7 +210,7 @@ export class MarkdownTextArea extends Component<
                 <textarea
                   id={this.id}
                   className={classNames(
-                    "form-control border-0 rounded-bottom",
+                    "form-control border-0 rounded-top-0 rounded-bottom",
                     {
                       "d-none": this.state.previewMode,
                     }


### PR DESCRIPTION
These corners shouldn't be rounded; this fixes that.

<img width="272" alt="Screenshot 2023-06-17 at 1 43 31 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/72d350fb-6479-48c2-885b-e8667fe44c60">
