### PR TITLE
WIP: test(css): Proof of concept for possible approach to using custom CSS class names

### DIFF
--- a/src/assets/css/components/paginator.scss
+++ b/src/assets/css/components/paginator.scss
@@ -1,0 +1,14 @@
+.paginator {
+  margin-block: $spacer;
+}
+
+.paginator__button {
+  @extend .btn;
+  @extend .btn-secondary;
+
+  margin-right: $spacer;
+
+  &:last-child {
+    margin-right: 0;
+  }
+}

--- a/src/assets/css/themes/litely.scss
+++ b/src/assets/css/themes/litely.scss
@@ -1,2 +1,3 @@
 @import "variables.litely";
 @import "../../../../node_modules/bootstrap-v4/scss/bootstrap";
+@import "../components/paginator";

--- a/src/shared/components/common/paginator.tsx
+++ b/src/shared/components/common/paginator.tsx
@@ -12,16 +12,16 @@ export class Paginator extends Component<PaginatorProps, any> {
   }
   render() {
     return (
-      <div className="my-2">
+      <div className="paginator">
         <button
-          className="btn btn-secondary mr-2"
+          className="paginator__button"
           disabled={this.props.page == 1}
           onClick={linkEvent(this, this.handlePrev)}
         >
           {i18n.t("prev")}
         </button>
         <button
-          className="btn btn-secondary"
+          className="paginator__button"
           onClick={linkEvent(this, this.handleNext)}
         >
           {i18n.t("next")}


### PR DESCRIPTION
# DO NOT MERGE

I've been thinking a lot about the future of CSS on this project, if it's ever going to go beyond Bootstrap classes. Here's a proof of concept that handles a small but common component, the Paginator.

## Goal

The goal here is to gradually move away from Bootstrap class names to custom class names, while still using the styles that Bootstrap provides, with the possible ultimate goal of remove Bootstrap as a dependency entirely. Bootstrap doesn't provide an off-ramp as far as I can tell, and most articles either say "Don't use Bootstrap" or show someone rewriting an entire codebase.

## Benefits

### 1. Reusability

Right now, every time we want to make a component that looks like another component that uses, say, four Bootstrap class names to get its styles, that new component needs to use all four of those classes. If a class is added to the original component for some small change, a developer will have to know to find every similar-looking component and update those class names as well.

### 2. Custom theming

Greasemonkey-style plugins and, more importantly, use stylesheets (for people with vision or mental impairments, for instance) have a really hard time latching on to collections of multiple classnames on a single component, so customizability is very difficult with Bootstrap classes only.

## Approach

### 1. Use `@extend` on Bootstrap classes for complex styles

This is the shortest route to getting off of Bootstrap classes in the HTML, but it adds some well-documented overhead to the compiled CSS (see below). But for something like `.btn`, Bootstrap unfortunately doesn't provide any mixins.

### 2. Use Bootstrap Sass vars

This is possible for smaller utility classes, like margins and colors, and is more "future-proof," as vars like `$spacer` can be easily copied into a custom codebase

### 3. Use BEM

[BEM](https://en.bem.info) is a common naming methodology that works well for complex projects with a lot of people touching the same codebase.

### 4. One component at a time

Rather than throwing hundreds of CSS classes at the codebase and hoping that something is eventually done with them, doing this on a component-by-component basis will allow any shortcomings to surface earlier to allow for better course-correction. Lessons will be learned as components are rewritten, lessons in terms of naming, file structure, `@extend`s and vars, etc.

## Obstacles

### 1. Style inconsistencies

One of the benefits of Bootstrap is that it provides a fully consistent UI; there's no easy way to just put an arbitrary 17px margin on something, for instance, and this can be a good thing.

Moving to separate stylesheets will invite the temptation to add these arbitrary values, which could quickly result in a lot of UI inconsistencies.

### 2. Bloat

Using `@extend` a lot can seriously bloat a stylesheet, but gzip can crunch this down pretty efficiently.