### PR TITLE
Fix post view crosspost display

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -591,7 +591,10 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   }
 
   duplicatesLine() {
-    const dupes = this.props.crossPosts;
+    const dupes = this.props.crossPosts?.filter(
+      pv => pv.community.id !== this.postView.community.id
+    );
+
     return dupes && dupes.length > 0 ? (
       <ul className="list-inline mb-1 small text-muted">
         <>


### PR DESCRIPTION
Hi Lemdevs!

Currently, the crosspost UI is displaying for all posts even if the post isn't crossposted.

I propose we:

- Filter out all crossposts with the same community ID as the current `PostView`.
- If there's a better way to do this, I propose we do that.

Resolves https://github.com/LemmyNet/lemmy-ui/issues/1394.

Thanks all!