### PR TITLE
fix: Adjust sidebar banner to wrap bellow the title

### DIFF
--- a/src/shared/components/common/banner-icon-header.tsx
+++ b/src/shared/components/common/banner-icon-header.tsx
@@ -16,7 +16,7 @@ export class BannerIconHeader extends Component<BannerIconHeaderProps, any> {
     const icon = this.props.icon;
     return (
       (banner || icon) && (
-        <div className="banner-icon-header position-relative mb-2">
+        <div className="banner-icon-header position-relative mb-2 mx-auto">
           {banner && <PictrsImage src={banner} banner alt="" />}
           {icon && (
             <PictrsImage

--- a/src/shared/components/common/banner-icon-header.tsx
+++ b/src/shared/components/common/banner-icon-header.tsx
@@ -16,7 +16,7 @@ export class BannerIconHeader extends Component<BannerIconHeaderProps, any> {
     const icon = this.props.icon;
     return (
       (banner || icon) && (
-        <div className="banner-icon-header position-relative mb-2 mx-auto">
+        <div className="banner-icon-header position-relative mb-2">
           {banner && <PictrsImage src={banner} banner alt="" />}
           {icon && (
             <PictrsImage

--- a/src/shared/components/home/site-sidebar.tsx
+++ b/src/shared/components/home/site-sidebar.tsx
@@ -33,7 +33,7 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
       <div className="site-sidebar accordion">
         <section id="sidebarInfo" className="card border-secondary mb-3">
           <header
-            className="card-header d-flex align-items-center"
+            className="card-header d-flex align-items-center flex-wrap"
             id="sidebarInfoHeader"
           >
             {this.siteName()}

--- a/src/shared/components/home/site-sidebar.tsx
+++ b/src/shared/components/home/site-sidebar.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { Component, linkEvent } from "inferno";
 import { PersonView, Site, SiteAggregates } from "lemmy-js-client";
 import { mdToHtml } from "../../markdown";
@@ -51,7 +52,7 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
 
   siteName() {
     return (
-      <div className={!this.state.collapsed ? "mb-2" : undefined}>
+      <div className={classNames({ "mb-2": !this.state.collapsed })}>
         <h5 className="mb-0 d-inline">{this.props.site.name}</h5>
         {!this.props.isMobile && (
           <button

--- a/src/shared/components/home/site-sidebar.tsx
+++ b/src/shared/components/home/site-sidebar.tsx
@@ -32,10 +32,7 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
     return (
       <div className="site-sidebar accordion">
         <section id="sidebarInfo" className="card border-secondary mb-3">
-          <header
-            className="card-header d-flex align-items-center flex-wrap"
-            id="sidebarInfoHeader"
-          >
+          <header className="card-header" id="sidebarInfoHeader">
             {this.siteName()}
             {!this.state.collapsed && (
               <BannerIconHeader banner={this.props.site.banner} />
@@ -54,7 +51,7 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
 
   siteName() {
     return (
-      <>
+      <div className={!this.state.collapsed ? "mb-2" : undefined}>
         <h5 className="mb-0 d-inline">{this.props.site.name}</h5>
         {!this.props.isMobile && (
           <button
@@ -83,7 +80,7 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
             )}
           </button>
         )}
-      </>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Description
Fixes #1607 

Makes it so that the sidebar and banner don't appear in the same row.



## Screenshots

### Before

![Before](https://user-images.githubusercontent.com/6192223/248788563-6eed85c1-5218-4e25-bfe7-54643deb4914.png)

### After

![Screenshot 2023-07-04 at 21 36 25](https://github.com/LemmyNet/lemmy-ui/assets/46496055/464b6264-d000-4a22-a621-ba8f6dd55a99)
