### PR TITLE
Feature add hours as sorting options frontend

### DIFF
--- a/src/shared/components/common/sort-select.tsx
+++ b/src/shared/components/common/sort-select.tsx
@@ -66,6 +66,9 @@ export class SortSelect extends Component<SortSelectProps, SortSelectState> {
           <option disabled aria-hidden="true">
             ─────
           </option>
+          <option value={"TopHour"}>{i18n.t("top_hour")}</option>
+          <option value={"TopSixHour"}>{i18n.t("top_six_hours")}</option>
+          <option value={"TopTwelveHour"}>{i18n.t("top_twelve_hours")}</option>
           <option value={"TopDay"}>{i18n.t("top_day")}</option>
           <option value={"TopWeek"}>{i18n.t("top_week")}</option>
           <option value={"TopMonth"}>{i18n.t("top_month")}</option>

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -986,6 +986,9 @@ export function commentsToFlatNodes(comments: CommentView[]): CommentNodeI[] {
 export function convertCommentSortType(sort: SortType): CommentSortType {
   if (
     sort == "TopAll" ||
+    sort ==  "TopHour" ||
+    sort ==  "TopSixHour" ||
+    sort ==  "TopTwelveHour" ||
     sort == "TopDay" ||
     sort == "TopWeek" ||
     sort == "TopMonth" ||


### PR DESCRIPTION
This feature adds the possiblity to sort by Top Hour, Top Six Hours and Top Twelve Hours.

---

**Related issue:**
https://github.com/LemmyNet/lemmy/issues/3049

---

**This PR is part of a 3 PRs:**

Back End
https://github.com/LemmyNet/lemmy/pull/3161

Translation
https://github.com/LemmyNet/lemmy-translations/pull/63

Front End
https://github.com/LemmyNet/lemmy-ui/pull/1345