### PR TITLE
Add scripts to make managing translations easier

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
     "build:prod": "webpack --mode=production",
     "clean": "yarn run rimraf dist",
     "dev": "yarn start",
-    "lint": "node generate_translations.js && tsc --noEmit && eslint --report-unused-disable-directives --ext .js,.ts,.tsx \"src/**\" && prettier --check \"src/**/*.{ts,tsx,js,css,scss}\"",
+    "lint": "yarn translations:generate && tsc --noEmit && eslint --report-unused-disable-directives --ext .js,.ts,.tsx \"src/**\" && prettier --check \"src/**/*.{ts,tsx,js,css,scss}\"",
     "prepare": "husky install",
     "start": "yarn build:dev --watch",
     "themes:build": "sass src/assets/css/themes/:src/assets/css/themes",
-    "themes:watch": "sass --watch src/assets/css/themes/:src/assets/css/themes"
+    "themes:watch": "sass --watch src/assets/css/themes/:src/assets/css/themes",
+    "translations:generate": "node generate_translations.js",
+    "translations:init": "git submodule init && yarn translations:update",
+    "translations:update": "git submodule update --remote --recursive"
   },
   "lint-staged": {
     "*.{ts,tsx,js}": [


### PR DESCRIPTION
I've had new contributors ask on multiple occasions what to do when they can't get translations. Hopefully making this a script in package.json will make it easier to figure out for future contributors.