### PR TITLE
Add community name to featured post action in Modlog

### DIFF
--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -312,6 +312,7 @@ function renderModlogType({ type_, view }: ModlogType) {
       const {
         mod_feature_post: { featured, is_featured_community },
         post: { id, name },
+        community,
       } = view as ModFeaturePostView;
 
       return (
@@ -320,7 +321,12 @@ function renderModlogType({ type_, view }: ModlogType) {
           <span>
             Post <Link to={`/post/${id}`}>{name}</Link>
           </span>
-          <span>{is_featured_community ? " In Community" : " In Local"}</span>
+          <span>
+            {is_featured_community
+              ? " in community "
+              : " in Local, from community "}
+          </span>
+          <CommunityLink community={community} />
         </>
       );
     }
@@ -532,7 +538,7 @@ function renderModlogType({ type_, view }: ModlogType) {
 
       return (
         <>
-          <span>Purged a Post from from </span>
+          <span>Purged a Post from </span>
           <CommunityLink community={community} />
           {reason && (
             <span>


### PR DESCRIPTION
## Description

This PR adds the community name to the "Featured post" action in the Modlog, so we can avoid having to open the post to figure that out.

## Screenshots

### Before
<img width="831" alt="image" src="https://github.com/LemmyNet/lemmy-ui/assets/1769968/be4d56c1-8d1b-4d9a-a0fa-4f8cd5c6af8b">

### After
<img width="854" alt="image" src="https://github.com/LemmyNet/lemmy-ui/assets/1769968/d82c18a2-4f34-4b6a-8d0e-0ca9e39e3180">