### PR TITLE
Add theme option for compact that respects browser default

### DIFF
--- a/src/shared/components/app/theme.tsx
+++ b/src/shared/components/app/theme.tsx
@@ -21,13 +21,35 @@ export class Theme extends Component<Props> {
           />
         </Helmet>
       );
-    } else if (this.props.defaultTheme != "browser") {
+    } else if (
+      this.props.defaultTheme != "browser" &&
+      this.props.defaultTheme != "browser-compact"
+    ) {
       return (
         <Helmet>
           <link
             rel="stylesheet"
             type="text/css"
             href={`/css/themes/${this.props.defaultTheme}.css`}
+          />
+        </Helmet>
+      );
+    } else if (this.props.defaultTheme == "browser-compact") {
+      return (
+        <Helmet>
+          <link
+            rel="stylesheet"
+            type="text/css"
+            href="/css/themes/litely-compact.css"
+            id="default-light"
+            media="(prefers-color-scheme: light)"
+          />
+          <link
+            rel="stylesheet"
+            type="text/css"
+            href="/css/themes/darkly-compact.css"
+            id="default-dark"
+            media="(prefers-color-scheme: no-preference), (prefers-color-scheme: dark)"
           />
         </Helmet>
       );

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -411,6 +411,9 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
               <option value="browser">
                 {I18NextService.i18n.t("browser_default")}
               </option>
+              <option value="browser-compact">
+                {I18NextService.i18n.t("browser_default_compact")}
+              </option>
               {this.props.themeList?.map(theme => (
                 <option key={theme} value={theme}>
                   {theme}

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -596,6 +596,9 @@ export class Settings extends Component<any, SettingsState> {
                 <option value="browser">
                   {I18NextService.i18n.t("browser_default")}
                 </option>
+                <option value="browser-compact">
+                  {I18NextService.i18n.t("browser_default_compact")}
+                </option>
                 <option disabled aria-hidden="true">
                   ──
                 </option>
@@ -634,6 +637,9 @@ export class Settings extends Component<any, SettingsState> {
                 </option>
                 <option value="browser">
                   {I18NextService.i18n.t("browser_default")}
+                </option>
+                <option value="browser-compact">
+                  {I18NextService.i18n.t("browser_default_compact")}
                 </option>
                 {this.state.themeList.map(theme => (
                   <option key={theme} value={theme}>


### PR DESCRIPTION
## Description

Allows setting the default theme as `compact` while respecting the browser default.

Related: https://github.com/LemmyNet/lemmy-translations/pull/82