### PR TITLE
fix: Prettier ignore generated themes, as they aren't written by humans

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 src/shared/translations
 lemmy-translations
+src/assets/css/themes/*.css


### PR DESCRIPTION
Prettier doesn't need to be applied to the generated theme CSS files