### PR TITLE
Fix start_url and scope in web app manifest

### DIFF
--- a/src/server/utils/generate-manifest-json.ts
+++ b/src/server/utils/generate-manifest-json.ts
@@ -1,4 +1,3 @@
-import { getHttpBaseExternal } from "@utils/env";
 import { readFile } from "fs/promises";
 import { GetSiteResponse } from "lemmy-js-client";
 import path from "path";
@@ -21,15 +20,13 @@ export default async function ({
     local_site: { community_creation_admin_only },
   },
 }: GetSiteResponse) {
-  const url = getHttpBaseExternal();
-
   const icon = site.icon ? await fetchIconPng(site.icon) : null;
 
   return {
     name: site.name,
     description: site.description ?? "A link aggregator for the fediverse",
-    start_url: url,
-    scope: url,
+    start_url: "/",
+    scope: "/",
     display: "standalone",
     id: "/",
     background_color: "#222222",


### PR DESCRIPTION
## Description

<!-- Please describe exactly what this PR changes, including URLs and issue
numbers. If it fixes an issue, add "Fixes #XXXX" -->
Lemmy's manifest is currently broken.
https://lemmy.world/manifest.webmanifest serves `"start_url":"http://lemmy.world","scope":"http://lemmy.world"` which doesn't match the scheme and is rejected by the browser.
This change makes it use "/" to keep things simple.
