### PR TITLE
fix: Fix comment collapse and vote buttons not having focus style

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -299,7 +299,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
           >
             <div className="d-flex flex-wrap align-items-center text-muted small">
               <button
-                className="btn btn-sm text-muted me-2"
+                className="btn btn-sm btn-link text-muted me-2"
                 onClick={linkEvent(this, this.handleCommentCollapse)}
                 aria-label={this.expandText}
                 data-tippy-content={this.expandText}

--- a/src/shared/components/common/vote-buttons.tsx
+++ b/src/shared/components/common/vote-buttons.tsx
@@ -113,7 +113,7 @@ export class VoteButtonsCompact extends Component<
       <>
         <button
           type="button"
-          className={`btn-animate btn py-0 px-1 ${
+          className={`btn btn-animate btn-sm btn-link py-0 px-1 ${
             this.props.my_vote === 1 ? "text-info" : "text-muted"
           }`}
           data-tippy-content={tippy(this.props.counts)}
@@ -137,7 +137,7 @@ export class VoteButtonsCompact extends Component<
         {this.props.enableDownvotes && (
           <button
             type="button"
-            className={`ms-2 btn-animate btn py-0 px-1 ${
+            className={`ms-2 btn btn-sm btn-link btn-animate btn py-0 px-1 ${
               this.props.my_vote === -1 ? "text-danger" : "text-muted"
             }`}
             onClick={linkEvent(this, handleDownvote)}


### PR DESCRIPTION
## Description

Comment collapse and vote buttons were missing focus borders. This fixes that.

## Screenshots

### Before

<img width="457" alt="Screenshot 2023-07-03 at 2 23 45 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/35b48b65-56c3-404f-81b7-97a96ff9c2d5">


### After

<img width="361" alt="Screenshot 2023-07-03 at 2 17 18 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/77f8d6fc-7bc0-4c1b-a913-89430ad08b9f">
<img width="424" alt="Screenshot 2023-07-03 at 2 17 14 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/4fb1dfb1-4e5b-4262-89e6-ae0054f8d85a">
<img width="467" alt="Screenshot 2023-07-03 at 2 17 09 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/1da4b028-e847-4d29-9715-58ca3b7669a2">
