### PR TITLE
Update post listing to prefer local image when available

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -310,16 +310,10 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const url = post.url;
     const thumbnail = post.thumbnail_url;
 
-    if (url && isImage(url)) {
-      if (url.includes("pictrs")) {
-        return url;
-      } else if (thumbnail) {
-        return thumbnail;
-      } else {
-        return url;
-      }
-    } else if (thumbnail) {
+    if (thumbnail) {
       return thumbnail;
+    } else if (url && isImage(url)) {
+      return url;
     } else {
       return undefined;
     }


### PR DESCRIPTION
## Description

Currently, the backend is copying images from federated posts locally and providing the URL as `thumbnail_url`. These images are mostly unused as the UI is preferring to use the post `url`, which in the case of images are from the originating instance.

This changes the logic on the UI to prefer the `thumbnail_url` of the local instance. It should help reduce the load on some of the larger instances while ensuring a good UX even if the origin instance is having connectivity issues. The change has been applied to my instance and appears to be working as intended. That said, I may be overlooking some edgecases.

I think this is ultimately a band-aid for now until we can come up with a more comprehensive solution for image proxying/caching on the backend.