### PR TITLE
Fix `PostListing` mobile margin layout issue

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -401,10 +401,11 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     }
   }
 
-  createdLine() {
+  createdLine({ extraClasses = "" }: { extraClasses?: string }) {
     const post_view = this.postView;
+
     return (
-      <div className="small">
+      <div className={`small ${extraClasses}`}>
         <span className="me-1">
           <PersonListing person={post_view.creator} />
         </span>
@@ -1373,7 +1374,9 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         <div className="d-block d-sm-none">
           <article className="row post-container">
             <div className="col-12">
-              <div className="mb-1">{this.createdLine()}</div>
+              {this.createdLine({
+                extraClasses: "mb-1",
+              })}
 
               {/* If it has a thumbnail, do a right aligned thumbnail */}
               {this.mobileThumbnail()}
@@ -1407,7 +1410,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
                 </div>
                 <div className="col flex-grow-1">
                   {this.postTitleLine()}
-                  {this.createdLine()}
+                  {this.createdLine({})}
                   {this.commentsLine()}
                   {this.duplicatesLine()}
                   {this.removeAndBanDialogs()}

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -1373,7 +1373,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         <div className="d-block d-sm-none">
           <article className="row post-container">
             <div className="col-12">
-              {this.createdLine()}
+              <div className="mb-1">{this.createdLine()}</div>
 
               {/* If it has a thumbnail, do a right aligned thumbnail */}
               {this.mobileThumbnail()}

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -401,11 +401,11 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     }
   }
 
-  createdLine({ extraClasses = "" }: { extraClasses?: string }) {
+  createdLine() {
     const post_view = this.postView;
 
     return (
-      <div className={`small ${extraClasses}`}>
+      <div className="small mb-1 mb-md-0">
         <span className="me-1">
           <PersonListing person={post_view.creator} />
         </span>
@@ -1374,9 +1374,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         <div className="d-block d-sm-none">
           <article className="row post-container">
             <div className="col-12">
-              {this.createdLine({
-                extraClasses: "mb-1",
-              })}
+              {this.createdLine()}
 
               {/* If it has a thumbnail, do a right aligned thumbnail */}
               {this.mobileThumbnail()}
@@ -1410,7 +1408,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
                 </div>
                 <div className="col flex-grow-1">
                   {this.postTitleLine()}
-                  {this.createdLine({})}
+                  {this.createdLine()}
                   {this.commentsLine()}
                   {this.duplicatesLine()}
                   {this.removeAndBanDialogs()}


### PR DESCRIPTION
Hi all!

In this PR:

- Fix `PostListing` mobile margin layout issue

On mobile, the avatar of the user on the `createdLine` was touching the title of the post. It was bugging me. This fixes it.

Thanks!