### PR TITLE
feat(UI): Make post listing (icon) avatars smaller (line-height)

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -360,8 +360,9 @@ br.big {
 }
 
 .img-icon {
-  width: 2rem;
-  height: 2rem;
+  width: calc(var(--bs-body-line-height) * 1em);
+  height: calc(var(--bs-body-line-height) * 1em);
+  border-radius: 0.25em;
 }
 
 .tribute-container ul {

--- a/src/shared/components/common/pictrs-image.tsx
+++ b/src/shared/components/common/pictrs-image.tsx
@@ -39,7 +39,7 @@ export class PictrsImage extends Component<PictrsImageProps, any> {
             "img-expanded slight-radius":
               !this.props.thumbnail && !this.props.icon,
             "img-blur": this.props.thumbnail && this.props.nsfw,
-            "rounded-circle img-cover img-icon me-2": this.props.icon,
+            "img-cover img-icon me-1": this.props.icon,
             "ms-2 mb-0 rounded-circle img-cover avatar-overlay":
               this.props.iconOverlay,
             "avatar-pushup": this.props.pushup,

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -106,6 +106,7 @@ interface PostListingProps {
   siteLanguages: number[];
   showCommunity?: boolean;
   showBody?: boolean;
+  hideAvatars?: boolean;
   hideImage?: boolean;
   enableDownvotes?: boolean;
   enableNsfw?: boolean;
@@ -397,7 +398,10 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const post_view = this.postView;
     return (
       <span className="small">
-        <PersonListing person={post_view.creator} />
+        <PersonListing
+          person={post_view.creator}
+          hideAvatar={this.props.hideAvatars}
+        />
         {this.creatorIsMod_ && (
           <span className="mx-1 badge text-bg-light">
             {I18NextService.i18n.t("mod")}
@@ -417,7 +421,10 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           <>
             {" "}
             {I18NextService.i18n.t("to")}{" "}
-            <CommunityLink community={post_view.community} />
+            <CommunityLink
+              community={post_view.community}
+              hideAvatar={this.props.hideAvatars}
+            />
           </>
         )}
         {post_view.post.language_id !== 0 && (

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -106,7 +106,7 @@ interface PostListingProps {
   siteLanguages: number[];
   showCommunity?: boolean;
   showBody?: boolean;
-  hideAvatars?: boolean;
+  smallAvatars?: boolean;
   hideImage?: boolean;
   enableDownvotes?: boolean;
   enableNsfw?: boolean;
@@ -398,10 +398,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const post_view = this.postView;
     return (
       <span className="small">
-        <PersonListing
-          person={post_view.creator}
-          hideAvatar={this.props.hideAvatars}
-        />
+        <PersonListing person={post_view.creator} />
         {this.creatorIsMod_ && (
           <span className="mx-1 badge text-bg-light">
             {I18NextService.i18n.t("mod")}
@@ -421,10 +418,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           <>
             {" "}
             {I18NextService.i18n.t("to")}{" "}
-            <CommunityLink
-              community={post_view.community}
-              hideAvatar={this.props.hideAvatars}
-            />
+            <CommunityLink community={post_view.community} />
           </>
         )}
         {post_view.post.language_id !== 0 && (

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -106,7 +106,6 @@ interface PostListingProps {
   siteLanguages: number[];
   showCommunity?: boolean;
   showBody?: boolean;
-  smallAvatars?: boolean;
   hideImage?: boolean;
   enableDownvotes?: boolean;
   enableNsfw?: boolean;

--- a/src/shared/components/post/post-listings.tsx
+++ b/src/shared/components/post/post-listings.tsx
@@ -76,7 +76,6 @@ export class PostListings extends Component<PostListingsProps, any> {
                 showCommunity={this.props.showCommunity}
                 enableDownvotes={this.props.enableDownvotes}
                 enableNsfw={this.props.enableNsfw}
-                hideAvatars={true}
                 viewOnly={this.props.viewOnly}
                 allLanguages={this.props.allLanguages}
                 siteLanguages={this.props.siteLanguages}

--- a/src/shared/components/post/post-listings.tsx
+++ b/src/shared/components/post/post-listings.tsx
@@ -76,6 +76,7 @@ export class PostListings extends Component<PostListingsProps, any> {
                 showCommunity={this.props.showCommunity}
                 enableDownvotes={this.props.enableDownvotes}
                 enableNsfw={this.props.enableNsfw}
+                hideAvatars={true}
                 viewOnly={this.props.viewOnly}
                 allLanguages={this.props.allLanguages}
                 siteLanguages={this.props.siteLanguages}


### PR DESCRIPTION
Need opinions on this. This will reduce some visual noise and also tighten things up vertically a little.

## Before

<img width="465" alt="Screenshot 2023-06-25 at 4 37 21 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/53a5859c-4ecc-41b7-b25c-d197daf95fbf">


## After

<img width="284" alt="Screenshot 2023-06-26 at 6 06 42 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/f626e3ca-3715-4a20-8835-663cf7688191">
<img width="675" alt="Screenshot 2023-06-26 at 6 09 19 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/4b572251-4c13-477a-b7a5-a1d97467f0dd">


