### PR TITLE
Fix broken `BUG_REPORT.yml` template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,6 +1,5 @@
 name: "\U0001F41E Bug report"
 description: Create a bug report to help us improve Lemmy-UI!
-title: ""
 labels: ["bug", "triage"]
 body:
   - type: markdown


### PR DESCRIPTION
`title` can't be left blank... apparently. This fixes things and restores ability to report bugs to this repo.