### PR TITLE
Fix: missing semantic css classes and html elements

### DIFF
--- a/src/shared/components/app/app.tsx
+++ b/src/shared/components/app/app.tsx
@@ -59,7 +59,7 @@ export class App extends Component<any, any> {
 
                         return (
                           <ErrorGuard>
-                            <main tabIndex={-1} ref={this.mainContentRef}>
+                            <div tabIndex={-1}>
                               {RouteComponent &&
                                 (isAuthPath(path ?? "") ? (
                                   <AuthGuard>
@@ -68,7 +68,7 @@ export class App extends Component<any, any> {
                                 ) : (
                                   <RouteComponent {...routeProps} />
                                 ))}
-                            </main>
+                            </div>
                           </ErrorGuard>
                         );
                       }}

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -22,7 +22,7 @@ import {
 } from "@utils/helpers";
 import type { QueryParams } from "@utils/types";
 import { RouteDataResponse } from "@utils/types";
-import { Component, linkEvent } from "inferno";
+import { Component, RefObject, createRef, linkEvent } from "inferno";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import {
   AddAdmin,
@@ -154,7 +154,7 @@ export class Community extends Component<
     finished: new Map(),
     isIsomorphic: false,
   };
-
+  private readonly mainContentRef: RefObject<HTMLElement>;
   constructor(props: RouteComponentProps<{ name: string }>, context: any) {
     super(props, context);
 
@@ -195,7 +195,7 @@ export class Community extends Component<
     this.handleSavePost = this.handleSavePost.bind(this);
     this.handlePurgePost = this.handlePurgePost.bind(this);
     this.handleFeaturePost = this.handleFeaturePost.bind(this);
-
+    this.mainContentRef = createRef();
     // Only fetch the data if coming from another route
     if (FirstLoadService.isFirstLoad) {
       const { communityRes, commentsRes, postsRes } = this.isoData.routeData;
@@ -317,7 +317,7 @@ export class Community extends Component<
             />
 
             <div className="row">
-              <main className="col-12 col-md-8">
+              <main className="col-12 col-md-8" ref={this.mainContentRef}>
                 {this.communityInfo(res)}
                 <div className="d-block d-md-none">
                   <button

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -317,7 +317,7 @@ export class Community extends Component<
             />
 
             <div className="row">
-              <div className="col-12 col-md-8">
+              <main className="col-12 col-md-8">
                 {this.communityInfo(res)}
                 <div className="d-block d-md-none">
                   <button
@@ -339,10 +339,10 @@ export class Community extends Component<
                 {this.selects(res)}
                 {this.listings(res)}
                 <Paginator page={page} onChange={this.handlePageChange} />
-              </div>
-              <div className="d-none d-md-block col-md-4">
+              </main>
+              <aside className="d-none d-md-block col-md-4">
                 {this.sidebar(res)}
-              </div>
+              </aside>
             </div>
           </>
         );

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -348,7 +348,7 @@ export class Post extends Component<any, PostState> {
         const res = this.state.postRes.data;
         return (
           <div className="row">
-            <div className="col-12 col-md-8 mb-3">
+            <main className="col-12 col-md-8 mb-3">
               <HtmlTags
                 title={this.documentTitle}
                 path={this.context.router.route.match.url}
@@ -415,8 +415,10 @@ export class Post extends Component<any, PostState> {
                 this.commentsTree()}
               {this.state.commentViewType == CommentViewType.Flat &&
                 this.commentsFlat()}
-            </div>
-            <div className="d-none d-md-block col-md-4">{this.sidebar()}</div>
+            </main>
+            <aside className="d-none d-md-block col-md-4">
+              {this.sidebar()}
+            </aside>
           </div>
         );
       }


### PR DESCRIPTION
Now all pages have a main and aside element when a sidebar is present to facilitate custom theming. This does not impact the default behavior of the front.

~~Note: removed `ref={this.mainContentRef}` from the div element since it was flagged as an error, can't see  any impact but I don't know what it does in the first place.~~