### PR TITLE
Add RTL/BIDI to post text

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "markdown-it-ruby": "^0.1.1",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
+    "markdown-it-bidi": "^0.1.0",
     "mini-css-extract-plugin": "^2.7.5",
     "register-service-worker": "^1.7.2",
     "run-node-webpack-plugin": "^1.3.0",

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -8,6 +8,7 @@ import { CustomEmojiView } from "lemmy-js-client";
 import { default as MarkdownIt } from "markdown-it";
 import markdown_it_container from "markdown-it-container";
 // import markdown_it_emoji from "markdown-it-emoji/bare";
+import markdown_it_bidi from "markdown-it-bidi";
 import markdown_it_footnote from "markdown-it-footnote";
 import markdown_it_html5_embed from "markdown-it-html5-embed";
 import markdown_it_ruby from "markdown-it-ruby";
@@ -161,7 +162,8 @@ export function setupMarkdown() {
     .use(markdown_it_html5_embed, html5EmbedConfig)
     .use(markdown_it_container, "spoiler", spoilerConfig)
     .use(markdown_it_ruby)
-    .use(localInstanceLinkParser);
+    .use(localInstanceLinkParser)
+    .use(markdown_it_bidi);
   // .use(markdown_it_emoji, {
   //   defs: emojiDefs,
   // });
@@ -173,6 +175,7 @@ export function setupMarkdown() {
     .use(markdown_it_html5_embed, html5EmbedConfig)
     .use(markdown_it_container, "spoiler", spoilerConfig)
     .use(localInstanceLinkParser)
+    .use(markdown_it_bidi)
     // .use(markdown_it_emoji, {
     //   defs: emojiDefs,
     // })


### PR DESCRIPTION
## Description
This PR will add Bi Directional text and RTL support to posts text.
However it will not fix comments text direction because the plugin I'm using `markdown-it-bidi` by @ahangarha doesn't support lists yet.

Partially fixes #347

## Screenshots
### Before
![before](https://dl.hrkp.ir/lemmy-before.png)

### After
![after](https://dl.hrkp.ir/lemmy-after.png)