### PR TITLE
Display normal number up to 9999

### DIFF
--- a/src/shared/utils/helpers/num-to-si.ts
+++ b/src/shared/utils/helpers/num-to-si.ts
@@ -6,5 +6,8 @@ const SHORTNUM_SI_FORMAT = new Intl.NumberFormat("en-US", {
 });
 
 export default function numToSI(value: number): string {
+  if (value < 10000) {
+     return value.toString()
+  }
   return SHORTNUM_SI_FORMAT.format(value);
 }


### PR DESCRIPTION
Maybe it's because i'm not american, but I find
<img width="125" alt="image" src="https://github.com/LemmyNet/lemmy-ui/assets/1099219/d4c1bc02-a543-4ac2-af51-00a3ddcd8465">
to be very hard to read.

1150 takes the same amount of character and is much more readable and precise. Hence I propose to use normal numbers up to 9999.