### PR TITLE
Fix CSP in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "analyze": "webpack --mode=none",
     "prebuild:dev": "yarn clean && node generate_translations.js",
-    "build:dev": "webpack --env LEMMY_UI_DISABLE_CSP=true --env COMMIT_HASH=$(git rev-parse --short HEAD) --mode=development",
+    "build:dev": "webpack --env COMMIT_HASH=$(git rev-parse --short HEAD) --mode=development",
     "prebuild:prod": "yarn clean && node generate_translations.js",
     "build:prod": "webpack --env COMMIT_HASH=$(git rev-parse --short HEAD) --mode=production",
     "clean": "yarn run rimraf dist",

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -29,7 +29,11 @@ server.use(
 );
 server.use(setCacheControl);
 
-if (!process.env["LEMMY_UI_DISABLE_CSP"] && !process.env["LEMMY_UI_DEBUG"]) {
+if (
+  !process.env["LEMMY_UI_DISABLE_CSP"] &&
+  !process.env["LEMMY_UI_DEBUG"] &&
+  process.env["NODE_ENV"] !== "development"
+) {
   server.use(setDefaultCsp);
 }
 


### PR DESCRIPTION
## Description

I thought I had CSP properly disabled in dev mode in #1907, but turns out I was wrong (I think I had multiple solutions for this active parallel locally and I committed the wrong one)

This PR just disables CSP when `NODE_ENV=development` (which it is with build:dev)

Sorry if this caused any inconvenience for anybody!
