### PR TITLE
fix: Add data-bs-theme attribute for user dark/light modes

### DIFF
--- a/src/shared/components/app/app.tsx
+++ b/src/shared/components/app/app.tsx
@@ -1,10 +1,11 @@
 import { isAuthPath, setIsoData } from "@utils/app";
+import { dataBsTheme } from "@utils/browser";
 import { Component, RefObject, createRef, linkEvent } from "inferno";
 import { Provider } from "inferno-i18next-dess";
 import { Route, Switch } from "inferno-router";
 import { IsoDataOptionalSite } from "../../interfaces";
 import { routes } from "../../routes";
-import { FirstLoadService, I18NextService } from "../../services";
+import { FirstLoadService, I18NextService, UserService } from "../../services";
 import AuthGuard from "../common/auth-guard";
 import ErrorGuard from "../common/error-guard";
 import { ErrorPage } from "./error-page";
@@ -25,6 +26,13 @@ export class App extends Component<any, any> {
     event.preventDefault();
     this.mainContentRef.current?.focus();
   }
+
+  user = UserService.Instance.myUserInfo;
+
+  componentDidMount() {
+    this.setState({ bsTheme: dataBsTheme(this.user) });
+  }
+
   render() {
     const siteRes = this.isoData.site_res;
     const siteView = siteRes?.site_view;
@@ -32,7 +40,11 @@ export class App extends Component<any, any> {
     return (
       <>
         <Provider i18next={I18NextService.i18n}>
-          <div id="app" className="lemmy-site">
+          <div
+            id="app"
+            className="lemmy-site"
+            data-bs-theme={this?.state?.bsTheme}
+          >
             <button
               type="button"
               className="btn skip-link bg-light position-absolute start-0 z-3"

--- a/src/shared/components/app/app.tsx
+++ b/src/shared/components/app/app.tsx
@@ -43,7 +43,7 @@ export class App extends Component<any, any> {
           <div
             id="app"
             className="lemmy-site"
-            data-bs-theme={this?.state?.bsTheme}
+            data-bs-theme={this.state?.bsTheme}
           >
             <button
               type="button"

--- a/src/shared/utils/browser/data-bs-theme.ts
+++ b/src/shared/utils/browser/data-bs-theme.ts
@@ -1,0 +1,11 @@
+import isDark from "./is-dark";
+
+export default function dataBsTheme(user) {
+  return (isDark() && user?.local_user_view.local_user.theme === "browser") ||
+    (user &&
+      ["darkly", "darkly-red", "darkly-pureblack"].includes(
+        user.local_user_view.local_user.theme
+      ))
+    ? "dark"
+    : "light";
+}

--- a/src/shared/utils/browser/index.ts
+++ b/src/shared/utils/browser/index.ts
@@ -1,5 +1,7 @@
 import canShare from "./can-share";
+import dataBsTheme from "./data-bs-theme";
 import isBrowser from "./is-browser";
+import isDark from "./is-dark";
 import loadCss from "./load-css";
 import restoreScrollPosition from "./restore-scroll-position";
 import saveScrollPosition from "./save-scroll-position";
@@ -7,7 +9,9 @@ import share from "./share";
 
 export {
   canShare,
+  dataBsTheme,
   isBrowser,
+  isDark,
   loadCss,
   restoreScrollPosition,
   saveScrollPosition,

--- a/src/shared/utils/browser/is-dark.ts
+++ b/src/shared/utils/browser/is-dark.ts
@@ -1,0 +1,7 @@
+import isBrowser from "./is-browser";
+
+export default function isDark() {
+  return (
+    isBrowser() && window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}


### PR DESCRIPTION
Fixes #1774

## Before

<img width="544" alt="Screenshot 2023-07-03 at 12 29 08 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/5ebe415c-2b8d-4d18-ab62-3450d717ec38">



## After

<img width="525" alt="Screenshot 2023-07-03 at 12 26 22 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/c510a77d-29bf-4c6b-bd64-70df102512c5">
