### PR TITLE
Fix `?scrollToComments` query param feature

### DIFF
--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -294,7 +294,9 @@ export class Post extends Component<any, PostState> {
   }
 
   scrollIntoCommentSection() {
-    this.state.commentSectionRef?.current?.scrollIntoView();
+    setTimeout(() => {
+      this.state.commentSectionRef?.current?.scrollIntoView();
+    });
   }
 
   isBottom(el: Element): boolean {


### PR DESCRIPTION
Hi Lemdevs!

Right now, our `scrollToComments` query param feature isn't working. It's looking for a `this.state.commentSectionRef?.current` which doesn't yet exist when it's called. 

I propose:

- Add a `setTimeout` (equivalent of `nextTick`). Normally I'm not a fan of this, but it's a lot less complicated than adding some sort of watcher to wait for `this.state.commentSectionRef?.current` to `!== null` and then execute the method.

Thanks all!