### PR TITLE
Fix date-fns locale import failing for some locales

### DIFF
--- a/src/shared/utils/app/setup-date-fns.ts
+++ b/src/shared/utils/app/setup-date-fns.ts
@@ -7,6 +7,16 @@ export default async function () {
     lang = "en-US";
   }
 
+  // if lang and country are the same, then date-fns expects only the lang
+  // eg: instead of "fr-FR", we should import just "fr"
+
+  if (lang.includes("-")) {
+    const parts = lang.split("-");
+    if (parts[0] === parts[1].toLowerCase()) {
+      lang = parts[0];
+    }
+  }
+
   const locale = (
     await import(
       /* webpackExclude: /\.js\.flow$/ */


### PR DESCRIPTION
I realized that users who are still reporting issues with #1720 all have locales like `fr-FR`, the reason I could not reproduce the issue was that my browser was already setting it to `fr`.

Confirmed with two separate users that this solves the issue.

Fixes #1720