### PR TITLE
fix: Remove Bootstrap JS in sidebars

### DIFF
--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -570,8 +570,6 @@ export class Home extends Component<any, HomeState> {
               data-tippy-content={
                 subscribedCollapsed ? i18n.t("expand") : i18n.t("collapse")
               }
-              data-bs-toggle="collapse"
-              data-bs-target="#sidebarSubscribedBody"
               aria-expanded="true"
               aria-controls="sidebarSubscribedBody"
             >
@@ -582,24 +580,25 @@ export class Home extends Component<any, HomeState> {
             </button>
           )}
         </header>
-        <div
-          id="sidebarSubscribedBody"
-          className="collapse show"
-          aria-labelledby="sidebarSubscribedHeader"
-        >
-          <div className="card-body">
-            <ul className="list-inline mb-0">
-              {UserService.Instance.myUserInfo?.follows.map(cfv => (
-                <li
-                  key={cfv.community.id}
-                  className="list-inline-item d-inline-block"
-                >
-                  <CommunityLink community={cfv.community} />
-                </li>
-              ))}
-            </ul>
+        {!subscribedCollapsed && (
+          <div
+            id="sidebarSubscribedBody"
+            aria-labelledby="sidebarSubscribedHeader"
+          >
+            <div className="card-body">
+              <ul className="list-inline mb-0">
+                {UserService.Instance.myUserInfo?.follows.map(cfv => (
+                  <li
+                    key={cfv.community.id}
+                    className="list-inline-item d-inline-block"
+                  >
+                    <CommunityLink community={cfv.community} />
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
-        </div>
+        )}
       </>
     );
   }

--- a/src/shared/components/home/site-sidebar.tsx
+++ b/src/shared/components/home/site-sidebar.tsx
@@ -42,13 +42,11 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
             )}
           </header>
 
-          <div
-            id="sidebarInfoBody"
-            className="collapse show"
-            aria-labelledby="sidebarInfoHeader"
-          >
-            <div className="card-body">{this.siteInfo()}</div>
-          </div>
+          {!this.state.collapsed && (
+            <div id="sidebarInfoBody" aria-labelledby="sidebarInfoHeader">
+              <div className="card-body">{this.siteInfo()}</div>
+            </div>
+          )}
         </section>
       </div>
     );


### PR DESCRIPTION
#1355 added a dependency to Bootstrap Collapse JS for handling of sidebar collapsing. This reverts things to native Inferno state management.