### PR TITLE
Add Toast Messages for Bad Logins

### DIFF
--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -169,14 +169,8 @@ export class Login extends Component<any, State> {
             i.setState({ showTotp: true });
             toast(I18NextService.i18n.t("enter_two_factor_code"), "info");
           }
-          if (loginRes.msg === "couldnt_find_that_username_or_email") {
-            toast(
-              I18NextService.i18n.t("couldnt_find_that_username_or_email"),
-              "danger"
-            );
-          }
-          if (loginRes.msg === "password_incorrect") {
-            toast(I18NextService.i18n.t("password_incorrect"), "danger");
+          if (loginRes.msg === "incorrect_login") {
+            toast(I18NextService.i18n.t("incorrect_login"), "danger");
           }
 
           i.setState({ loginRes: { state: "failed", msg: loginRes.msg } });

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -169,6 +169,15 @@ export class Login extends Component<any, State> {
             i.setState({ showTotp: true });
             toast(I18NextService.i18n.t("enter_two_factor_code"), "info");
           }
+          if (loginRes.msg === "couldnt_find_that_username_or_email") {
+            toast(
+              I18NextService.i18n.t("couldnt_find_that_username_or_email"),
+              "danger"
+            );
+          }
+          if (loginRes.msg === "password_incorrect") {
+            toast(I18NextService.i18n.t("password_incorrect"), "danger");
+          }
 
           i.setState({ loginRes: { state: "failed", msg: loginRes.msg } });
           break;


### PR DESCRIPTION
## Description

Right now if you try to login and you provide an unknown username/email or a wrong password, you will get no toast message. This PR adds toast messages for those scenarios and uses the messages already found in `lemmy-translations`.

## Screenshots

![image](https://github.com/LemmyNet/lemmy-ui/assets/8102129/b77e3767-ad8d-4be0-b410-754f0f7d7a12)
