### PR TITLE
Update file input bg colors to match btn's in dark themes

### DIFF
--- a/src/assets/css/themes/darkly-compact.css
+++ b/src/assets/css/themes/darkly-compact.css
@@ -2169,11 +2169,12 @@ progress {
   opacity: 1;
 }
 .form-control::file-selector-button {
+  --bs-btn-bg: #444;
   padding: 0.375rem 0.75rem;
   margin: -0.375rem -0.75rem;
   margin-inline-end: 0.75rem;
   color: #fff;
-  background-color: var(--bs-tertiary-bg);
+  background-color: var(--bs-btn-bg);
   pointer-events: none;
   border-color: inherit;
   border-style: solid;
@@ -2188,7 +2189,8 @@ progress {
   }
 }
 .form-control:hover:not(:disabled):not([readonly])::file-selector-button {
-  background-color: var(--bs-secondary-bg);
+  --bs-btn-hover-bg: #3a3a3a;
+  background-color: var(--bs-btn-hover-bg);
 }
 
 .form-control-plaintext {

--- a/src/assets/css/themes/darkly-pureblack.css
+++ b/src/assets/css/themes/darkly-pureblack.css
@@ -2129,11 +2129,12 @@ progress {
   opacity: 1;
 }
 .form-control::file-selector-button {
+  --bs-btn-bg: #333;
   padding: 0.375rem 0.75rem;
   margin: -0.375rem -0.75rem;
   margin-inline-end: 0.75rem;
   color: #f3f3f3;
-  background-color: var(--bs-tertiary-bg);
+  background-color: var(--bs-btn-bg);
   pointer-events: none;
   border-color: inherit;
   border-style: solid;
@@ -2148,7 +2149,8 @@ progress {
   }
 }
 .form-control:hover:not(:disabled):not([readonly])::file-selector-button {
-  background-color: var(--bs-secondary-bg);
+  --bs-btn-hover-bg: #2b2b2b;
+  background-color: var(--bs-btn-hover-bg);
 }
 
 .form-control-plaintext {

--- a/src/assets/css/themes/darkly-red.css
+++ b/src/assets/css/themes/darkly-red.css
@@ -2153,11 +2153,12 @@ progress {
   opacity: 1;
 }
 .form-control::file-selector-button {
+  --bs-btn-bg: #444;
   padding: 0.375rem 0.75rem;
   margin: -0.375rem -0.75rem;
   margin-inline-end: 0.75rem;
   color: #fff;
-  background-color: var(--bs-tertiary-bg);
+  background-color: var(--bs-btn-bg);
   pointer-events: none;
   border-color: inherit;
   border-style: solid;
@@ -2172,7 +2173,8 @@ progress {
   }
 }
 .form-control:hover:not(:disabled):not([readonly])::file-selector-button {
-  background-color: var(--bs-secondary-bg);
+  --bs-btn-hover-bg: #3a3a3a;
+  background-color: var(--bs-btn-hover-bg);
 }
 
 .form-control-plaintext {

--- a/src/assets/css/themes/darkly.css
+++ b/src/assets/css/themes/darkly.css
@@ -2157,7 +2157,7 @@ progress {
   margin: -0.375rem -0.75rem;
   margin-inline-end: 0.75rem;
   color: #fff;
-  background-color: var(--bs-tertiary-bg);
+  background-color: var(--bs-gray-700);
   pointer-events: none;
   border-color: inherit;
   border-style: solid;
@@ -2172,16 +2172,18 @@ progress {
   }
 }
 .form-control:hover:not(:disabled):not([readonly])::file-selector-button {
-  background-color: var(--bs-secondary-bg);
+  --bs-btn-hover-bg: #3a3a3a;
+  background-color: var(--bs-btn-hover-bg);
 }
 
 .form-control-plaintext {
+  --bs-btn-bg: #444;
   display: block;
   width: 100%;
   padding: 0.375rem 0;
   margin-bottom: 0;
   line-height: 1.5;
-  color: var(--bs-body-color);
+  color: var(--bs-btn-bg);
   background-color: transparent;
   border: solid transparent;
   border-width: var(--bs-border-width) 0;


### PR DESCRIPTION
Opting to use the CSS variables for clarity instead of hardcoding the values. The name of the variables should hopefully provide context to why these are being set then.

Addresses issue #1774  