### PR TITLE
Use the 'node' user instead of root while running in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ FROM node:alpine as runner
 COPY --from=builder /usr/src/app/dist /app/dist
 COPY --from=builder /usr/src/app/node_modules /app/node_modules
 
+RUN chown -R node:node /app
+
+USER node
 EXPOSE 1234
 WORKDIR /app
 CMD node dist/js/server.js


### PR DESCRIPTION
## Description
Rather than running lemmy-ui as the root user in the container, run it as the `node` user provided by the node runner image.

## Screenshots
N/A

### Before
The `node` process runs as `root`, which should be avoided if possible.

### After
The `node` lemmy-ui process runs as the `node` user.