### PR TITLE
Decouple API calls from top level components.

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -1593,10 +1593,9 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
   async onVote(form: CreateCommentLike) {
     const response = await HttpService.client.likeComment(form);
     if (response.state == "success") {
-      console.log("Comment vote");
       this.setState({ commentView: response.data.comment_view });
     } else {
-      console.error("Comment could not be voted on!");
+      console.error("Comment could not be voted on.");
     }
   }
 }

--- a/src/shared/components/comment/comment-nodes.tsx
+++ b/src/shared/components/comment/comment-nodes.tsx
@@ -10,7 +10,6 @@ import {
   CommentId,
   CommunityModeratorView,
   CreateComment,
-  CreateCommentLike,
   CreateCommentReport,
   DeleteComment,
   DistinguishComment,
@@ -54,7 +53,6 @@ interface CommentNodesProps {
   onPersonMentionRead(form: MarkPersonMentionAsRead): void;
   onCreateComment(form: EditComment | CreateComment): void;
   onEditComment(form: EditComment | CreateComment): void;
-  onCommentVote(form: CreateCommentLike): void;
   onBlockPerson(form: BlockPerson): void;
   onDeleteComment(form: DeleteComment): void;
   onRemoveComment(form: RemoveComment): void;
@@ -118,7 +116,6 @@ export class CommentNodes extends Component<CommentNodesProps, any> {
               finished={this.props.finished}
               onCreateComment={this.props.onCreateComment}
               onEditComment={this.props.onEditComment}
-              onCommentVote={this.props.onCommentVote}
               onBlockPerson={this.props.onBlockPerson}
               onSaveComment={this.props.onSaveComment}
               onDeleteComment={this.props.onDeleteComment}

--- a/src/shared/components/comment/comment-report.tsx
+++ b/src/shared/components/comment/comment-report.tsx
@@ -86,7 +86,6 @@ export class CommentReport extends Component<
           onBlockPerson={() => {}}
           onDeleteComment={() => {}}
           onRemoveComment={() => {}}
-          onCommentVote={() => {}}
           onCommentReport={() => {}}
           onDistinguishComment={() => {}}
           onAddModToCommunity={() => {}}

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -39,7 +39,6 @@ import {
   CommentResponse,
   CommunityResponse,
   CreateComment,
-  CreateCommentLike,
   CreateCommentReport,
   CreatePostLike,
   CreatePostReport,
@@ -174,7 +173,6 @@ export class Community extends Component<
     this.handleBlockPerson = this.handleBlockPerson.bind(this);
     this.handleDeleteComment = this.handleDeleteComment.bind(this);
     this.handleRemoveComment = this.handleRemoveComment.bind(this);
-    this.handleCommentVote = this.handleCommentVote.bind(this);
     this.handleAddModToCommunity = this.handleAddModToCommunity.bind(this);
     this.handleAddAdmin = this.handleAddAdmin.bind(this);
     this.handlePurgePerson = this.handlePurgePerson.bind(this);
@@ -413,7 +411,6 @@ export class Community extends Component<
               siteLanguages={site_res.discussion_languages}
               onBlockPerson={this.handleBlockPerson}
               onPostEdit={this.handlePostEdit}
-              onPostVote={this.handlePostVote}
               onPostReport={this.handlePostReport}
               onLockPost={this.handleLockPost}
               onDeletePost={this.handleDeletePost}
@@ -455,7 +452,6 @@ export class Community extends Component<
               onBlockPerson={this.handleBlockPerson}
               onDeleteComment={this.handleDeleteComment}
               onRemoveComment={this.handleRemoveComment}
-              onCommentVote={this.handleCommentVote}
               onCommentReport={this.handleCommentReport}
               onDistinguishComment={this.handleDistinguishComment}
               onAddModToCommunity={this.handleAddModToCommunity}
@@ -730,11 +726,6 @@ export class Community extends Component<
   async handleFeaturePost(form: FeaturePost) {
     const featureRes = await HttpService.client.featurePost(form);
     this.findAndUpdatePost(featureRes);
-  }
-
-  async handleCommentVote(form: CreateCommentLike) {
-    const voteRes = await HttpService.client.likeComment(form);
-    this.findAndUpdateComment(voteRes);
   }
 
   async handlePostEdit(form: EditPost) {

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -38,9 +38,7 @@ import {
   CommentReplyResponse,
   CommentResponse,
   CreateComment,
-  CreateCommentLike,
   CreateCommentReport,
-  CreatePostLike,
   CreatePostReport,
   DeleteComment,
   DeletePost,
@@ -247,7 +245,6 @@ export class Home extends Component<any, HomeState> {
     this.handleBlockPerson = this.handleBlockPerson.bind(this);
     this.handleDeleteComment = this.handleDeleteComment.bind(this);
     this.handleRemoveComment = this.handleRemoveComment.bind(this);
-    this.handleCommentVote = this.handleCommentVote.bind(this);
     this.handleAddModToCommunity = this.handleAddModToCommunity.bind(this);
     this.handleAddAdmin = this.handleAddAdmin.bind(this);
     this.handlePurgePerson = this.handlePurgePerson.bind(this);
@@ -260,7 +257,6 @@ export class Home extends Component<any, HomeState> {
     this.handleBanFromCommunity = this.handleBanFromCommunity.bind(this);
     this.handleBanPerson = this.handleBanPerson.bind(this);
     this.handlePostEdit = this.handlePostEdit.bind(this);
-    this.handlePostVote = this.handlePostVote.bind(this);
     this.handlePostReport = this.handlePostReport.bind(this);
     this.handleLockPost = this.handleLockPost.bind(this);
     this.handleDeletePost = this.handleDeletePost.bind(this);
@@ -682,7 +678,6 @@ export class Home extends Component<any, HomeState> {
               siteLanguages={siteRes.discussion_languages}
               onBlockPerson={this.handleBlockPerson}
               onPostEdit={this.handlePostEdit}
-              onPostVote={this.handlePostVote}
               onPostReport={this.handlePostReport}
               onLockPost={this.handleLockPost}
               onDeletePost={this.handleDeletePost}
@@ -725,7 +720,6 @@ export class Home extends Component<any, HomeState> {
               onBlockPerson={this.handleBlockPerson}
               onDeleteComment={this.handleDeleteComment}
               onRemoveComment={this.handleRemoveComment}
-              onCommentVote={this.handleCommentVote}
               onCommentReport={this.handleCommentReport}
               onDistinguishComment={this.handleDistinguishComment}
               onAddModToCommunity={this.handleAddModToCommunity}
@@ -943,19 +937,9 @@ export class Home extends Component<any, HomeState> {
     this.findAndUpdatePost(featureRes);
   }
 
-  async handleCommentVote(form: CreateCommentLike) {
-    const voteRes = await HttpService.client.likeComment(form);
-    this.findAndUpdateComment(voteRes);
-  }
-
   async handlePostEdit(form: EditPost) {
     const res = await HttpService.client.editPost(form);
     this.findAndUpdatePost(res);
-  }
-
-  async handlePostVote(form: CreatePostLike) {
-    const voteRes = await HttpService.client.likePost(form);
-    this.findAndUpdatePost(voteRes);
   }
 
   async handleCommentReport(form: CreateCommentReport) {

--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -30,7 +30,6 @@ import {
   CommentSortType,
   CommentView,
   CreateComment,
-  CreateCommentLike,
   CreateCommentReport,
   CreatePrivateMessage,
   CreatePrivateMessageReport,
@@ -144,7 +143,6 @@ export class Inbox extends Component<any, InboxState> {
     this.handleBlockPerson = this.handleBlockPerson.bind(this);
     this.handleDeleteComment = this.handleDeleteComment.bind(this);
     this.handleRemoveComment = this.handleRemoveComment.bind(this);
-    this.handleCommentVote = this.handleCommentVote.bind(this);
     this.handleAddModToCommunity = this.handleAddModToCommunity.bind(this);
     this.handleAddAdmin = this.handleAddAdmin.bind(this);
     this.handlePurgePerson = this.handlePurgePerson.bind(this);
@@ -462,7 +460,6 @@ export class Inbox extends Component<any, InboxState> {
             onBlockPerson={this.handleBlockPerson}
             onDeleteComment={this.handleDeleteComment}
             onRemoveComment={this.handleRemoveComment}
-            onCommentVote={this.handleCommentVote}
             onCommentReport={this.handleCommentReport}
             onDistinguishComment={this.handleDistinguishComment}
             onAddModToCommunity={this.handleAddModToCommunity}
@@ -501,7 +498,6 @@ export class Inbox extends Component<any, InboxState> {
             onBlockPerson={this.handleBlockPerson}
             onDeleteComment={this.handleDeleteComment}
             onRemoveComment={this.handleRemoveComment}
-            onCommentVote={this.handleCommentVote}
             onCommentReport={this.handleCommentReport}
             onDistinguishComment={this.handleDistinguishComment}
             onAddModToCommunity={this.handleAddModToCommunity}
@@ -578,7 +574,6 @@ export class Inbox extends Component<any, InboxState> {
               onBlockPerson={this.handleBlockPerson}
               onDeleteComment={this.handleDeleteComment}
               onRemoveComment={this.handleRemoveComment}
-              onCommentVote={this.handleCommentVote}
               onCommentReport={this.handleCommentReport}
               onDistinguishComment={this.handleDistinguishComment}
               onAddModToCommunity={this.handleAddModToCommunity}
@@ -627,7 +622,6 @@ export class Inbox extends Component<any, InboxState> {
                 onBlockPerson={this.handleBlockPerson}
                 onDeleteComment={this.handleDeleteComment}
                 onRemoveComment={this.handleRemoveComment}
-                onCommentVote={this.handleCommentVote}
                 onCommentReport={this.handleCommentReport}
                 onDistinguishComment={this.handleDistinguishComment}
                 onAddModToCommunity={this.handleAddModToCommunity}
@@ -861,11 +855,6 @@ export class Inbox extends Component<any, InboxState> {
 
   async handleSaveComment(form: SaveComment) {
     const res = await HttpService.client.saveComment(form);
-    this.findAndUpdateComment(res);
-  }
-
-  async handleCommentVote(form: CreateCommentLike) {
-    const res = await HttpService.client.likeComment(form);
     this.findAndUpdateComment(res);
   }
 

--- a/src/shared/components/person/person-details.tsx
+++ b/src/shared/components/person/person-details.tsx
@@ -9,7 +9,6 @@ import {
   CommentId,
   CommentView,
   CreateComment,
-  CreateCommentLike,
   CreateCommentReport,
   CreatePostLike,
   CreatePostReport,
@@ -61,7 +60,6 @@ interface PersonDetailsProps {
   onPersonMentionRead(form: MarkPersonMentionAsRead): void;
   onCreateComment(form: CreateComment): void;
   onEditComment(form: EditComment): void;
-  onCommentVote(form: CreateCommentLike): void;
   onBlockPerson(form: BlockPerson): void;
   onDeleteComment(form: DeleteComment): void;
   onRemoveComment(form: RemoveComment): void;
@@ -154,7 +152,6 @@ export class PersonDetails extends Component<PersonDetailsProps, any> {
             onPersonMentionRead={this.props.onPersonMentionRead}
             onCreateComment={this.props.onCreateComment}
             onEditComment={this.props.onEditComment}
-            onCommentVote={this.props.onCommentVote}
             onBlockPerson={this.props.onBlockPerson}
             onSaveComment={this.props.onSaveComment}
             onDeleteComment={this.props.onDeleteComment}
@@ -185,7 +182,6 @@ export class PersonDetails extends Component<PersonDetailsProps, any> {
             allLanguages={this.props.allLanguages}
             siteLanguages={this.props.siteLanguages}
             onPostEdit={this.props.onPostEdit}
-            onPostVote={this.props.onPostVote}
             onPostReport={this.props.onPostReport}
             onBlockPerson={this.props.onBlockPerson}
             onLockPost={this.props.onLockPost}
@@ -262,7 +258,6 @@ export class PersonDetails extends Component<PersonDetailsProps, any> {
           onPersonMentionRead={this.props.onPersonMentionRead}
           onCreateComment={this.props.onCreateComment}
           onEditComment={this.props.onEditComment}
-          onCommentVote={this.props.onCommentVote}
           onBlockPerson={this.props.onBlockPerson}
           onSaveComment={this.props.onSaveComment}
           onDeleteComment={this.props.onDeleteComment}
@@ -296,7 +291,6 @@ export class PersonDetails extends Component<PersonDetailsProps, any> {
               allLanguages={this.props.allLanguages}
               siteLanguages={this.props.siteLanguages}
               onPostEdit={this.props.onPostEdit}
-              onPostVote={this.props.onPostVote}
               onPostReport={this.props.onPostReport}
               onBlockPerson={this.props.onBlockPerson}
               onLockPost={this.props.onLockPost}

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -43,7 +43,6 @@ import {
   Community,
   CommunityModeratorView,
   CreateComment,
-  CreateCommentLike,
   CreateCommentReport,
   CreatePostLike,
   CreatePostReport,
@@ -184,7 +183,6 @@ export class Profile extends Component<
     this.handleBlockPersonAlt = this.handleBlockPersonAlt.bind(this);
     this.handleDeleteComment = this.handleDeleteComment.bind(this);
     this.handleRemoveComment = this.handleRemoveComment.bind(this);
-    this.handleCommentVote = this.handleCommentVote.bind(this);
     this.handleAddModToCommunity = this.handleAddModToCommunity.bind(this);
     this.handleAddAdmin = this.handleAddAdmin.bind(this);
     this.handlePurgePerson = this.handlePurgePerson.bind(this);
@@ -349,7 +347,6 @@ export class Profile extends Component<
                 onBlockPerson={this.handleBlockPersonAlt}
                 onDeleteComment={this.handleDeleteComment}
                 onRemoveComment={this.handleRemoveComment}
-                onCommentVote={this.handleCommentVote}
                 onCommentReport={this.handleCommentReport}
                 onDistinguishComment={this.handleDistinguishComment}
                 onAddModToCommunity={this.handleAddModToCommunity}
@@ -880,11 +877,6 @@ export class Profile extends Component<
   async handleFeaturePost(form: FeaturePost) {
     const featureRes = await HttpService.client.featurePost(form);
     this.findAndUpdatePost(featureRes);
-  }
-
-  async handleCommentVote(form: CreateCommentLike) {
-    const voteRes = await HttpService.client.likeComment(form);
-    this.findAndUpdateComment(voteRes);
   }
 
   async handlePostVote(form: CreatePostLike) {

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -432,7 +432,6 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
                   viewOnly
                   // All of these are unused, since its view only
                   onPostEdit={() => {}}
-                  onPostVote={() => {}}
                   onPostReport={() => {}}
                   onBlockPerson={() => {}}
                   onLockPost={() => {}}
@@ -626,7 +625,6 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
                 viewOnly
                 // All of these are unused, since its view only
                 onPostEdit={() => {}}
-                onPostVote={() => {}}
                 onPostReport={() => {}}
                 onBlockPerson={() => {}}
                 onLockPost={() => {}}

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -642,6 +642,8 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const response = await HttpService.client.likePost(form);
     if (response.state == "success") {
       this.setState({ postView: response.data.post_view });
+    } else {
+      console.error("Comment could not be voted on.");
     }
   }
 

--- a/src/shared/components/post/post-listings.tsx
+++ b/src/shared/components/post/post-listings.tsx
@@ -7,7 +7,6 @@ import {
   BanFromCommunity,
   BanPerson,
   BlockPerson,
-  CreatePostLike,
   CreatePostReport,
   DeletePost,
   EditPost,
@@ -34,7 +33,6 @@ interface PostListingsProps {
   enableNsfw?: boolean;
   viewOnly?: boolean;
   onPostEdit(form: EditPost): void;
-  onPostVote(form: CreatePostLike): void;
   onPostReport(form: CreatePostReport): void;
   onBlockPerson(form: BlockPerson): void;
   onLockPost(form: LockPost): void;
@@ -80,7 +78,6 @@ export class PostListings extends Component<PostListingsProps, any> {
                 allLanguages={this.props.allLanguages}
                 siteLanguages={this.props.siteLanguages}
                 onPostEdit={this.props.onPostEdit}
-                onPostVote={this.props.onPostVote}
                 onPostReport={this.props.onPostReport}
                 onBlockPerson={this.props.onBlockPerson}
                 onLockPost={this.props.onLockPost}

--- a/src/shared/components/post/post-report.tsx
+++ b/src/shared/components/post/post-report.tsx
@@ -72,7 +72,6 @@ export class PostReport extends Component<PostReportProps, PostReportState> {
           hideImage
           // All of these are unused, since its view only
           onPostEdit={() => {}}
-          onPostVote={() => {}}
           onPostReport={() => {}}
           onBlockPerson={() => {}}
           onLockPost={() => {}}

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -40,7 +40,6 @@ import {
   CommentSortType,
   CommunityResponse,
   CreateComment,
-  CreateCommentLike,
   CreateCommentReport,
   CreatePostLike,
   CreatePostReport,
@@ -148,7 +147,6 @@ export class Post extends Component<any, PostState> {
     this.handleBlockPerson = this.handleBlockPerson.bind(this);
     this.handleDeleteComment = this.handleDeleteComment.bind(this);
     this.handleRemoveComment = this.handleRemoveComment.bind(this);
-    this.handleCommentVote = this.handleCommentVote.bind(this);
     this.handleAddModToCommunity = this.handleAddModToCommunity.bind(this);
     this.handleAddAdmin = this.handleAddAdmin.bind(this);
     this.handlePurgePerson = this.handlePurgePerson.bind(this);
@@ -368,7 +366,6 @@ export class Post extends Component<any, PostState> {
                 siteLanguages={this.state.siteRes.discussion_languages}
                 onBlockPerson={this.handleBlockPerson}
                 onPostEdit={this.handlePostEdit}
-                onPostVote={this.handlePostVote}
                 onPostReport={this.handlePostReport}
                 onLockPost={this.handleLockPost}
                 onDeletePost={this.handleDeletePost}
@@ -535,7 +532,6 @@ export class Post extends Component<any, PostState> {
             onBlockPerson={this.handleBlockPerson}
             onDeleteComment={this.handleDeleteComment}
             onRemoveComment={this.handleRemoveComment}
-            onCommentVote={this.handleCommentVote}
             onCommentReport={this.handleCommentReport}
             onDistinguishComment={this.handleDistinguishComment}
             onAddModToCommunity={this.handleAddModToCommunity}
@@ -622,7 +618,6 @@ export class Post extends Component<any, PostState> {
             onBlockPerson={this.handleBlockPerson}
             onDeleteComment={this.handleDeleteComment}
             onRemoveComment={this.handleRemoveComment}
-            onCommentVote={this.handleCommentVote}
             onCommentReport={this.handleCommentReport}
             onDistinguishComment={this.handleDistinguishComment}
             onAddModToCommunity={this.handleAddModToCommunity}
@@ -816,11 +811,6 @@ export class Post extends Component<any, PostState> {
   async handleFeaturePost(form: FeaturePost) {
     const featureRes = await HttpService.client.featurePost(form);
     this.updatePost(featureRes);
-  }
-
-  async handleCommentVote(form: CreateCommentLike) {
-    const voteRes = await HttpService.client.likeComment(form);
-    this.findAndUpdateComment(voteRes);
   }
 
   async handlePostVote(form: CreatePostLike) {

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -674,7 +674,6 @@ export class Search extends Component<any, SearchState> {
                   viewOnly
                   // All of these are unused, since its view only
                   onPostEdit={() => {}}
-                  onPostVote={() => {}}
                   onPostReport={() => {}}
                   onBlockPerson={() => {}}
                   onLockPost={() => {}}
@@ -714,7 +713,6 @@ export class Search extends Component<any, SearchState> {
                   onBlockPerson={() => {}}
                   onDeleteComment={() => {}}
                   onRemoveComment={() => {}}
-                  onCommentVote={() => {}}
                   onCommentReport={() => {}}
                   onDistinguishComment={() => {}}
                   onAddModToCommunity={() => {}}
@@ -775,7 +773,6 @@ export class Search extends Component<any, SearchState> {
         onBlockPerson={() => {}}
         onDeleteComment={() => {}}
         onRemoveComment={() => {}}
-        onCommentVote={() => {}}
         onCommentReport={() => {}}
         onDistinguishComment={() => {}}
         onAddModToCommunity={() => {}}
@@ -824,7 +821,6 @@ export class Search extends Component<any, SearchState> {
                 viewOnly
                 // All of these are unused, since its view only
                 onPostEdit={() => {}}
-                onPostVote={() => {}}
                 onPostReport={() => {}}
                 onBlockPerson={() => {}}
                 onLockPost={() => {}}


### PR DESCRIPTION
This PR is demonstrates decoupling of low level components from top level components. Right now interactions bubble from the originating component to the top component for that page. The state change propagates back down from the top, triggering costly renders of large components. Handling these interactions in components closer to the originating action has the benefit of:

- Limiting update rendering to smaller components, increasing performance
- Less boilerplate code between components
- Less code in top level components (`Home`, `Community`, etc)

Disadvantages I see are API related state updates are not saved on a global level. This does currently effect how state is managed with the `HomeCacheService`, since it copies `state.postsRes`. This approach is however already problematic as state is not retained, so collapsing/expanding of elements resetting is already an issue.

I propose fixing the coupling and state issues by moving API calls closer to the components they effect, and creating a new method to create a snapshot of the listings for `HomeCacheService`.

This is just an example and request for comments. I will continue to do the rest of the API calls in this fashion unless there is some objection.