### PR TITLE
Add fallback `style` tag for theme if backend offline

### DIFF
--- a/src/server/utils/create-ssr-html.tsx
+++ b/src/server/utils/create-ssr-html.tsx
@@ -4,11 +4,10 @@ import serialize from "serialize-javascript";
 import sharp from "sharp";
 import { favIconPngUrl, favIconUrl } from "../../shared/config";
 import { ILemmyConfig, IsoDataOptionalSite } from "../../shared/interfaces";
+import { buildThemeList } from "./build-themes-list";
 import { fetchIconPng } from "./fetch-icon-png";
 
 const customHtmlHeader = process.env["LEMMY_UI_CUSTOM_HTML_HEADER"] || "";
-
-const fallbackStyleTag = `<link rel="stylesheet" type="text/css" href="/css/themes/darkly.css" />`;
 
 let appleTouchIcon: string | undefined = undefined;
 
@@ -17,6 +16,10 @@ export async function createSsrHtml(
   isoData: IsoDataOptionalSite
 ) {
   const site = isoData.site_res;
+
+  const fallbackTheme = `<link rel="stylesheet" type="text/css" href="/css/themes/${
+    (await buildThemeList())[0]
+  }.css" />`;
 
   if (!appleTouchIcon) {
     appleTouchIcon = site?.site_view.site.icon
@@ -87,7 +90,7 @@ export async function createSsrHtml(
     <link rel="stylesheet" type="text/css" href="/static/styles/styles.css" />
   
     <!-- Current theme and more -->
-    ${helmet.link.toString() || fallbackStyleTag}
+    ${helmet.link.toString() || fallbackTheme}
     
     </head>
   

--- a/src/server/utils/create-ssr-html.tsx
+++ b/src/server/utils/create-ssr-html.tsx
@@ -8,6 +8,8 @@ import { fetchIconPng } from "./fetch-icon-png";
 
 const customHtmlHeader = process.env["LEMMY_UI_CUSTOM_HTML_HEADER"] || "";
 
+const fallbackStyleTag = `<link rel="stylesheet" type="text/css" href="/css/themes/darkly.css" />`;
+
 let appleTouchIcon: string | undefined = undefined;
 
 export async function createSsrHtml(
@@ -85,7 +87,7 @@ export async function createSsrHtml(
     <link rel="stylesheet" type="text/css" href="/static/styles/styles.css" />
   
     <!-- Current theme and more -->
-    ${helmet.link.toString()}
+    ${helmet.link.toString() || fallbackStyleTag}
     
     </head>
   


### PR DESCRIPTION
Hi Lemdevs!

I propose we:

- Add a fallback `style` tag if backend is offline, ensuring _some_ theme is linked.

Before:

<img width="1361" alt="Screenshot 2023-06-22 at 10 31 41 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/8c176c91-ad8e-4dc9-a91a-12751f4f7036">

After:

<img width="1361" alt="Screenshot 2023-06-22 at 10 31 23 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/9be40d4f-737a-4db7-aab2-c8cb6ff35da1">

