### PR TITLE
fix: Make new comment indicator easier to distinguish

### DIFF
--- a/src/assets/css/themes/_variables.darkly.scss
+++ b/src/assets/css/themes/_variables.darkly.scss
@@ -19,7 +19,7 @@ $cyan: #3498db;
 $primary: $green;
 $secondary: $gray-700;
 $success: $green;
-$dark: $gray-400;
+$dark: $gray-300;
 
 $body-color: $gray-300;
 $body-bg: $gray-900;

--- a/src/assets/css/themes/_variables.darkly.scss
+++ b/src/assets/css/themes/_variables.darkly.scss
@@ -19,7 +19,7 @@ $cyan: #3498db;
 $primary: $green;
 $secondary: $gray-700;
 $success: $green;
-$dark: $gray-300;
+$dark: $gray-400;
 
 $body-color: $gray-300;
 $body-bg: $gray-900;

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -760,7 +760,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         {this.unreadCount && (
           <>
             {" "}
-            <span className="fst-italic">
+            <span className="badge text-bg-info">
               ({this.unreadCount} {I18NextService.i18n.t("new")})
             </span>
           </>


### PR DESCRIPTION
## Description

The "(2 new)" comments indicator is too hard to miss now that it's just gray. This changes that.

## Screenshots

### Before
<img width="633" alt="Screenshot 2023-07-04 at 1 12 40 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/7981e820-803b-46ac-873e-ed8611e742c0">
<img width="670" alt="Screenshot 2023-07-04 at 1 12 24 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/1f2e2e2f-430e-46a1-ab25-d944440e2a28">



### After
<img width="747" alt="Screenshot 2023-07-04 at 1 11 31 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/2c8eb86d-9d95-4a19-a807-935fb3cfa0ef">
<img width="807" alt="Screenshot 2023-07-04 at 1 11 20 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/2e56f12c-67d9-497e-b20f-6b90ab1a8280">

