### PR TITLE
Modify MXID regex to allow ports in hostname

### DIFF
--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -548,7 +548,7 @@ export class Settings extends Component<any, SettingsState> {
                 placeholder="@user:example.com"
                 value={this.state.saveUserSettingsForm.matrix_user_id}
                 onInput={linkEvent(this, this.handleMatrixUserIdChange)}
-                pattern="^@[A-Za-z0-9._=-]+:[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"
+                pattern="^@[A-Za-z0-9._=-]+:[A-Za-z0-9.-]+\.[A-Za-z]{2,}(:[0-9]{1,5})?$"
               />
             </div>
           </div>


### PR DESCRIPTION
This is the change in Lemmy UI that goes along with LemmyNet/lemmy#3441 which fixes #1726. I just updated the regex expression that validates Matrix user IDS to allow having ports in the hostname.

While this regex validates that the port is not over 5 digits, it does not validate that the port is not above 65535 while still being 5 digits, however my change on the server does validate this seperately. Since Lemmy UI accepts the subtly invalid input, but the server does not, this results in the save button seemingly not doing anything in that edge case. This is probably not optimal UX, but I don't think it matters in this case.