### PR TITLE
Prevent `PostListing` previews from collapsing when voting

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -42,6 +42,7 @@ import {
   SavePost,
   TransferCommunity,
 } from "lemmy-js-client";
+import deepEqual from "lodash.isequal";
 import { relTags } from "../../config";
 import {
   BanType,
@@ -168,7 +169,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   }
 
   componentWillReceiveProps(nextProps: PostListingProps) {
-    if (this.props !== nextProps) {
+    if (!deepEqual(this.props, nextProps)) {
       this.setState({
         purgeLoading: false,
         reportLoading: false,
@@ -183,7 +184,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         addModLoading: false,
         addAdminLoading: false,
         transferLoading: false,
-        imageExpanded: false,
       });
     }
   }

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -167,6 +167,26 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     this.handleEditCancel = this.handleEditCancel.bind(this);
   }
 
+  componentWillReceiveProps(nextProps: PostListingProps) {
+    if (this.props !== nextProps) {
+      this.setState({
+        purgeLoading: false,
+        reportLoading: false,
+        blockLoading: false,
+        lockLoading: false,
+        deleteLoading: false,
+        removeLoading: false,
+        saveLoading: false,
+        featureCommunityLoading: false,
+        featureLocalLoading: false,
+        banLoading: false,
+        addModLoading: false,
+        addAdminLoading: false,
+        transferLoading: false,
+      });
+    }
+  }
+
   get postView(): PostView {
     return this.props.post_view;
   }

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -42,7 +42,6 @@ import {
   SavePost,
   TransferCommunity,
 } from "lemmy-js-client";
-import deepEqual from "lodash.isequal";
 import { relTags } from "../../config";
 import {
   BanType,
@@ -166,26 +165,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
 
     this.handleEditPost = this.handleEditPost.bind(this);
     this.handleEditCancel = this.handleEditCancel.bind(this);
-  }
-
-  componentWillReceiveProps(nextProps: PostListingProps) {
-    if (!deepEqual(this.props, nextProps)) {
-      this.setState({
-        purgeLoading: false,
-        reportLoading: false,
-        blockLoading: false,
-        lockLoading: false,
-        deleteLoading: false,
-        removeLoading: false,
-        saveLoading: false,
-        featureCommunityLoading: false,
-        featureLocalLoading: false,
-        banLoading: false,
-        addModLoading: false,
-        addAdminLoading: false,
-        transferLoading: false,
-      });
-    }
   }
 
   get postView(): PostView {


### PR DESCRIPTION
Hi Lemdevs!

In this PR:

- Prevent `PostListing` previews from collapsing when voting

Resolves #1602.

Thanks!