### PR TITLE
feat: Subtler user badge style

### DIFF
--- a/src/shared/components/common/user-badges.tsx
+++ b/src/shared/components/common/user-badges.tsx
@@ -53,7 +53,7 @@ export class UserBadges extends Component<UserBadgesProps> {
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("banned"),
                 tooltip: I18NextService.i18n.t("banned"),
-                classes: "text-bg-danger",
+                classes: "text-danger border border-danger",
                 shrink: false,
               })}
             </span>
@@ -63,7 +63,7 @@ export class UserBadges extends Component<UserBadgesProps> {
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("deleted"),
                 tooltip: I18NextService.i18n.t("deleted"),
-                classes: "text-bg-danger",
+                classes: "text-danger border border-danger",
                 shrink: false,
               })}
             </span>
@@ -74,7 +74,7 @@ export class UserBadges extends Component<UserBadgesProps> {
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("op").toUpperCase(),
                 tooltip: I18NextService.i18n.t("creator"),
-                classes: "text-bg-info",
+                classes: "text-info border border-info",
                 shrink: false,
               })}
             </span>
@@ -84,7 +84,7 @@ export class UserBadges extends Component<UserBadgesProps> {
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("mod"),
                 tooltip: I18NextService.i18n.t("mod"),
-                classes: "text-bg-primary",
+                classes: "text-primary border border-primary",
               })}
             </span>
           )}
@@ -93,7 +93,7 @@ export class UserBadges extends Component<UserBadgesProps> {
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("admin"),
                 tooltip: I18NextService.i18n.t("admin"),
-                classes: "text-bg-danger",
+                classes: "text-danger border border-danger",
               })}
             </span>
           )}


### PR DESCRIPTION
## Description

Making user badges styles a little subtler. Open to comment.

## Screenshots

### Before

<img width="636" alt="Screenshot 2023-07-04 at 12 31 14 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/8cde016d-d336-4a6e-9732-b144d55fac49">
<img width="567" alt="Screenshot 2023-07-04 at 12 30 58 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/80575944-7918-41c1-bddd-f37c2367d31e">


### After
<img width="641" alt="Screenshot 2023-07-04 at 12 30 37 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/2383afcd-80cd-40e4-9d5a-18af9baa43ee">
<img width="609" alt="Screenshot 2023-07-04 at 12 30 28 AM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/088fe17d-ec66-4114-9f9f-18972886b8f8">

