### PR TITLE
fix: Always show advanced post buttons dropdown

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -642,17 +642,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     );
   }
 
-  get hasAdvancedButtons() {
-    return (
-      this.myPost ||
-      (this.showBody && this.postView.post.body) ||
-      amMod(this.props.moderators) ||
-      amAdmin() ||
-      this.canMod_ ||
-      this.canAdmin_
-    );
-  }
-
   showPreviewButton() {
     const post_view = this.postView;
     const body = post_view.post.body;
@@ -694,50 +683,48 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
 
         {this.showBody && post_view.post.body && this.viewSourceButton}
 
-        {this.hasAdvancedButtons && (
-          <div className="dropdown">
-            <button
-              className="btn btn-link btn-animate text-muted py-0 dropdown-toggle"
-              onClick={linkEvent(this, this.handleShowAdvanced)}
-              data-tippy-content={i18n.t("more")}
-              data-bs-toggle="dropdown"
-              aria-expanded="false"
-              aria-controls="advancedButtonsDropdown"
-              aria-label={i18n.t("more")}
-            >
-              <Icon icon="more-vertical" inline />
-            </button>
+        <div className="dropdown">
+          <button
+            className="btn btn-link btn-animate text-muted py-0 dropdown-toggle"
+            onClick={linkEvent(this, this.handleShowAdvanced)}
+            data-tippy-content={i18n.t("more")}
+            data-bs-toggle="dropdown"
+            aria-expanded="false"
+            aria-controls="advancedButtonsDropdown"
+            aria-label={i18n.t("more")}
+          >
+            <Icon icon="more-vertical" inline />
+          </button>
 
-            <ul className="dropdown-menu" id="advancedButtonsDropdown">
-              {!this.myPost ? (
-                <>
-                  <li>{this.reportButton}</li>
-                  <li>{this.blockButton}</li>
-                </>
-              ) : (
-                <>
-                  <li>{this.editButton}</li>
-                  <li>{this.deleteButton}</li>
-                </>
-              )}
+          <ul className="dropdown-menu" id="advancedButtonsDropdown">
+            {!this.myPost ? (
+              <>
+                <li>{this.reportButton}</li>
+                <li>{this.blockButton}</li>
+              </>
+            ) : (
+              <>
+                <li>{this.editButton}</li>
+                <li>{this.deleteButton}</li>
+              </>
+            )}
 
-              {/* Any mod can do these, not limited to hierarchy*/}
-              {(amMod(this.props.moderators) || amAdmin()) && (
-                <>
-                  <li>
-                    <hr className="dropdown-divider" />
-                  </li>
-                  <li>{this.lockButton}</li>
-                  {this.featureButtons}
-                </>
-              )}
+            {/* Any mod can do these, not limited to hierarchy*/}
+            {(amMod(this.props.moderators) || amAdmin()) && (
+              <>
+                <li>
+                  <hr className="dropdown-divider" />
+                </li>
+                <li>{this.lockButton}</li>
+                {this.featureButtons}
+              </>
+            )}
 
-              {(this.canMod_ || this.canAdmin_) && (
-                <li>{this.modRemoveButton}</li>
-              )}
-            </ul>
-          </div>
-        )}
+            {(this.canMod_ || this.canAdmin_) && (
+              <li>{this.modRemoveButton}</li>
+            )}
+          </ul>
+        </div>
       </>
     );
   }


### PR DESCRIPTION
The advanced button dropdown (where the report and block buttons are) was not showing on the post listing page if you were not the post author. This fixes that.

## Before

<img width="519" alt="Screenshot 2023-06-19 at 3 58 22 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/1de00401-c171-4c8d-a89d-f9cace85086d">


## After

<img width="490" alt="Screenshot 2023-06-19 at 3 57 28 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/8dd9eee9-2acd-4f8f-96bb-8772e3c28bc2">
