### PR TITLE
feat: Move advanced post menu into dropdown

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -873,7 +873,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get reportButton() {
     return (
       <button
-        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
+        className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleShowReportDialog)}
         data-tippy-content={i18n.t("show_report_dialog")}
         aria-label={i18n.t("show_report_dialog")}
@@ -886,7 +886,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get blockButton() {
     return (
       <button
-        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
+        className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleBlockPersonClick)}
         data-tippy-content={i18n.t("block_user")}
         aria-label={i18n.t("block_user")}
@@ -899,7 +899,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get editButton() {
     return (
       <button
-        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
+        className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleEditClick)}
         aria-label={i18n.t("edit")}
       >
@@ -914,7 +914,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const label = !deleted ? i18n.t("delete") : i18n.t("restore");
     return (
       <button
-        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
+        className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleDeleteClick)}
         aria-label={label}
       >
@@ -956,7 +956,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const label = locked ? i18n.t("unlock") : i18n.t("lock");
     return (
       <button
-        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
+        className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleModLock)}
         aria-label={label}
       >
@@ -990,7 +990,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <>
         <li>
           <button
-            className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
+            className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
             onClick={linkEvent(this, this.handleModFeaturePostCommunity)}
             data-tippy-content={labelCommunity}
             aria-label={labelCommunity}
