### PR TITLE
Fix borders on `MarkdownTextarea` buttons when disabled

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -159,13 +159,16 @@ export class MarkdownTextArea extends Component<
         <div className="mb-3 row">
           <div className="col-12">
             <div className="rounded bg-light border">
-              <div className="d-flex flex-wrap border-bottom">
+              <div
+                className={`d-flex flex-wrap border-bottom ${
+                  this.isDisabled ? "no-click" : ""
+                }`}
+              >
                 {this.getFormatButton("bold", this.handleInsertBold)}
                 {this.getFormatButton("italic", this.handleInsertItalic)}
                 {this.getFormatButton("link", this.handleInsertLink)}
                 <EmojiPicker
                   onEmojiClick={e => this.handleEmoji(this, e)}
-                  disabled={this.isDisabled}
                 ></EmojiPicker>
                 <form className="btn btn-sm text-muted fw-bold">
                   <label
@@ -188,9 +191,7 @@ export class MarkdownTextArea extends Component<
                     name="file"
                     className="d-none"
                     multiple
-                    disabled={
-                      !UserService.Instance.myUserInfo || this.isDisabled
-                    }
+                    disabled={!UserService.Instance.myUserInfo}
                     onChange={linkEvent(this, this.handleImageUpload)}
                   />
                 </form>
@@ -352,7 +353,6 @@ export class MarkdownTextArea extends Component<
         data-tippy-content={I18NextService.i18n.t(type)}
         aria-label={I18NextService.i18n.t(type)}
         onClick={linkEvent(this, handleClick)}
-        disabled={this.isDisabled}
       >
         <Icon icon={iconType} classes="icon-inline" />
       </button>


### PR DESCRIPTION
Hi Lemdevs!

In this PR:

- Fix borders on disabled `MarkdownTextarea` buttons when `props.isDisabled`.

Before:

<img width="722" alt="Screenshot 2023-06-27 at 12 59 29 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/6f699999-a067-430a-a06e-cd2da193e28c">

After:

<img width="736" alt="Screenshot 2023-06-27 at 12 59 19 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/e229014d-f1cb-4260-989f-a7dd667f66c3">

Thanks!