### PR TITLE
(Hopefully) fix webmanifest different origin issue

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -25,7 +25,7 @@ if (!process.env["LEMMY_UI_DISABLE_CSP"] && !process.env["LEMMY_UI_DEBUG"]) {
 
 server.get("/robots.txt", RobotsHandler);
 server.get("/service-worker.js", ServiceWorkerHandler);
-server.get("/manifest", ManifestHandler);
+server.get("/manifest.webmanifest", ManifestHandler);
 server.get("/css/themes/:name", ThemeHandler);
 server.get("/css/themelist", ThemesListHandler);
 server.get("/*", CatchAllHandler);

--- a/src/server/utils/create-ssr-html.tsx
+++ b/src/server/utils/create-ssr-html.tsx
@@ -77,7 +77,7 @@ export async function createSsrHtml(
      />
   
     <!-- Web app manifest -->
-    <link rel="manifest" href="/manifest" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href=${appleTouchIcon} />
     <link rel="apple-touch-startup-image" href=${appleTouchIcon} />
   


### PR DESCRIPTION
https://voyager.lemmy.ml is currently still having this error:
![image](https://github.com/LemmyNet/lemmy-ui/assets/28871516/65843e86-82ec-4f87-8097-743ae9490ecd)

This is despite the fact that the `start_url` and url of the home page are the same. I'm hoping an appropriate file extension on the manifest will fix this.