### PR TITLE
Fix broken `user.auth()` method on `middleware.ts`

### DIFF
--- a/src/server/utils/is-request-authenticated.ts
+++ b/src/server/utils/is-request-authenticated.ts
@@ -1,0 +1,9 @@
+import type { Request } from "express";
+
+export function isRequestAuthenticated(req: Request): boolean {
+  if (!req.headers.cookie) {
+    return false;
+  }
+
+  return req.headers.cookie?.split("; ").some(c => c.startsWith("jwt"));
+}


### PR DESCRIPTION
New strategy for this. Let's parse `req.headers.cookie` directly with a server helper utility. Once #1713, we should update `is-request-authenticated` to use `cookie.parse(...).jwt`.