### PR TITLE
robots.txt: Disallow /modlog since it is not relevant for bots

### DIFF
--- a/src/server/handlers/robots-handler.ts
+++ b/src/server/handlers/robots-handler.ts
@@ -15,5 +15,6 @@ export default async ({ res }: { res: Response }) => {
   Disallow: /admin
   Disallow: /password_change
   Disallow: /search/
+  Disallow: /modlog
   `);
 };


### PR DESCRIPTION
## Description

Adds Disallow to the /modlog since it is not relevant for bots and as mentioned on /modlog the content may be disturbing. If search engines index the content on this page, it may negatively affect the Lemmy instance rank.
