### PR TITLE
Remove hard-coded `getRoleLabelPill` text foreground color classes

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -322,7 +322,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 getRoleLabelPill({
                   label: I18NextService.i18n.t("op").toUpperCase(),
                   tooltip: I18NextService.i18n.t("creator"),
-                  classes: "text-bg-info text-black",
+                  classes: "text-bg-info",
                   shrink: false,
                 })}
 
@@ -330,14 +330,14 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 getRoleLabelPill({
                   label: I18NextService.i18n.t("mod"),
                   tooltip: I18NextService.i18n.t("mod"),
-                  classes: "text-bg-primary text-black",
+                  classes: "text-bg-primary",
                 })}
 
               {isAdmin_ &&
                 getRoleLabelPill({
                   label: I18NextService.i18n.t("admin"),
                   tooltip: I18NextService.i18n.t("admin"),
-                  classes: "text-bg-danger text-white",
+                  classes: "text-bg-danger",
                 })}
 
               {cv.creator.bot_account &&

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -489,7 +489,7 @@ export class Profile extends Component<
                         {getRoleLabelPill({
                           label: I18NextService.i18n.t("banned"),
                           tooltip: I18NextService.i18n.t("banned"),
-                          classes: "text-bg-danger text-white",
+                          classes: "text-bg-danger",
                           shrink: false,
                         })}
                       </li>
@@ -499,7 +499,7 @@ export class Profile extends Component<
                         {getRoleLabelPill({
                           label: I18NextService.i18n.t("deleted"),
                           tooltip: I18NextService.i18n.t("deleted"),
-                          classes: "text-bg-danger text-white",
+                          classes: "text-bg-danger",
                           shrink: false,
                         })}
                       </li>

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -406,13 +406,13 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           getRoleLabelPill({
             label: I18NextService.i18n.t("mod"),
             tooltip: I18NextService.i18n.t("mod"),
-            classes: "text-bg-primary text-black",
+            classes: "text-bg-primary",
           })}
         {this.creatorIsAdmin_ &&
           getRoleLabelPill({
             label: I18NextService.i18n.t("admin"),
             tooltip: I18NextService.i18n.t("admin"),
-            classes: "text-bg-danger text-white",
+            classes: "text-bg-danger",
           })}
         {post_view.creator.bot_account &&
           getRoleLabelPill({


### PR DESCRIPTION
Appendum to #1656.

I did more testing with `lightly` and discovered we really aught to just use the default foreground colors for these pills, which means not manually specifying `text-black`/`text-white`, and just letting Bootstrap pick the default. This keeps things looking good across themes, see pics below.

<img width="1426" alt="Screenshot 2023-06-27 at 4 53 14 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/46a15848-2e1f-4fdc-b3d5-a274165b38f2">

<img width="1426" alt="Screenshot 2023-06-27 at 4 53 05 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/35377827/e084a891-f068-4632-82b5-1fe803fc486b">
