### PR TITLE
feat: Hide 'comments' in post listing comments button

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -734,24 +734,22 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
 
   get commentsButton() {
     const post_view = this.postView;
+    const title = i18n.t("number_of_comments", {
+      count: Number(post_view.counts.comments),
+      formattedCount: Number(post_view.counts.comments),
+    });
+
     return (
       <Link
-        className="btn btn-link text-muted ps-0 text-muted"
-        title={i18n.t("number_of_comments", {
-          count: Number(post_view.counts.comments),
-          formattedCount: Number(post_view.counts.comments),
-        })}
+        className="btn btn-link btn-sm text-muted ps-0"
+        title={title}
         to={`/post/${post_view.post.id}?scrollToComments=true`}
+        data-tippy-content={title}
       >
         <Icon icon="message-square" classes="me-1" inline />
-        <span className="me-2">
-          {i18n.t("number_of_comments", {
-            count: Number(post_view.counts.comments),
-            formattedCount: numToSI(post_view.counts.comments),
-          })}
-        </span>
+        {post_view.counts.comments}
         {this.unreadCount && (
-          <span className="small text-warning">
+          <span className="badge text-bg-warning">
             ({this.unreadCount} {i18n.t("new")})
           </span>
         )}


### PR DESCRIPTION
The icon and the title/aria/tippy text should be enough that people know what the number refers to. Trying to save a little more space in this row of buttons, especially on mobile.

## Before

<img width="736" alt="Screenshot 2023-06-20 at 7 55 25 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/e124acc3-653b-4ede-b46d-992d165cc782">
<img width="360" alt="Screenshot 2023-06-20 at 7 55 18 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/82b15384-6f06-4230-a626-13dedac0534a">


## After
<img width="703" alt="Screenshot 2023-06-20 at 7 54 28 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/73216533-ebb6-4dee-be8d-8998b543b798">
<img width="361" alt="Screenshot 2023-06-20 at 7 55 00 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/b67615bb-ee36-4329-8156-32ded4487f59">


