### PR TITLE
Remove invalid default option from language list

### DIFF
--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -596,9 +596,6 @@ export class Settings extends Component<any, SettingsState> {
                 <option value="browser">
                   {I18NextService.i18n.t("browser_default")}
                 </option>
-                <option value="browser-compact">
-                  {I18NextService.i18n.t("browser_default_compact")}
-                </option>
                 <option disabled aria-hidden="true">
                   ──
                 </option>


### PR DESCRIPTION
This was mistakenly added by me to the user's settings page for languages. See: https://github.com/LemmyNet/lemmy-ui/pull/1870

![Screenshot from 2023-07-11 16-24-08](https://github.com/LemmyNet/lemmy-ui/assets/137361180/9a4dd584-c2f4-44b4-8342-310fbf75cd94)
