### PR TITLE
Use canonical URLs

### DIFF
--- a/src/shared/components/common/html-tags.tsx
+++ b/src/shared/components/common/html-tags.tsx
@@ -8,6 +8,7 @@ import { I18NextService } from "../../services";
 interface HtmlTagsProps {
   title: string;
   path: string;
+  canonicalPath?: string;
   description?: string;
   image?: string;
 }
@@ -16,6 +17,8 @@ interface HtmlTagsProps {
 export class HtmlTags extends Component<HtmlTagsProps, any> {
   render() {
     const url = httpExternalPath(this.props.path);
+    const canonicalUrl =
+      this.props.canonicalPath ?? httpExternalPath(this.props.path);
     const desc = this.props.description;
     const image = this.props.image;
 
@@ -29,6 +32,8 @@ export class HtmlTags extends Component<HtmlTagsProps, any> {
         {["og:url", "twitter:url"].map(u => (
           <meta key={u} property={u} content={url} />
         ))}
+
+        <link rel="canonical" href={canonicalUrl} />
 
         {/* Open Graph / Facebook */}
         <meta property="og:type" content="website" />

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -312,6 +312,7 @@ export class Community extends Component<
             <HtmlTags
               title={this.documentTitle}
               path={this.context.router.route.match.url}
+              canonicalPath={res.community_view.community.actor_id}
               description={res.community_view.community.description}
               image={res.community_view.community.icon}
             />

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -324,6 +324,7 @@ export class Profile extends Component<
               <HtmlTags
                 title={this.documentTitle}
                 path={this.context.router.route.match.url}
+                canonicalPath={personRes.person_view.person.actor_id}
                 description={personRes.person_view.person.bio}
                 image={personRes.person_view.person.avatar}
               />

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -353,6 +353,7 @@ export class Post extends Component<any, PostState> {
               <HtmlTags
                 title={this.documentTitle}
                 path={this.context.router.route.match.url}
+                canonicalPath={res.post_view.post.ap_id}
                 image={this.imageTag}
                 description={res.post_view.post.body}
               />

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -466,6 +466,10 @@ export class Search extends Component<any, SearchState> {
         <HtmlTags
           title={this.documentTitle}
           path={this.context.router.route.match.url}
+          canonicalPath={
+            this.context.router.route.match.url +
+            this.context.router.route.location.search
+          }
         />
         <h1 className="h4 mb-4">{I18NextService.i18n.t("search")}</h1>
         {this.selects}


### PR DESCRIPTION
Fixes #1418

This links each community, user profile, and post to the original instance it was made on as canonical. It also links comments to their posts as canonical, since [that seems recommended](https://proposals.codidact.com/posts/288902) and that's what reddit does. The only pages with query parameters included in the canonical URL are search pages since those are pretty inherent to the page's content and since that seems to be what other sites do.
