### PR TITLE
feat(post): Move post domain beneath post title

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -84,10 +84,6 @@
   margin-top: -6.5px;
 }
 
-.post-title {
-  line-height: 1;
-}
-
 .post-title a:visited {
   color: var(--gray) !important;
 }

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -367,8 +367,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
 
   createdLine() {
     const post_view = this.postView;
-    const url = post_view.post.url;
-    const body = post_view.post.body;
     return (
       <ul className="list-inline mb-1 text-muted small">
         <li className="list-inline-item">
@@ -402,21 +400,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           </span>
         )}
         <li className="list-inline-item">•</li>
-        {url && !(hostname(url) === getExternalHost()) && (
-          <>
-            <li className="list-inline-item">
-              <a
-                className="text-muted font-italic"
-                href={url}
-                title={url}
-                rel={relTags}
-              >
-                {hostname(url)}
-              </a>
-            </li>
-            <li className="list-inline-item">•</li>
-          </>
-        )}
         <li className="list-inline-item">
           <span>
             <MomentTime
@@ -425,21 +408,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             />
           </span>
         </li>
-        {body && (
-          <>
-            <li className="list-inline-item">•</li>
-            <li className="list-inline-item">
-              <button
-                className="text-muted btn btn-sm btn-link p-0"
-                data-tippy-content={mdNoImages.render(body)}
-                data-tippy-allowHtml={true}
-                onClick={linkEvent(this, this.handleShowBody)}
-              >
-                <Icon icon="book-open" classes="icon-inline mr-1" />
-              </button>
-            </li>
-          </>
-        )}
       </ul>
     );
   }
@@ -516,10 +484,11 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   postTitleLine() {
     const post = this.postView.post;
     const url = post.url;
+    const body = post.body;
 
     return (
-      <div className="post-title overflow-hidden">
-        <h5>
+      <div className="lh-1 overflow-hidden">
+        <h5 className="post-title m-0">
           {url ? (
             this.props.showBody ? (
               <a
@@ -601,6 +570,31 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             </small>
           )}
         </h5>
+        <p className="d-flex text-muted align-items-center gap-1 small">
+          {url && !(hostname(url) === getExternalHost()) && (
+            <a
+              className="text-muted font-italic"
+              href={url}
+              title={url}
+              rel={relTags}
+            >
+              {hostname(url)}
+            </a>
+          )}
+          {body && (
+            <>
+              <span>•</span>
+              <button
+                className="text-muted btn btn-sm btn-link p-0"
+                data-tippy-content={mdNoImages.render(body)}
+                data-tippy-allowHtml={true}
+                onClick={linkEvent(this, this.handleShowBody)}
+              >
+                <Icon icon="book-open" classes="icon-inline mr-1" />
+              </button>
+            </>
+          )}
+        </p>
       </div>
     );
   }

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -368,7 +368,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   createdLine() {
     const post_view = this.postView;
     return (
-      <ul className="list-inline mb-1 text-muted small">
+      <ul className="list-inline mb-1 text-muted small mt-2">
         <li className="list-inline-item">
           <PersonListing person={post_view.creator} />
 
@@ -573,7 +573,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const url = post.url;
 
     return (
-      <p className="d-flex text-muted align-items-center gap-1 small">
+      <p className="d-flex text-muted align-items-center gap-1 small m-0">
         {url && !(hostname(url) === getExternalHost()) && (
           <a
             className="text-muted font-italic"

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -484,7 +484,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   postTitleLine() {
     const post = this.postView.post;
     const url = post.url;
-    const body = post.body;
 
     return (
       <>
@@ -564,32 +563,28 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             </small>
           )}
         </div>
-        <p className="d-flex text-muted align-items-center gap-1 small">
-          {url && !(hostname(url) === getExternalHost()) && (
-            <a
-              className="text-muted font-italic"
-              href={url}
-              title={url}
-              rel={relTags}
-            >
-              {hostname(url)}
-            </a>
-          )}
-          {body && (
-            <>
-              <span>•</span>
-              <button
-                className="text-muted btn btn-sm btn-link p-0"
-                data-tippy-content={mdNoImages.render(body)}
-                data-tippy-allowHtml={true}
-                onClick={linkEvent(this, this.handleShowBody)}
-              >
-                <Icon icon="book-open" classes="icon-inline mr-1" />
-              </button>
-            </>
-          )}
-        </p>
+        {url && this.urlLine()}
       </>
+    );
+  }
+
+  urlLine() {
+    const post = this.postView.post;
+    const url = post.url;
+
+    return (
+      <p className="d-flex text-muted align-items-center gap-1 small">
+        {url && !(hostname(url) === getExternalHost()) && (
+          <a
+            className="text-muted font-italic"
+            href={url}
+            title={url}
+            rel={relTags}
+          >
+            {hostname(url)}
+          </a>
+        )}
+      </p>
     );
   }
 
@@ -658,14 +653,44 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     );
   }
 
+  showPreviewButton() {
+    const post_view = this.postView;
+    const body = post_view.post.body;
+
+    return (
+      <button
+        className="btn btn-link btn-animate text-muted py-0"
+        data-tippy-content={body && mdNoImages.render(body)}
+        data-tippy-allowHtml={true}
+        onClick={linkEvent(this, this.handleShowBody)}
+      >
+        <Icon
+          icon="book-open"
+          classes={classNames("icon-inline mr-1", {
+            "text-success": this.state.showBody,
+          })}
+        />
+      </button>
+    );
+  }
+
   postActions() {
     // Possible enhancement: Priority+ pattern instead of just hard coding which get hidden behind the show more button.
     // Possible enhancement: Make each button a component.
     const post_view = this.postView;
+    const post = post_view.post;
+
     return (
       <>
         {this.saveButton}
         {this.crossPostButton}
+
+        {/**
+         * If there is a URL, or if the post has a body and we were told not to
+         * show the body, show the MetadataCard/body toggle.
+         */}
+        {(post.url || (post.body && !this.props.showBody)) &&
+          this.showPreviewButton()}
 
         {this.showBody && post_view.post.body && this.viewSourceButton}
 


### PR DESCRIPTION
Some design work here, trying to tidy up all the metadata grouped together in the post details.

I've moved the link domain and the "expand" button to beneath the post title in small text. I think this makes it easier to parse the information.


## Before

<img width="783" alt="Screenshot 2023-06-18 at 10 37 24 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/95231b9e-fe70-494d-bf58-c9eea4c784b9">
<img width="416" alt="Screenshot 2023-06-18 at 10 37 19 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/8c7a54ea-0b80-46e2-ad88-78bda656458d">



## After
<img width="766" alt="Screenshot 2023-06-18 at 2 33 04 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/46891abc-a478-4124-9755-9b6f52edc157">
<img width="412" alt="Screenshot 2023-06-18 at 2 33 12 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/1b9a8985-33a9-404e-b6c9-37215743fef1">



