### PR TITLE
Moving webpack-bundle-analyzer require inside mode check to fix docker.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,8 +6,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const RunNodeWebpackPlugin = require("run-node-webpack-plugin");
 const merge = require("lodash.merge");
 const { ServiceWorkerPlugin } = require("service-worker-webpack");
-const BundleAnalyzerPlugin =
-  require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
+
 const banner = `
   hash:[contentHash], chunkhash:[chunkhash], name:[name], filebase:[base], query:[query], file:[file]
   Source code: https://github.com/LemmyNet/lemmy-ui
@@ -156,6 +155,8 @@ const createClientConfig = (_env, mode) => {
   });
 
   if (mode === "none") {
+    const BundleAnalyzerPlugin =
+      require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
     config.plugins.push(new BundleAnalyzerPlugin());
   }
 


### PR DESCRIPTION
Without this, I kept getting docker errors on production builds: https://woodpecker.join-lemmy.org/repos/135/pipeline/870/7