### PR TITLE
Add fallback date-fns locale import

### DIFF
--- a/src/shared/utils/app/setup-date-fns.ts
+++ b/src/shared/utils/app/setup-date-fns.ts
@@ -1,10 +1,12 @@
 import setDefaultOptions from "date-fns/setDefaultOptions";
 import { I18NextService } from "../../services";
 
+const EN_US = "en-US";
+
 export default async function () {
   let lang = I18NextService.i18n.language;
   if (lang === "en") {
-    lang = "en-US";
+    lang = EN_US;
   }
 
   // if lang and country are the same, then date-fns expects only the lang
@@ -17,12 +19,26 @@ export default async function () {
     }
   }
 
-  const locale = (
-    await import(
-      /* webpackExclude: /\.js\.flow$/ */
-      `date-fns/locale/${lang}`
-    )
-  ).default;
+  let locale;
+
+  try {
+    locale = (
+      await import(
+        /* webpackExclude: /\.js\.flow$/ */
+        `date-fns/locale/${lang}`
+      )
+    ).default;
+  } catch (e) {
+    console.log(
+      `Could not load locale ${lang} from date-fns, falling back to ${EN_US}`
+    );
+    locale = (
+      await import(
+        /* webpackExclude: /\.js\.flow$/ */
+        `date-fns/locale/${EN_US}`
+      )
+    ).default;
+  }
   setDefaultOptions({
     locale,
   });


### PR DESCRIPTION
This date-fns locale bug is like a bossfight with multiple phases... hopefully this is the last phase 😅

Previously I fixed:
1. Other locales not loading at all https://github.com/LemmyNet/lemmy-ui/pull/1672
2. Locales like `xx-XX` (eg: `fr-FR`) failing to work, because for these date-fns expects just `xx` https://github.com/LemmyNet/lemmy-ui/pull/1721

These fixed the problem for most users, but turns out there are some locales out there which date-fns simply doesn't have support for. One example: `es-MX`. **For these users, the import still fails and Lemmy is still broken.**

This PR adds a fallback import of `en-US` when the user's locale is not availabe in date-fns.