### PR TITLE
fix: Fix too-intense hr color between posts

### DIFF
--- a/src/assets/css/themes/_variables.darkly.scss
+++ b/src/assets/css/themes/_variables.darkly.scss
@@ -92,6 +92,8 @@ $input-border-color: $body-bg;
 $input-group-addon-color: $gray-500;
 $input-group-addon-bg: $gray-700;
 
+$hr-border-color: rgba($body-color, 0.25);
+
 $table-accent-bg: $gray-800;
 $table-border-color: $gray-700;
 

--- a/src/assets/css/themes/_variables.litely.scss
+++ b/src/assets/css/themes/_variables.litely.scss
@@ -76,3 +76,5 @@ $border-radius: 0.5rem;
 $border-radius-lg: 0.5rem;
 $border-radius-sm: 1rem;
 $rounded-pill: 0.25rem;
+
+$hr-border-color: rgba($body-color, 0.25);

--- a/src/assets/css/themes/darkly-red.css
+++ b/src/assets/css/themes/darkly-red.css
@@ -450,7 +450,7 @@ hr {
   margin-top: 1rem;
   margin-bottom: 1rem;
   border: 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-top: 1px solid rgba(222, 226, 230, 0.25);
 }
 
 small,

--- a/src/assets/css/themes/darkly.css
+++ b/src/assets/css/themes/darkly.css
@@ -450,7 +450,7 @@ hr {
   margin-top: 1rem;
   margin-bottom: 1rem;
   border: 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-top: 1px solid rgba(222, 226, 230, 0.25);
 }
 
 small,

--- a/src/assets/css/themes/litely-red.css
+++ b/src/assets/css/themes/litely-red.css
@@ -450,7 +450,7 @@ hr {
   margin-top: 1rem;
   margin-bottom: 1rem;
   border: 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-top: 1px solid rgba(222, 226, 230, 0.25);
 }
 
 small,

--- a/src/assets/css/themes/litely.css
+++ b/src/assets/css/themes/litely.css
@@ -449,7 +449,7 @@ hr {
   margin-top: 1rem;
   margin-bottom: 1rem;
   border: 0;
-  border-top: 1px solid rgba(34, 34, 34, 0.1);
+  border-top: 1px solid rgba(73, 80, 87, 0.25);
 }
 
 small,

--- a/src/shared/components/post/post-listings.tsx
+++ b/src/shared/components/post/post-listings.tsx
@@ -96,9 +96,7 @@ export class PostListings extends Component<PostListingsProps, any> {
                 onAddAdmin={this.props.onAddAdmin}
                 onTransferCommunity={this.props.onTransferCommunity}
               />
-              {idx + 1 !== this.posts.length && (
-                <hr className="my-3 border border-primary" />
-              )}
+              {idx + 1 !== this.posts.length && <hr className="my-3" />}
             </>
           ))
         ) : (


### PR DESCRIPTION
#1304 used the `primary` color for horizontal rules, which looks subtle-ish on dark mode, but less subtle on light mode.

It also increased the border width of the `<hr>`s.

This PR makes the colors more subtle, while still being visible, and modifies the Bootstrap `hr-border-color` variable for more global `<hr>` color fixing.

Would like feedback from @ayan4m1 and @SleeplessOne1917 on this, as they were responsible for the previous fix.

## Before

<img width="784" alt="Screenshot 2023-06-18 at 3 43 29 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/d3d67007-373e-437d-9d31-326c3afaeee3">

<img width="785" alt="Screenshot 2023-06-18 at 3 43 20 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/9f1a4ca5-2557-4e45-bc4d-0a37b9dc585f">

## After

<img width="784" alt="Screenshot 2023-06-18 at 3 37 25 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/ec1c62a4-c0ab-46f4-b980-6184705acd35">

<img width="795" alt="Screenshot 2023-06-18 at 3 37 36 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/c79a211e-51c0-4223-a5d6-dbddae321083">
