### PR TITLE
improve CSP to prevent XSS

### DIFF
--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -10,7 +10,16 @@ export function setDefaultCsp({
 }) {
   res.setHeader(
     "Content-Security-Policy",
-    `default-src 'self'; manifest-src *; connect-src *; img-src * data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; form-action 'self'; base-uri 'self'; frame-src *; media-src * data:`
+    `default-src 'self';
+    manifest-src *;
+    connect-src *;
+    img-src * data:;
+    script-src 'self';
+    style-src 'self' 'unsafe-inline';
+    form-action 'self';
+    base-uri 'self';
+    frame-src *;
+    media-src * data:`.replace(/\s+/g, " ")
   );
 
   next();

--- a/src/server/utils/create-ssr-html.tsx
+++ b/src/server/utils/create-ssr-html.tsx
@@ -1,7 +1,6 @@
 import { getStaticDir } from "@utils/env";
 import { Helmet } from "inferno-helmet";
 import { renderToString } from "inferno-server";
-import serialize from "serialize-javascript";
 import sharp from "sharp";
 import { favIconPngUrl, favIconUrl } from "../../shared/config";
 import { ILemmyConfig, IsoDataOptionalSite } from "../../shared/interfaces";
@@ -59,8 +58,12 @@ export async function createSsrHtml(
     <!DOCTYPE html>
     <html ${helmet.htmlAttributes.toString()}>
     <head>
-    <script>window.isoData = ${serialize(isoData)}</script>
-    <script>window.lemmyConfig = ${serialize(config)}</script>
+    <script type="application/json" id="isoData">${JSON.stringify(
+      isoData
+    )}</script>
+    <script type="application/json" id="lemmyConfig">${JSON.stringify(
+      config
+    )}</script>
   
     <!-- A remote debugging utility for mobile -->
     ${erudaStr}

--- a/src/shared/utils/app/set-iso-data.ts
+++ b/src/shared/utils/app/set-iso-data.ts
@@ -6,6 +6,8 @@ export default function setIsoData<T extends RouteData>(
 ): IsoData<T> {
   // If its the browser, you need to deserialize the data from the window
   if (isBrowser()) {
-    return window.isoData;
+    const ele = document.getElementById("isoData");
+    if (!ele) throw Error("could not find iso data");
+    return JSON.parse(ele.textContent ?? "");
   } else return context.router.staticContext;
 }


### PR DESCRIPTION
## Description

This PR replaces the inline scripts with raw json, and adjusts the CSP header to forbid inline scripts and eval.

The previous serialize() function allowed serializing undefineds and functions and regexes, but I didn't actually see that being used anywhere.

I didn't see obvious breakage but idk if some random other component also uses inline scripts?

This works in prod mode of webpack but the default dev mode of webpack uses eval so either the header has to be changed for dev mode or the webpack compilation mode changed probably.