### PR TITLE
Fix redirect after successful password reset

### DIFF
--- a/src/shared/components/person/password-change.tsx
+++ b/src/shared/components/person/password-change.tsx
@@ -140,7 +140,7 @@ export class PasswordChange extends Component<any, State> {
           UserService.Instance.myUserInfo = site.data.my_user;
         }
 
-        this.props.history.replace("/");
+        i.props.history.replace("/");
       }
     }
   }


### PR DESCRIPTION
The redirect to the home page after a successful password reset is currently broken, because the function references `this.props`, which is `undefined`. This PR fixes it.


Side-note: the `i` pattern that is used a lot in this project (including in this function) seems quite error-prone and not really idiomatic. Is there an explanation anywhere as to why this is done over just regular arrow functions + `this`?