### PR TITLE
Fix grave `ReferenceError: fetch is not defined` error

### DIFF
--- a/src/server/handlers/catch-all-handler.tsx
+++ b/src/server/handlers/catch-all-handler.tsx
@@ -1,5 +1,6 @@
 import { initializeSite, isAuthPath } from "@utils/app";
 import { ErrorPageData } from "@utils/types";
+import fetch from "cross-fetch";
 import type { Request, Response } from "express";
 import { StaticRouter, matchPath } from "inferno-router";
 import { renderToString } from "inferno-server";

--- a/src/server/handlers/manifest-handler.ts
+++ b/src/server/handlers/manifest-handler.ts
@@ -1,3 +1,4 @@
+import fetch from "cross-fetch";
 import type { Request, Response } from "express";
 import { LemmyHttp } from "lemmy-js-client";
 import { getHttpBaseExternal, getHttpBaseInternal } from "../../shared/env";

--- a/src/server/utils/fetch-icon-png.ts
+++ b/src/server/utils/fetch-icon-png.ts
@@ -1,3 +1,5 @@
+import fetch from "cross-fetch";
+
 export async function fetchIconPng(iconUrl: string) {
   return await fetch(iconUrl)
     .then(res => res.blob())

--- a/src/shared/utils/app/fetch-theme-list.ts
+++ b/src/shared/utils/app/fetch-theme-list.ts
@@ -1,5 +1,3 @@
-import fetch from "cross-fetch";
-
 export default async function fetchThemeList(): Promise<string[]> {
   return fetch("/css/themelist").then(res => res.json());
 }

--- a/src/shared/utils/app/fetch-theme-list.ts
+++ b/src/shared/utils/app/fetch-theme-list.ts
@@ -1,3 +1,5 @@
+import fetch from "cross-fetch";
+
 export default async function fetchThemeList(): Promise<string[]> {
   return fetch("/css/themelist").then(res => res.json());
 }


### PR DESCRIPTION
Hi Lemdevs!

I'm not sure what happened, but recent changes led to the server breaking today with `ReferenceError: fetch is not defined` as an error. It appears we already have `cross-fetch` as a dependency, but weren't using it anywhere. This PR utilizes it for shared/server use cases, ensuring it's both browser & Node friendly. Resolves the issue.

Thanks!