### PR TITLE
feat: provide a reason when blocking instances

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,14 @@
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/explicit-module-boundary-types": 0,
     "@typescript-eslint/no-empty-function": 0,
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
     "arrow-body-style": 0,
     "curly": 0,
     "eol-last": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ src/shared/translations
 
 stats.json
 
+#files generated when using yalc to develop against local changes to http client
+.yalc
+yalc.lock

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -2,6 +2,7 @@ import { setIsoData } from "@utils/app";
 import { RouteDataResponse } from "@utils/types";
 import { Component } from "inferno";
 import {
+  BlockedInstance,
   GetFederatedInstancesResponse,
   GetSiteResponse,
   Instance,
@@ -122,34 +123,38 @@ export class Instances extends Component<any, InstancesState> {
     );
   }
 
-  itemList(items: Instance[]) {
-    return items.length > 0 ? (
-      <div className="table-responsive">
-        <table id="instances_table" className="table table-sm table-hover">
-          <thead className="pointer">
-            <tr>
-              <th>{I18NextService.i18n.t("name")}</th>
-              <th>{I18NextService.i18n.t("software")}</th>
-              <th>{I18NextService.i18n.t("version")}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map(i => (
-              <tr key={i.domain}>
-                <td>
-                  <a href={`https://${i.domain}`} rel={relTags}>
-                    {i.domain}
-                  </a>
-                </td>
-                <td>{i.software}</td>
-                <td>{i.version}</td>
+  itemList(items: (Instance | BlockedInstance)[]) {
+    if (items.length > 0) {
+      const reasonProvided = items.filter(i => "reason" in i).length > 0;
+      return (
+        <div className="table-responsive">
+          <table id="instances_table" className="table table-sm table-hover">
+            <thead className="pointer">
+              <tr>
+                <th>{I18NextService.i18n.t("name")}</th>
+                <th>{I18NextService.i18n.t("software")}</th>
+                <th>{I18NextService.i18n.t("version")}</th>
+                {reasonProvided && <th>{I18NextService.i18n.t("reason")}</th>}
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    ) : (
-      <div>{I18NextService.i18n.t("none_found")}</div>
-    );
+            </thead>
+            <tbody>
+              {items.map(i => (
+                <tr key={i.domain}>
+                  <td>
+                    <a href={`https://${i.domain}`} rel={relTags}>
+                      {i.domain}
+                    </a>
+                  </td>
+                  <td>{i.software}</td>
+                  <td>{i.version}</td>
+                  {reasonProvided && <td>{(i as BlockedInstance).reason}</td>}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+    return <div>{I18NextService.i18n.t("none_found")}</div>;
   }
 }


### PR DESCRIPTION
This allows:
- admins to add a reason when blocking an instance;
- users to see reasons (when provided) at `/instances`

Companion MR to: https://github.com/LemmyNet/lemmy/pull/3168

Should resolve issue: https://github.com/LemmyNet/lemmy/issues/1947

New blocklist in admin interface:
<img src="https://github.com/LemmyNet/lemmy-ui/assets/28776554/108ae470-3640-4a68-922a-d6af0233e9b2" data-canonical-src="https://github.com/LemmyNet/lemmy-ui/assets/28776554/108ae470-3640-4a68-922a-d6af0233e9b2" width="200" />

New column in `/instances` table:
<img src="https://github.com/LemmyNet/lemmy-ui/assets/28776554/9092d21a-62f6-4488-8b02-0bc56517eb7b" data-canonical-src="https://github.com/LemmyNet/lemmy-ui/assets/28776554/9092d21a-62f6-4488-8b02-0bc56517eb7b" width="200" />

Notes:
- I have left in temporary types to allow everything to compile, but presumably when the backend MR is merged this can just consume the published types
- I configured the `no-unused-vars` rule to ignore variables starting with an underscore, so that it's possible to do something like discards (https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards), happy to remove that if it's not wanted though!
- Previously the allowlist/blocklist were rendered generically on the admin page (since they were doing the exact same thing), I couldn't see a nice way to keep this generic handling so explicitly separated them. Would be happy to hear an alternative though!