### PR TITLE
Use showApubName in comment and post listings 

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -306,7 +306,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 />
               </button>
 
-              <PersonListing person={cv.creator} />
+              <PersonListing person={cv.creator} showApubName />
 
               {cv.comment.distinguished && (
                 <Icon icon="shield" inline classes="text-danger ms-1" />

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -401,7 +401,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
 
     return (
       <div className="small mb-1 mb-md-0">
-        <PersonListing person={post_view.creator} />
+        <PersonListing person={post_view.creator} showApubName />
         <UserBadges
           classNames="ms-1"
           isMod={this.creatorIsMod_}


### PR DESCRIPTION
## Description

This helps distinguish people from other instances which use a Display name and can help prevent impersonations which we've seen in the past.

Fixes https://github.com/LemmyNet/lemmy-ui/issues/1974

## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before
![image](https://github.com/LemmyNet/lemmy-ui/assets/39467792/f4237472-3c37-4789-b3a3-89170c70b77a)

### After
![image](https://github.com/LemmyNet/lemmy-ui/assets/39467792/2808e947-272f-41a5-be99-64f208a7544f)
