### PR TITLE
Refactor first load handling

### DIFF
--- a/src/shared/components/app/app.tsx
+++ b/src/shared/components/app/app.tsx
@@ -4,7 +4,7 @@ import { Provider } from "inferno-i18next-dess";
 import { Route, Switch } from "inferno-router";
 import { IsoDataOptionalSite } from "../../interfaces";
 import { routes } from "../../routes";
-import { I18NextService } from "../../services";
+import { FirstLoadService, I18NextService } from "../../services";
 import AuthGuard from "../common/auth-guard";
 import ErrorGuard from "../common/error-guard";
 import { ErrorPage } from "./error-page";
@@ -45,27 +45,35 @@ export class App extends Component<any, any> {
             <Navbar siteRes={siteRes} />
             <div className="mt-4 p-0 fl-1">
               <Switch>
-                {routes.map(({ path, component: RouteComponent }) => (
-                  <Route
-                    key={path}
-                    path={path}
-                    exact
-                    component={routeProps => (
-                      <ErrorGuard>
-                        <main tabIndex={-1} ref={this.mainContentRef}>
-                          {RouteComponent &&
-                            (isAuthPath(path ?? "") ? (
-                              <AuthGuard>
-                                <RouteComponent {...routeProps} />
-                              </AuthGuard>
-                            ) : (
-                              <RouteComponent {...routeProps} />
-                            ))}
-                        </main>
-                      </ErrorGuard>
-                    )}
-                  />
-                ))}
+                {routes.map(
+                  ({ path, component: RouteComponent, fetchInitialData }) => (
+                    <Route
+                      key={path}
+                      path={path}
+                      exact
+                      component={routeProps => {
+                        if (!fetchInitialData) {
+                          FirstLoadService.falsify();
+                        }
+
+                        return (
+                          <ErrorGuard>
+                            <main tabIndex={-1} ref={this.mainContentRef}>
+                              {RouteComponent &&
+                                (isAuthPath(path ?? "") ? (
+                                  <AuthGuard>
+                                    <RouteComponent {...routeProps} />
+                                  </AuthGuard>
+                                ) : (
+                                  <RouteComponent {...routeProps} />
+                                ))}
+                            </main>
+                          </ErrorGuard>
+                        );
+                      }}
+                    />
+                  )
+                )}
                 <Route component={ErrorPage} />
               </Switch>
             </div>

--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -4,7 +4,7 @@ import {
   CreateCommunity as CreateCommunityI,
   GetSiteResponse,
 } from "lemmy-js-client";
-import { FirstLoadService, HttpService, I18NextService } from "../../services";
+import { HttpService, I18NextService } from "../../services";
 import { HtmlTags } from "../common/html-tags";
 import { CommunityForm } from "./community-form";
 
@@ -22,8 +22,6 @@ export class CreateCommunity extends Component<any, CreateCommunityState> {
   constructor(props: any, context: any) {
     super(props, context);
     this.handleCommunityCreate = this.handleCommunityCreate.bind(this);
-
-    FirstLoadService.isFirstLoad;
   }
 
   get documentTitle(): string {

--- a/src/shared/components/home/legal.tsx
+++ b/src/shared/components/home/legal.tsx
@@ -2,7 +2,7 @@ import { setIsoData } from "@utils/app";
 import { Component } from "inferno";
 import { GetSiteResponse } from "lemmy-js-client";
 import { mdToHtml } from "../../markdown";
-import { FirstLoadService, I18NextService } from "../../services";
+import { I18NextService } from "../../services";
 import { HtmlTags } from "../common/html-tags";
 
 interface LegalState {
@@ -17,8 +17,6 @@ export class Legal extends Component<any, LegalState> {
 
   constructor(props: any, context: any) {
     super(props, context);
-
-    FirstLoadService.isFirstLoad;
   }
 
   get documentTitle(): string {

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -3,7 +3,7 @@ import { isBrowser } from "@utils/browser";
 import { validEmail } from "@utils/helpers";
 import { Component, linkEvent } from "inferno";
 import { GetSiteResponse, LoginResponse } from "lemmy-js-client";
-import { FirstLoadService, I18NextService, UserService } from "../../services";
+import { I18NextService, UserService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
 import { toast } from "../../toast";
 import { HtmlTags } from "../common/html-tags";
@@ -32,8 +32,6 @@ export class Login extends Component<any, State> {
 
   constructor(props: any, context: any) {
     super(props, context);
-
-    FirstLoadService.isFirstLoad;
   }
 
   componentDidMount() {

--- a/src/shared/components/home/setup.tsx
+++ b/src/shared/components/home/setup.tsx
@@ -7,7 +7,7 @@ import {
   LoginResponse,
   Register,
 } from "lemmy-js-client";
-import { FirstLoadService, I18NextService, UserService } from "../../services";
+import { I18NextService, UserService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
 import { Spinner } from "../common/icon";
 import { SiteForm } from "./site-form";
@@ -47,8 +47,6 @@ export class Setup extends Component<any, State> {
     super(props, context);
 
     this.handleCreateSite = this.handleCreateSite.bind(this);
-
-    FirstLoadService.isFirstLoad;
   }
 
   async componentDidMount() {

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -14,7 +14,7 @@ import {
 } from "lemmy-js-client";
 import { joinLemmyUrl } from "../../config";
 import { mdToHtml } from "../../markdown";
-import { FirstLoadService, I18NextService, UserService } from "../../services";
+import { I18NextService, UserService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
 import { toast } from "../../toast";
 import { HtmlTags } from "../common/html-tags";
@@ -84,8 +84,6 @@ export class Signup extends Component<any, State> {
     super(props, context);
 
     this.handleAnswerChange = this.handleAnswerChange.bind(this);
-
-    FirstLoadService.isFirstLoad;
   }
 
   async componentDidMount() {

--- a/src/shared/components/person/password-change.tsx
+++ b/src/shared/components/person/password-change.tsx
@@ -2,12 +2,7 @@ import { myAuth, setIsoData } from "@utils/app";
 import { capitalizeFirstLetter } from "@utils/helpers";
 import { Component, linkEvent } from "inferno";
 import { GetSiteResponse, LoginResponse } from "lemmy-js-client";
-import {
-  FirstLoadService,
-  HttpService,
-  I18NextService,
-  UserService,
-} from "../../services";
+import { HttpService, I18NextService, UserService } from "../../services";
 import { RequestState } from "../../services/HttpService";
 import { HtmlTags } from "../common/html-tags";
 import { Spinner } from "../common/icon";
@@ -35,8 +30,6 @@ export class PasswordChange extends Component<any, State> {
 
   constructor(props: any, context: any) {
     super(props, context);
-
-    FirstLoadService.isFirstLoad;
   }
 
   get documentTitle(): string {

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -29,7 +29,7 @@ import {
   SortType,
 } from "lemmy-js-client";
 import { elementUrl, emDash, relTags } from "../../config";
-import { FirstLoadService, UserService } from "../../services";
+import { UserService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
 import { I18NextService, languages } from "../../services/I18NextService";
 import { setupTippy } from "../../tippy";
@@ -169,8 +169,6 @@ export class Settings extends Component<any, SettingsState> {
 
     this.handleBlockPerson = this.handleBlockPerson.bind(this);
     this.handleBlockCommunity = this.handleBlockCommunity.bind(this);
-
-    FirstLoadService.isFirstLoad;
 
     const mui = UserService.Instance.myUserInfo;
     if (mui) {

--- a/src/shared/components/person/verify-email.tsx
+++ b/src/shared/components/person/verify-email.tsx
@@ -1,7 +1,7 @@
 import { setIsoData } from "@utils/app";
 import { Component } from "inferno";
 import { GetSiteResponse, VerifyEmailResponse } from "lemmy-js-client";
-import { FirstLoadService, I18NextService } from "../../services";
+import { I18NextService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
 import { toast } from "../../toast";
 import { HtmlTags } from "../common/html-tags";
@@ -22,8 +22,6 @@ export class VerifyEmail extends Component<any, State> {
 
   constructor(props: any, context: any) {
     super(props, context);
-
-    FirstLoadService.isFirstLoad;
   }
 
   async verify() {

--- a/src/shared/services/FirstLoadService.ts
+++ b/src/shared/services/FirstLoadService.ts
@@ -17,11 +17,19 @@ export class FirstLoadService {
     return isFirst;
   }
 
+  falsify() {
+    this.#isFirstLoad = false;
+  }
+
   static get #Instance() {
     return this.#instance ?? (this.#instance = new this());
   }
 
   static get isFirstLoad() {
     return !isBrowser() || this.#Instance.isFirstLoad;
+  }
+
+  static falsify() {
+    this.#Instance.falsify();
   }
 }


### PR DESCRIPTION
Refactor of the fix implemented in #1528. This should prevent contributors from always needing to remember to manually call `FirstLoadService.isFirstLoad` in the constructors of new route page components even if they're not using it.