### PR TITLE
Added distinguished check for isMod & isAdmin comment user badges

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -319,8 +319,8 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
               <UserBadges
                 classNames="ms-1"
                 isPostCreator={this.isPostCreator}
-                isMod={isMod_}
-                isAdmin={isAdmin_}
+                isMod={isMod_ && cv.comment.distinguished}
+                isAdmin={isAdmin_ && cv.comment.distinguished}
                 isBot={cv.creator.bot_account}
               />
 


### PR DESCRIPTION
## Description

Added a distinguished check to the isMod and isAdmin UserBadges on comments so they will only appear when speaking as a moderator.

This will fix the comment side of  #1828 

## Screenshots

### Before
![before undistinguished](https://github.com/LemmyNet/lemmy-ui/assets/16372547/6395251d-2c69-4f02-ad33-72fc853e18a2)

### After
![after undistinguished](https://github.com/LemmyNet/lemmy-ui/assets/16372547/edd21abb-c965-477c-bde0-112274ee20e8)
![before undistinguished](https://github.com/LemmyNet/lemmy-ui/assets/16372547/0201e837-65eb-44b7-94b1-58bd3055173a)
