### PR TITLE
Fix inability to navigate to `Home` from `Settings` routes

### DIFF
--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -642,7 +642,7 @@ export class Home extends Component<any, HomeState> {
     const siteRes = this.state.siteRes;
 
     if (dataType === DataType.Post) {
-      switch (this.state.postsRes.state) {
+      switch (this.state.postsRes?.state) {
         case "loading":
           return (
             <h5>


### PR DESCRIPTION
Hi Lemmiaires.

In this PR:

- Fix inability to navigate to `Home` from `Settings` route, and probably other routes, too.
- Optional chaining resolves it
- Uh... don't know why TypeScript doesn't catch this

https://github.com/LemmyNet/lemmy-ui/assets/35377827/a8742620-0429-40ae-9509-b4472fbfa38a

Thanks.