### PR TITLE
fix: Fix mobile thumbnail being too small

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -204,6 +204,11 @@ blockquote {
   height: 5rem;
 }
 
+.mobile-thumbnail-container .thumbnail {
+  width: 100%;
+  height: auto;
+}
+
 .thumbnail svg {
   height: 1.25rem;
   width: 1.25rem;

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -1327,10 +1327,10 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const post = this.postView.post;
     return post.thumbnail_url || (post.url && isImage(post.url)) ? (
       <div className="row">
-        <div className={`${this.state.imageExpanded ? "col-12" : "col-8"}`}>
+        <div className={`${this.state.imageExpanded ? "col-12" : "col-9"}`}>
           {this.postTitleLine()}
         </div>
-        <div className="col-4">
+        <div className="col-3 mobile-thumbnail-container">
           {/* Post thumbnail */}
           {!this.state.imageExpanded && this.thumbnail()}
         </div>


### PR DESCRIPTION
## Description

Mobile thumbnails weren't taking up their full width; this fixes that.

## Screenshots

### Before

<img width="576" alt="Screenshot 2023-07-04 at 1 19 11 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/7ce0bd1b-9352-4d61-a255-2c9a6a876837">


### After

<img width="575" alt="Screenshot 2023-07-04 at 1 18 30 PM" src="https://github.com/LemmyNet/lemmy-ui/assets/643417/d93a2592-3d45-44c2-b688-42833a79180f">

