### PR TITLE
Use Join Lemmy hostname as link text in footer

### DIFF
--- a/src/shared/components/app/footer.tsx
+++ b/src/shared/components/app/footer.tsx
@@ -60,7 +60,7 @@ export class Footer extends Component<FooterProps, any> {
             <li className="nav-item">
               <a className="nav-link" href={joinLemmyUrl}>
                 {myAuth()
-                  ? "join-lemmy.org"
+                  ? new URL(joinLemmyUrl).hostname
                   : I18NextService.i18n.t("join_lemmy")}
               </a>
             </li>

--- a/src/shared/components/app/footer.tsx
+++ b/src/shared/components/app/footer.tsx
@@ -1,3 +1,4 @@
+import { myAuth } from "@utils/app";
 import { Component } from "inferno";
 import { NavLink } from "inferno-router";
 import { GetSiteResponse } from "lemmy-js-client";
@@ -58,7 +59,9 @@ export class Footer extends Component<FooterProps, any> {
             </li>
             <li className="nav-item">
               <a className="nav-link" href={joinLemmyUrl}>
-                {I18NextService.i18n.t("join_lemmy")}
+                {myAuth()
+                  ? "join-lemmy.org"
+                  : I18NextService.i18n.t("join_lemmy")}
               </a>
             </li>
           </ul>

--- a/src/shared/components/app/footer.tsx
+++ b/src/shared/components/app/footer.tsx
@@ -1,4 +1,3 @@
-import { myAuth } from "@utils/app";
 import { Component } from "inferno";
 import { NavLink } from "inferno-router";
 import { GetSiteResponse } from "lemmy-js-client";
@@ -59,9 +58,7 @@ export class Footer extends Component<FooterProps, any> {
             </li>
             <li className="nav-item">
               <a className="nav-link" href={joinLemmyUrl}>
-                {myAuth()
-                  ? new URL(joinLemmyUrl).hostname
-                  : I18NextService.i18n.t("join_lemmy")}
+                {new URL(joinLemmyUrl).hostname}
               </a>
             </li>
           </ul>


### PR DESCRIPTION
I think it makes sense to keep a link to the Join Lemmy website even though there's a logged in user. There's plenty of other useful info on that website beyond just joining Lemmy.

Using the URL avoids the phrase "Join Lemmy" and should indicate that you're navigating to said website.

Should address issue #1723 