### PR TITLE
Add margin to new comment text

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -741,9 +741,12 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         <Icon icon="message-square" classes="me-1" inline />
         {post_view.counts.comments}
         {this.unreadCount && (
-          <span className="text-muted fst-italic ms-1">
-            ({this.unreadCount} {I18NextService.i18n.t("new")})
-          </span>
+          <>
+            {" "}
+            <span className="text-muted fst-italic">
+              ({this.unreadCount} {I18NextService.i18n.t("new")})
+            </span>
+          </>
         )}
       </Link>
     );

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -743,7 +743,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         {this.unreadCount && (
           <>
             {" "}
-            <span className="text-muted fst-italic">
+            <span className="fst-italic">
               ({this.unreadCount} {I18NextService.i18n.t("new")})
             </span>
           </>

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -741,7 +741,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         <Icon icon="message-square" classes="me-1" inline />
         {post_view.counts.comments}
         {this.unreadCount && (
-          <span className="text-muted fst-italic">
+          <span className="text-muted fst-italic ms-1">
             ({this.unreadCount} {I18NextService.i18n.t("new")})
           </span>
         )}


### PR DESCRIPTION
Adds some space between the comment symbol and new comment symbol on a post.
![image](https://github.com/LemmyNet/lemmy-ui/assets/28871516/6c0f982e-2578-409c-af86-e63e992ce7c8)
