### PR TITLE
Reduce fetchLimit (40 -> 20)

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -21,7 +21,7 @@ export const markdownFieldCharacterLimit = 50000;
 export const maxUploadImages = 20;
 export const concurrentImageUpload = 4;
 export const updateUnreadCountsInterval = 30000;
-export const fetchLimit = 40;
+export const fetchLimit = 20;
 export const relTags = "noopener nofollow";
 export const emDash = "\u2014";
 


### PR DESCRIPTION
This PR proposes reducing the default page size. It's certainly a change with some trade-offs, so feel free to reject it (or debate the extent of the reduction), but I will provide my argument below:

On lemm.ee, I have noticed that this small tweak has **vastly** improved the experience for our users. By reducing the page size in half, our page loads significantly faster, and server load has in general decreased slightly as well.

I will also share some actual stats. This was with `fetchLimit` set to 40:
![image](https://github.com/LemmyNet/lemmy-ui/assets/5356547/f1c5c33e-876f-4fe9-bea8-1dbb1a97ea1b)

And this is the same test run with `fetchLimit` reduced to 20:
![image](https://github.com/LemmyNet/lemmy-ui/assets/5356547/19839a1c-2bcc-49e7-8140-00996a90abd5)


Of course, the downside with this is that users need to load additional pages more often, but it seems like a small price to pay considering the performance benefits.