### PR TITLE
Handle embedded videos the same as other content

### DIFF
--- a/src/shared/components/post/metadata-card.tsx
+++ b/src/shared/components/post/metadata-card.tsx
@@ -1,8 +1,7 @@
-import { Component, linkEvent } from "inferno";
+import { Component } from "inferno";
 import { Post } from "lemmy-js-client";
 import * as sanitizeHtml from "sanitize-html";
 import { relTags } from "../../config";
-import { I18NextService } from "../../services";
 import { Icon } from "../common/icon";
 
 interface MetadataCardProps {
@@ -17,10 +16,6 @@ export class MetadataCard extends Component<
   MetadataCardProps,
   MetadataCardState
 > {
-  state: MetadataCardState = {
-    expanded: false,
-  };
-
   constructor(props: any, context: any) {
     super(props, context);
   }
@@ -29,7 +24,7 @@ export class MetadataCard extends Component<
     const post = this.props.post;
     return (
       <>
-        {!this.state.expanded && post.embed_title && post.url && (
+        {post.embed_title && post.url && (
           <div className="post-metadata-card card border-secondary mt-3 mb-2">
             <div className="row">
               <div className="col-12">
@@ -61,34 +56,12 @@ export class MetadataCard extends Component<
                       }}
                     />
                   )}
-                  {post.embed_video_url && (
-                    <button
-                      className="mt-2 btn btn-secondary text-monospace"
-                      onClick={linkEvent(this, this.handleIframeExpand)}
-                    >
-                      {I18NextService.i18n.t("expand_here")}
-                    </button>
-                  )}
                 </div>
               </div>
             </div>
           </div>
         )}
-        {this.state.expanded && post.embed_video_url && (
-          <div className="ratio ratio-16x9">
-            <iframe
-              allowFullScreen
-              className="post-metadata-iframe"
-              src={post.embed_video_url}
-              title={post.embed_title}
-            ></iframe>
-          </div>
-        )}
       </>
     );
-  }
-
-  handleIframeExpand(i: MetadataCard) {
-    i.setState({ expanded: !i.state.expanded });
   }
 }

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -262,12 +262,27 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const { post } = this.postView;
     const { url } = post;
 
+    // if direct video link
     if (url && isVideo(url)) {
       return (
         <div className="embed-responsive mt-3">
           <video muted controls className="embed-responsive-item col-12">
             <source src={url} type="video/mp4" />
           </video>
+        </div>
+      );
+    }
+
+    // if embedded video link
+    if (url && post.embed_video_url) {
+      return (
+        <div className="ratio ratio-16x9">
+          <iframe
+            allowFullScreen
+            className="post-metadata-iframe"
+            src={post.embed_video_url}
+            title={post.embed_title}
+          ></iframe>
         </div>
       );
     }
@@ -338,7 +353,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         </a>
       );
     } else if (url) {
-      if (!this.props.hideImage && isVideo(url)) {
+      if ((!this.props.hideImage && isVideo(url)) || post.embed_video_url) {
         return (
           <a
             className="text-body"


### PR DESCRIPTION
Hi Lemdevs!

In this PR:

- Handle embedded videos the same as other content (eg. click thumbnail to expand)
- Replace somewhat convoluted way of viewing content previously (clicking metadata card button and clicking another expand button)

<img width="1086" alt="Screenshot 2023-06-25 at 11 01 14 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/11bd75f4-31c4-424d-b666-c2f949391102">

Resolves #1556.

Thanks!