### PR TITLE
Allow sorting on /communities

### DIFF
--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -20,6 +20,7 @@ import {
   ListCommunities,
   ListCommunitiesResponse,
   ListingType,
+  SortType,
 } from "lemmy-js-client";
 import { InitialFetchRequest } from "../../interfaces";
 import { FirstLoadService, I18NextService } from "../../services";
@@ -28,6 +29,7 @@ import { HtmlTags } from "../common/html-tags";
 import { Spinner } from "../common/icon";
 import { ListingTypeSelect } from "../common/listing-type-select";
 import { Paginator } from "../common/paginator";
+import { SortSelect } from "../common/sort-select";
 import { CommunityLink } from "./community-link";
 
 const communityLimit = 50;
@@ -45,11 +47,16 @@ interface CommunitiesState {
 
 interface CommunitiesProps {
   listingType: ListingType;
+  sort: SortType;
   page: number;
 }
 
 function getListingTypeFromQuery(listingType?: string): ListingType {
   return listingType ? (listingType as ListingType) : "Local";
+}
+
+function getSortTypeFromQuery(type?: string): SortType {
+  return type ? (type as SortType) : "TopMonth";
 }
 
 export class Communities extends Component<any, CommunitiesState> {
@@ -64,6 +71,7 @@ export class Communities extends Component<any, CommunitiesState> {
   constructor(props: any, context: any) {
     super(props, context);
     this.handlePageChange = this.handlePageChange.bind(this);
+    this.handleSortChange = this.handleSortChange.bind(this);
     this.handleListingTypeChange = this.handleListingTypeChange.bind(this);
 
     // Only fetch the data if coming from another route
@@ -99,13 +107,13 @@ export class Communities extends Component<any, CommunitiesState> {
           </h5>
         );
       case "success": {
-        const { listingType, page } = this.getCommunitiesQueryParams();
+        const { listingType, sort, page } = this.getCommunitiesQueryParams();
         return (
           <div>
             <h1 className="h4 mb-4">
               {I18NextService.i18n.t("list_of_communities")}
             </h1>
-            <div className="row g-2 justify-content-between">
+            <div className="row g-2 row-cols-4 align-items-center">
               <div className="col-auto">
                 <ListingTypeSelect
                   type_={listingType}
@@ -113,6 +121,9 @@ export class Communities extends Component<any, CommunitiesState> {
                   showSubscribed
                   onChange={this.handleListingTypeChange}
                 />
+              </div>
+              <div className="col-auto me-auto">
+                <SortSelect sort={sort} onChange={this.handleSortChange} />
               </div>
               <div className="col-auto">{this.searchForm()}</div>
             </div>
@@ -252,12 +263,16 @@ export class Communities extends Component<any, CommunitiesState> {
     );
   }
 
-  async updateUrl({ listingType, page }: Partial<CommunitiesProps>) {
-    const { listingType: urlListingType, page: urlPage } =
-      this.getCommunitiesQueryParams();
+  async updateUrl({ listingType, sort, page }: Partial<CommunitiesProps>) {
+    const {
+      listingType: urlListingType,
+      sort: urlSort,
+      page: urlPage,
+    } = this.getCommunitiesQueryParams();
 
     const queryParams: QueryParams<CommunitiesProps> = {
       listingType: listingType ?? urlListingType,
+      sort: sort ?? urlSort,
       page: (page ?? urlPage)?.toString(),
     };
 
@@ -268,6 +283,10 @@ export class Communities extends Component<any, CommunitiesState> {
 
   handlePageChange(page: number) {
     this.updateUrl({ page });
+  }
+
+  handleSortChange(val: SortType) {
+    this.updateUrl({ sort: val, page: 1 });
   }
 
   handleListingTypeChange(val: ListingType) {
@@ -290,7 +309,7 @@ export class Communities extends Component<any, CommunitiesState> {
   }
 
   static async fetchInitialData({
-    query: { listingType, page },
+    query: { listingType, sort, page },
     client,
     auth,
   }: InitialFetchRequest<
@@ -298,7 +317,7 @@ export class Communities extends Component<any, CommunitiesState> {
   >): Promise<CommunitiesData> {
     const listCommunitiesForm: ListCommunities = {
       type_: getListingTypeFromQuery(listingType),
-      sort: "TopMonth",
+      sort: getSortTypeFromQuery(sort),
       limit: communityLimit,
       page: getPageFromString(page),
       auth: auth,
@@ -314,6 +333,7 @@ export class Communities extends Component<any, CommunitiesState> {
   getCommunitiesQueryParams() {
     return getQueryParams<CommunitiesProps>({
       listingType: getListingTypeFromQuery,
+      sort: getSortTypeFromQuery,
       page: getPageFromString,
     });
   }
@@ -334,12 +354,12 @@ export class Communities extends Component<any, CommunitiesState> {
   async refetch() {
     this.setState({ listCommunitiesResponse: { state: "loading" } });
 
-    const { listingType, page } = this.getCommunitiesQueryParams();
+    const { listingType, sort, page } = this.getCommunitiesQueryParams();
 
     this.setState({
       listCommunitiesResponse: await HttpService.client.listCommunities({
         type_: listingType,
-        sort: "TopMonth",
+        sort: sort,
         limit: communityLimit,
         page,
         auth: myAuth(),

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -113,7 +113,7 @@ export class Communities extends Component<any, CommunitiesState> {
             <h1 className="h4 mb-4">
               {I18NextService.i18n.t("list_of_communities")}
             </h1>
-            <div className="row g-2 row-cols-4 align-items-center">
+            <div className="row g-3 align-items-center mb-2">
               <div className="col-auto">
                 <ListingTypeSelect
                   type_={listingType}
@@ -235,10 +235,7 @@ export class Communities extends Component<any, CommunitiesState> {
 
   searchForm() {
     return (
-      <form
-        className="row mb-2"
-        onSubmit={linkEvent(this, this.handleSearchSubmit)}
-      >
+      <form className="row" onSubmit={linkEvent(this, this.handleSearchSubmit)}>
         <div className="col-auto">
           <input
             type="text"


### PR DESCRIPTION
## Description

Fixes [#3500 mistakenly filed on the main repo](https://github.com/LemmyNet/lemmy-ui/issues/1941) by simply adding a sort dropdown to /communities using the existing `SortSelect` element. The right-justification of the search bar is preserved and the default sort is still `TopMonth`. The one issue is that the question mark should link to an explanation of community sorting, but the linked page on join-lemmy ([03 Votes and Ranking](https://join-lemmy.org/docs/users/03-votes-and-ranking.html)) only talks about post and comment sorting.

The functionality for sorting communities is already present in the API, so this feels like a no-brainer once join-lemmy is updated, which I'm happy to do as well if it needs doing.

Also, just a minor note, this also fixes a small inaccuracy where the bottom margin for the selector row (`.mb-2`) was applied to the search bar instead of the entire row, which only acted correctly because the containing row was set to justify. The screenshots were taken before this fix so there's a few things off by a few pixels, but nothing really noticeable.

## Screenshots

Examples using lemmy.world (mobile screenshots taken using emulated 335x667 display on Firefox):

### Before
![image](https://github.com/LemmyNet/lemmy-ui/assets/2458686/643f36ed-9c03-4ab9-a4bc-a70adc6e6f07)
![image](https://github.com/LemmyNet/lemmy-ui/assets/2458686/0410e95d-39d5-45e8-978d-7d7d39779c0d)

### After
![image](https://github.com/LemmyNet/lemmy-ui/assets/2458686/941a057f-975b-49ef-8850-ec7dba55c55c)
![image](https://github.com/LemmyNet/lemmy-ui/assets/2458686/4153e97b-d065-4d52-9852-8ff2244eb0ec)
![image](https://github.com/LemmyNet/lemmy-ui/assets/2458686/c2b10d49-1742-4eb3-b1aa-8f1b49daa79f)
![image](https://github.com/LemmyNet/lemmy-ui/assets/2458686/915404c7-7a54-4f9f-a58c-2255df94e162)