### PR TITLE
Fix markdown editor quote bugs

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -702,18 +702,20 @@ export class MarkdownTextArea extends Component<
   quoteInsert() {
     const textarea: any = document.getElementById(this.id);
     const selectedText = window.getSelection()?.toString();
-    const { content } = this.state;
+    let { content } = this.state;
     if (selectedText) {
       const quotedText =
         selectedText
           .split("\n")
           .map(t => `> ${t}`)
           .join("\n") + "\n\n";
+
       if (!content) {
-        this.setState({ content: "" });
+        content = "";
       } else {
-        this.setState({ content: `${content}\n` });
+        content = `${content}\n\n`;
       }
+
       this.setState({
         content: `${content}${quotedText}`,
       });


### PR DESCRIPTION
Currently, when using the quote functionality in markdown editors (by highlighting some text before clicking reply/comment), the editor inserts "undefined" in front of quoted text:

![Screenshot 2023-07-01 at 19 44 15](https://github.com/LemmyNet/lemmy-ui/assets/5356547/cfc8ac02-2111-4786-9106-10261d40cbca)

This is due to a bug in the code which handles existing content in case of a quote being used. This PR fixes that bug.

(This PR also fixes the quoted text appearing appended on the end of the last line when editing existing messages)