### PR TITLE
Fix `NODE_ENV` variable, avoid setting `Cache-Control` in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "analyze": "webpack --mode=none",
     "prebuild:dev": "yarn clean && node generate_translations.js",
-    "build:dev": "webpack --env COMMIT_HASH=$(git rev-parse --short HEAD) --mode=development",
+    "build:dev": "webpack --env COMMIT_HASH=$(git rev-parse --short HEAD) NODE_ENV=development --mode=development",
     "prebuild:prod": "yarn clean && node generate_translations.js",
     "build:prod": "webpack --env COMMIT_HASH=$(git rev-parse --short HEAD) --mode=production",
     "clean": "yarn run rimraf dist",

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -27,6 +27,11 @@ export function setCacheControl(
   res: Response,
   next: NextFunction
 ) {
+  // Avoid setting Cache-Control in development
+  if (process.env.NODE_ENV === "development") {
+    return next();
+  }
+
   const user = UserService.Instance;
   let caching: string;
 


### PR DESCRIPTION
This fixes our dev environment which currently has webpack HMR bundles cached to 1 day.