### PR TITLE
Expanded the RegEx to check if the title contains new line caracters. Should fix issue #1962

### DIFF
--- a/src/shared/utils/helpers/valid-title.ts
+++ b/src/shared/utils/helpers/valid-title.ts
@@ -2,14 +2,12 @@ export default function validTitle(title?: string): boolean {
   // Initial title is null, minimum length is taken care of by textarea's minLength={3}
   if (!title || title.length < 3) return true;
 
-
   /*
     Test if the Title is in a valid format:
-      (?=.*\S.*) checks if the title consits of only whitespace characters
+      (?=.*\S.*) checks if the title consists of only whitespace characters
       (?=^[^\r\n]+$) checks if the title contains newlines 
   */
   const regex = new RegExp(/(?=(.*\S.*))(?=^[^\r\n]+$)/, "g");
-
 
   return regex.test(title);
 }

--- a/src/shared/utils/helpers/valid-title.ts
+++ b/src/shared/utils/helpers/valid-title.ts
@@ -2,7 +2,14 @@ export default function validTitle(title?: string): boolean {
   // Initial title is null, minimum length is taken care of by textarea's minLength={3}
   if (!title || title.length < 3) return true;
 
-  const regex = new RegExp(/.*\S.*/, "g");
+
+  /*
+    Test if the Title is in a valid format:
+      (?=.*\S.*) checks if the title consits of only whitespace characters
+      (?=^[^\r\n]+$) checks if the title contains newlines 
+  */
+  const regex = new RegExp(/(?=(.*\S.*))(?=^[^\r\n]+$)/, "g");
+
 
   return regex.test(title);
 }


### PR DESCRIPTION
Should fix the issue #1962.
Also added Comments for clarity.

## Description

Expanded the RegEx in the validTitle helper function. 
Fixes #1962 

### Before
Invalid titles containing a new line character didn't return the correct value

### After
Invalid titles containing a new line character return the right value