### PR TITLE
Remove thumbnail expand icon on `PostListing`'s `postTitleLine`

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -482,26 +482,13 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               this.postLink
             )}
           </h5>
-          {(url && isImage(url)) ||
-            (post.thumbnail_url && (
-              <button
-                className="btn btn-sm text-monospace text-muted d-inline-block"
-                data-tippy-content={I18NextService.i18n.t("expand_here")}
-                onClick={linkEvent(this, this.handleImageExpandClick)}
-              >
-                <Icon
-                  icon={
-                    !this.state.imageExpanded ? "plus-square" : "minus-square"
-                  }
-                  classes="icon-inline"
-                />
-              </button>
-            ))}
+
           {post.removed && (
             <small className="ms-2 badge text-bg-secondary">
               {I18NextService.i18n.t("removed")}
             </small>
           )}
+
           {post.deleted && (
             <small
               className="unselectable pointer ms-2 text-muted fst-italic"
@@ -510,6 +497,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               <Icon icon="trash" classes="icon-inline text-danger" />
             </small>
           )}
+
           {post.locked && (
             <small
               className="unselectable pointer ms-2 text-muted fst-italic"
@@ -518,6 +506,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               <Icon icon="lock" classes="icon-inline text-danger" />
             </small>
           )}
+
           {post.featured_community && (
             <small
               className="unselectable pointer ms-2 text-muted fst-italic"
@@ -529,6 +518,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               <Icon icon="pin" classes="icon-inline text-primary" />
             </small>
           )}
+
           {post.featured_local && (
             <small
               className="unselectable pointer ms-2 text-muted fst-italic"
@@ -538,6 +528,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               <Icon icon="pin" classes="icon-inline text-secondary" />
             </small>
           )}
+
           {post.nsfw && (
             <small className="ms-2 badge text-bg-danger">
               {I18NextService.i18n.t("nsfw")}


### PR DESCRIPTION
Hi Lemdevs!

In this PR:

- Remove extra expand icon on `PostListing`'s `postTitleLine`
- Why would a user want to expand a thumbnail? It's a confusing button.

<img width="678" alt="Screenshot 2023-06-26 at 2 33 39 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/81f8402f-f024-4da6-95be-89c99dcf1817">

Thanks!