### PR TITLE
Fix DM replies not working

### DIFF
--- a/src/shared/components/private_message/private-message.tsx
+++ b/src/shared/components/private_message/private-message.tsx
@@ -284,7 +284,6 @@ export class PrivateMessage extends Component<
           <div className="row">
             <div className="col-sm-6">
               <PrivateMessageForm
-                privateMessageView={message_view}
                 replyType={true}
                 recipient={otherPerson}
                 onCreate={this.props.onCreate}


### PR DESCRIPTION
The `PrivateMessageForm` decides whether it's being used for editing a DM or replying to a DM based on whether `privateMessageView` is `undefined`.

Currently in rc7, replying to private messages is impossible, as `privateMessageView` is passed in even when replying. Clicking the reply icon opens up an edit form, and saving this edit form generates an error (because you can't edit another person's DM).

This PR fixes the bug by removing `privateMessageView` from replies.
