### PR TITLE
fix: Fix comment upvote/downvote totals not showing in some cases

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -464,13 +464,11 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                         ) : (
                           <>
                             <Icon icon="arrow-up1" classes="icon-inline" />
-                            {showScores() &&
-                              this.commentView.counts.upvotes !==
-                                this.commentView.counts.score && (
-                                <span className="ms-1">
-                                  {numToSI(this.commentView.counts.upvotes)}
-                                </span>
-                              )}
+                            {showScores() && (
+                              <span className="ms-1">
+                                {numToSI(this.commentView.counts.upvotes)}
+                              </span>
+                            )}
                           </>
                         )}
                       </button>
@@ -491,13 +489,11 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                           ) : (
                             <>
                               <Icon icon="arrow-down1" classes="icon-inline" />
-                              {showScores() &&
-                                this.commentView.counts.upvotes !==
-                                  this.commentView.counts.score && (
-                                  <span className="ms-1">
-                                    {numToSI(this.commentView.counts.downvotes)}
-                                  </span>
-                                )}
+                              {showScores() && (
+                                <span className="ms-1">
+                                  {numToSI(this.commentView.counts.downvotes)}
+                                </span>
+                              )}
                             </>
                           )}
                         </button>


### PR DESCRIPTION
A comment count wouldn't show if the number of upvotes was equal to the total score. This meant if there was one upvote, and the total score was 1, no number would appear next to upvotes or downvotes.