### PR TITLE
Added newline button to markdown editor

### DIFF
--- a/src/assets/symbols.svg
+++ b/src/assets/symbols.svg
@@ -258,5 +258,8 @@
       <path d="M8.72046 10.6397L14.9999 7.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       <path d="M8.70605 13.353L15 16.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </symbol>
+    <symbol id="icon-newline" viewBox="0 0 24 24">
+      <path transform="rotate(90 12 12)" d="M18.293 11.293l-5.293 5.293v-11.586c0-0.552-0.448-1-1-1s-1 0.448-1 1v11.586l-5.293-5.293c-0.391-0.391-1.024-0.391-1.414 0s-0.391 1.024 0 1.414l7 7c0.092 0.092 0.202 0.166 0.324 0.217 0.245 0.101 0.521 0.101 0.766 0 0.118-0.049 0.228-0.121 0.324-0.217l7-7c0.391-0.391 0.391-1.024 0-1.414s-1.024-0.391-1.414 0z"></path>
+    </symbol>
   </defs>
 </svg>

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -213,6 +213,7 @@ export class MarkdownTextArea extends Component<
                   this.handleInsertSuperscript
                 )}
                 {this.getFormatButton("spoiler", this.handleInsertSpoiler)}
+                {this.getFormatButton("newline", this.handleInsertNewline)}
                 <a
                   href={markdownHelpUrl}
                   className="btn btn-sm btn-link rounded-0 text-muted fw-bold"
@@ -632,6 +633,17 @@ export class MarkdownTextArea extends Component<
   handleInsertBold(i: MarkdownTextArea, event: any) {
     event.preventDefault();
     i.simpleSurround("**");
+  }
+
+  handleInsertNewline(i: MarkdownTextArea, event: any) {
+    event.preventDefault();
+    const content = i.state.content ?? "";
+    const textarea: any = document.getElementById(i.id);
+
+    i.setState({
+      content: `${content}  \n`,
+    });
+    textarea.focus();
   }
 
   handleInsertItalic(i: MarkdownTextArea, event: any) {


### PR DESCRIPTION
## Description
- Added 'newline' button to markdown editor to add line break.
- Added newline svg (left pointing arrow this can be changed if there is a better suggestion for a newline icon)

Resolves: https://github.com/LemmyNet/lemmy-ui/issues/1856
Depends on: https://github.com/LemmyNet/lemmy-translations/pull/84
## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before
![Screenshot_20230709_020431-1](https://github.com/LemmyNet/lemmy-ui/assets/25917358/11b83177-8186-471b-b384-0a7b866ef437)

### After
![Screenshot_20230709_014353](https://github.com/LemmyNet/lemmy-ui/assets/25917358/357f5a92-206e-4c0c-bc4e-f8844543a8ef)

https://github.com/LemmyNet/lemmy-ui/assets/25917358/e9c7b03c-fa77-41a5-92c9-b709eaca7e73