@@ -1014,7 +1014,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         <li>
           {amAdmin() && (
             <button
-              className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
+              className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
               onClick={linkEvent(this, this.handleModFeaturePostLocal)}
               data-tippy-content={labelLocal}
               aria-label={labelLocal}
@@ -1044,7 +1044,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const removed = this.postView.post.removed;
     return (
       <button
-        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
+        className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(
           this,
           !removed ? this.handleModRemoveShow : this.handleModRemoveSubmit

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -659,6 +659,17 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     );
   }
 
+  get hasAdvancedButtons() {
+    return (
+      this.myPost ||
+      (this.showBody && this.postView.post.body) ||
+      amMod(this.props.moderators) ||
+      amAdmin() ||
+      this.canMod_ ||
+      this.canAdmin_
+    );
+  }
+
   postActions(mobile = false) {
     // Possible enhancement: Priority+ pattern instead of just hard coding which get hidden behind the show more button.
     // Possible enhancement: Make each button a component.
@@ -667,37 +678,52 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <>
         {this.saveButton}
         {this.crossPostButton}
-        {mobile && this.showMoreButton}
-        {(!mobile || this.state.showAdvanced) && (
-          <>
-            {!this.myPost && (
-              <>
-                {this.reportButton}
-                {this.blockButton}
-              </>
-            )}
-            {this.myPost && (this.showBody || this.state.showAdvanced) && (
-              <>
-                {this.editButton}
-                {this.deleteButton}
-              </>
-            )}
-          </>
+
+        {this.showBody && post_view.post.body && this.viewSourceButton}
+
+        {this.hasAdvancedButtons && (
+          <div className="dropdown">
+            <button
+              className="btn btn-link btn-animate text-muted py-0 dropdown-toggle"
+              onClick={linkEvent(this, this.handleShowAdvanced)}
+              data-tippy-content={i18n.t("more")}
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+              aria-label={i18n.t("more")}
+            >
+              <Icon icon="more-vertical" inline />
+            </button>
+
+            <ul className="dropdown-menu">
+              {!this.myPost ? (
+                <>
+                  <li>{this.reportButton}</li>
+                  <li>{this.blockButton}</li>
+                </>
+              ) : (
+                <>
+                  <li>{this.editButton}</li>
+                  <li>{this.deleteButton}</li>
+                </>
+              )}
+
+              {/* Any mod can do these, not limited to hierarchy*/}
+              {(amMod(this.props.moderators) || amAdmin()) && (
+                <>
+                  <li>
+                    <hr className="dropdown-divider" />
+                  </li>
+                  <li>{this.lockButton}</li>
+                  {this.featureButtons}
+                </>
+              )}
+
+              {(this.canMod_ || this.canAdmin_) && (
+                <li>{this.modRemoveButton}</li>
+              )}
+            </ul>
+          </div>
         )}
-        {this.state.showAdvanced && (
-          <>
-            {this.showBody && post_view.post.body && this.viewSourceButton}
-            {/* Any mod can do these, not limited to hierarchy*/}
-            {(amMod(this.props.moderators) || amAdmin()) && (
-              <>
-                {this.lockButton}
-                {this.featureButton}
-              </>
-            )}
-            {(this.canMod_ || this.canAdmin_) && <>{this.modRemoveButton}</>}
-          </>
-        )}
-        {!mobile && this.showMoreButton}
       </>
     );
   }
@@ -846,7 +872,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get reportButton() {
     return (
       <button
-        className="btn btn-link btn-animate text-muted py-0"
+        className="btn btn-link btn-animate text-muted py-0 dropdown-item"
         onClick={linkEvent(this, this.handleShowReportDialog)}
         data-tippy-content={i18n.t("show_report_dialog")}
         aria-label={i18n.t("show_report_dialog")}
@@ -859,7 +885,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get blockButton() {
     return (
       <button
-        className="btn btn-link btn-animate text-muted py-0"
+        className="btn btn-link btn-animate text-muted py-0 dropdown-item"
         onClick={linkEvent(this, this.handleBlockPersonClick)}
         data-tippy-content={i18n.t("block_user")}
         aria-label={i18n.t("block_user")}
@@ -872,12 +898,13 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get editButton() {
     return (
       <button
-        className="btn btn-link btn-animate text-muted py-0"
+        className="btn btn-link text-muted dropdown-item"
         onClick={linkEvent(this, this.handleEditClick)}
         data-tippy-content={i18n.t("edit")}
         aria-label={i18n.t("edit")}
       >
-        <Icon icon="edit" inline />
+        <Icon classes="mr-1" icon="edit" inline />
+        {i18n.t("edit")}
       </button>
     );
   }
@@ -887,7 +914,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const label = !deleted ? i18n.t("delete") : i18n.t("restore");
     return (
       <button
-        className="btn btn-link btn-animate text-muted py-0"
+        className="btn btn-link text-muted dropdown-item"
         onClick={linkEvent(this, this.handleDeleteClick)}
         data-tippy-content={label}
         aria-label={label}
@@ -895,25 +922,15 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         {this.state.deleteLoading ? (
           <Spinner />
         ) : (
-          <Icon
-            icon="trash"
-            classes={classNames({ "text-danger": deleted })}
-            inline
-          />
+          <>
+            <Icon
+              icon="trash"
+              classes={classNames("mr-1", { "text-danger": deleted })}
+              inline
+            />
+            {i18n.t("delete")}
+          </>
         )}
-      </button>
-    );
-  }
-
-  get showMoreButton() {
-    return (
-      <button
-        className="btn btn-link btn-animate text-muted py-0"
-        onClick={linkEvent(this, this.handleShowAdvanced)}
-        data-tippy-content={i18n.t("more")}
-        aria-label={i18n.t("more")}
-      >
-        <Icon icon="more-vertical" inline />
       </button>
     );
   }
@@ -940,7 +957,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const label = locked ? i18n.t("unlock") : i18n.t("lock");
     return (
       <button
-        className="btn btn-link btn-animate text-muted py-0"
+        className="btn btn-link text-muted dropdown-item"
         onClick={linkEvent(this, this.handleModLock)}
         data-tippy-content={label}
         aria-label={label}
@@ -948,17 +965,20 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         {this.state.lockLoading ? (
           <Spinner />
         ) : (
-          <Icon
-            icon="lock"
-            classes={classNames({ "text-danger": locked })}
-            inline
-          />
+          <>
+            <Icon
+              icon="lock"
+              classes={classNames("mr-1", { "text-danger": locked })}
+              inline
+            />
+            {i18n.t("lock")}
+          </>
         )}
       </button>
     );
   }
 
-  get featureButton() {
+  get featureButtons() {
     const featuredCommunity = this.postView.post.featured_community;
     const labelCommunity = featuredCommunity
       ? i18n.t("unfeature_from_community")
@@ -969,48 +989,56 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       ? i18n.t("unfeature_from_local")
       : i18n.t("feature_in_local");
     return (
-      <span>
-        <button
-          className="btn btn-link btn-animate text-muted py-0 pl-0"
-          onClick={linkEvent(this, this.handleModFeaturePostCommunity)}
-          data-tippy-content={labelCommunity}
-          aria-label={labelCommunity}
-        >
-          {this.state.featureCommunityLoading ? (
-            <Spinner />
-          ) : (
-            <span>
-              <Icon
-                icon="pin"
-                classes={classNames({ "text-success": featuredCommunity })}
-                inline
-              />
-              {i18n.t("community")}
-            </span>
-          )}
-        </button>
-        {amAdmin() && (
+      <>
+        <li>
           <button
-            className="btn btn-link btn-animate text-muted py-0"
-            onClick={linkEvent(this, this.handleModFeaturePostLocal)}
-            data-tippy-content={labelLocal}
-            aria-label={labelLocal}
+            className="btn btn-link text-muted dropdown-item"
+            onClick={linkEvent(this, this.handleModFeaturePostCommunity)}
+            data-tippy-content={labelCommunity}
+            aria-label={labelCommunity}
           >
-            {this.state.featureLocalLoading ? (
+            {this.state.featureCommunityLoading ? (
               <Spinner />
             ) : (
-              <span>
+              <>
                 <Icon
                   icon="pin"
-                  classes={classNames({ "text-success": featuredLocal })}
+                  classes={classNames("mr-1", {
+                    "text-success": featuredCommunity,
+                  })}
                   inline
                 />
-                {i18n.t("local")}
-              </span>
+                {i18n.t("community")}
+              </>
             )}
           </button>
-        )}
-      </span>
+        </li>
+        <li>
+          {amAdmin() && (
+            <button
+              className="btn btn-link text-muted dropdown-item"
+              onClick={linkEvent(this, this.handleModFeaturePostLocal)}
+              data-tippy-content={labelLocal}
+              aria-label={labelLocal}
+            >
+              {this.state.featureLocalLoading ? (
+                <Spinner />
+              ) : (
+                <>
+                  <Icon
+                    icon="pin"
+                    classes={classNames("mr-1", {
+                      "text-success": featuredLocal,
+                    })}
+                    inline
+                  />
+                  {i18n.t("local")}
+                </>
+              )}
+            </button>
+          )}
+        </li>
+      </>
     );
   }
 
@@ -1018,7 +1046,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const removed = this.postView.post.removed;
     return (
       <button
-        className="btn btn-link btn-animate text-muted py-0"
+        className="btn btn-link text-muted dropdown-item"
         onClick={linkEvent(
           this,
           !removed ? this.handleModRemoveShow : this.handleModRemoveSubmit

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -689,12 +689,13 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               data-tippy-content={i18n.t("more")}
               data-bs-toggle="dropdown"
               aria-expanded="false"
+              aria-controls="advancedButtonsDropdown"
               aria-label={i18n.t("more")}
             >
               <Icon icon="more-vertical" inline />
             </button>
 
-            <ul className="dropdown-menu">
+            <ul className="dropdown-menu" id="advancedButtonsDropdown">
               {!this.myPost ? (
                 <>
                   <li>{this.reportButton}</li>

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -873,7 +873,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get reportButton() {
     return (
       <button
-        className="btn btn-link btn-animate text-muted py-0 dropdown-item"
+        className="btn btn-link btn-animate d-flex align-items-center rounded-0 py-0 dropdown-item"
         onClick={linkEvent(this, this.handleShowReportDialog)}
         data-tippy-content={i18n.t("show_report_dialog")}
         aria-label={i18n.t("show_report_dialog")}
@@ -886,7 +886,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get blockButton() {
     return (
       <button
-        className="btn btn-link btn-animate text-muted py-0 dropdown-item"
+        className="btn btn-link btn-animate d-flex align-items-center rounded-0 py-0 dropdown-item"
         onClick={linkEvent(this, this.handleBlockPersonClick)}
         data-tippy-content={i18n.t("block_user")}
         aria-label={i18n.t("block_user")}
@@ -899,7 +899,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get editButton() {
     return (
       <button
-        className="btn btn-link text-muted dropdown-item"
+        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleEditClick)}
         aria-label={i18n.t("edit")}
       >
@@ -914,7 +914,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const label = !deleted ? i18n.t("delete") : i18n.t("restore");
     return (
       <button
-        className="btn btn-link text-muted dropdown-item"
+        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleDeleteClick)}
         aria-label={label}
       >
@@ -956,7 +956,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const label = locked ? i18n.t("unlock") : i18n.t("lock");
     return (
       <button
-        className="btn btn-link text-muted dropdown-item"
+        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleModLock)}
         aria-label={label}
       >
@@ -990,7 +990,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <>
         <li>
           <button
-            className="btn btn-link text-muted dropdown-item"
+            className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
             onClick={linkEvent(this, this.handleModFeaturePostCommunity)}
             data-tippy-content={labelCommunity}
             aria-label={labelCommunity}
@@ -1014,7 +1014,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         <li>
           {amAdmin() && (
             <button
-              className="btn btn-link text-muted dropdown-item"
+              className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
               onClick={linkEvent(this, this.handleModFeaturePostLocal)}
               data-tippy-content={labelLocal}
               aria-label={labelLocal}
@@ -1044,7 +1044,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const removed = this.postView.post.removed;
     return (
       <button
-        className="btn btn-link text-muted dropdown-item"
+        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(
           this,
           !removed ? this.handleModRemoveShow : this.handleModRemoveSubmit

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -873,7 +873,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get reportButton() {
     return (
       <button
-        className="btn btn-link btn-animate d-flex align-items-center rounded-0 py-0 dropdown-item"
+        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleShowReportDialog)}
         data-tippy-content={i18n.t("show_report_dialog")}
         aria-label={i18n.t("show_report_dialog")}
@@ -886,7 +886,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get blockButton() {
     return (
       <button
-        className="btn btn-link btn-animate d-flex align-items-center rounded-0 py-0 dropdown-item"
+        className="btn btn-link d-flex align-items-center rounded-0 dropdown-item"
         onClick={linkEvent(this, this.handleBlockPersonClick)}
         data-tippy-content={i18n.t("block_user")}
         aria-label={i18n.t("block_user")}

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -654,7 +654,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         {mobile && !this.props.viewOnly && this.mobileVotes}
         {UserService.Instance.myUserInfo &&
           !this.props.viewOnly &&
-          this.postActions(mobile)}
+          this.postActions()}
       </div>
     );
   }
@@ -670,7 +670,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     );
   }
 
-  postActions(mobile = false) {
+  postActions() {
     // Possible enhancement: Priority+ pattern instead of just hard coding which get hidden behind the show more button.
     // Possible enhancement: Make each button a component.
     const post_view = this.postView;

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -900,7 +900,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <button
         className="btn btn-link text-muted dropdown-item"
         onClick={linkEvent(this, this.handleEditClick)}
-        data-tippy-content={i18n.t("edit")}
         aria-label={i18n.t("edit")}
       >
         <Icon classes="mr-1" icon="edit" inline />
@@ -916,7 +915,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <button
         className="btn btn-link text-muted dropdown-item"
         onClick={linkEvent(this, this.handleDeleteClick)}
-        data-tippy-content={label}
         aria-label={label}
       >
         {this.state.deleteLoading ? (
@@ -928,7 +926,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               classes={classNames("mr-1", { "text-danger": deleted })}
               inline
             />
-            {i18n.t("delete")}
+            {label}
           </>
         )}
       </button>
@@ -959,7 +957,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <button
         className="btn btn-link text-muted dropdown-item"
         onClick={linkEvent(this, this.handleModLock)}
-        data-tippy-content={label}
         aria-label={label}
       >
         {this.state.lockLoading ? (
@@ -971,7 +968,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               classes={classNames("mr-1", { "text-danger": locked })}
               inline
             />
-            {i18n.t("lock")}
+            {label}
           </>
         )}
       </button>


### PR DESCRIPTION
Rather than having all those "advanced"/"more" buttons for a post in a horizontally-expanding row (which causes content to move around and causes the row to wrap, making the context of the buttons confusing), I've here tucked them away into a dropdown menu.

## Before
<img width="349" alt="Screenshot 2023-06-17 at 6 05 25 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/e6ce729f-006d-45f3-b140-3f63b99dd5ea">
<img width="979" alt="Screenshot 2023-06-17 at 6 05 17 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/7669be59-32f9-4c96-b2cb-96a410a8e6d4">




## After

<img width="330" alt="Screenshot 2023-06-17 at 6 03 33 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/e289b5c9-97d8-4eec-931f-3d5f9fe63326">
<img width="765" alt="Screenshot 2023-06-17 at 6 02 35 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/3082ea21-00c9-4664-a2cf-55914a5bac79">
