### PR TITLE
Add support for Command (⌘) key shortcuts on Markdown text areas

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -473,7 +473,7 @@ export class MarkdownTextArea extends Component<
   // Keybind handler
   // Keybinds inspired by github comment area
   handleKeyBinds(i: MarkdownTextArea, event: KeyboardEvent) {
-    if (event.ctrlKey) {
+    if (event.ctrlKey || event.metaKey) {
       switch (event.key) {
         case "k": {
           i.handleInsertLink(i, event);


### PR DESCRIPTION
On MacOS, Ctrl is less commonly used than Command (⌘).
Javascript expresses command as `metaKey`.

This allows for _either_ Ctrl or Command to be used in the Markdown text area.

Note that on Windows, on some browsers, the "windows" key is labeled as meta, so it would work on windows as well.

http://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey
