### PR TITLE
Allow limited set of markdown in title inline md rendering, fixes #1976

### DIFF
--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -23,6 +23,14 @@ export let md: MarkdownIt = new MarkdownIt();
 
 export let mdNoImages: MarkdownIt = new MarkdownIt();
 
+// Zero disables all rules.
+// Only explicitly allow a limited set of rules safe for use in post titles.
+export const mdLimited: MarkdownIt = new MarkdownIt("zero").enable([
+  "emphasis",
+  "backticks",
+  "strikethrough",
+]);
+
 export const customEmojis: EmojiMartCategory[] = [];
 
 export let customEmojisLookup: Map<string, CustomEmojiView> = new Map<
@@ -43,7 +51,7 @@ export function mdToHtmlNoImages(text: string) {
 }
 
 export function mdToHtmlInline(text: string) {
-  return { __html: md.renderInline(text) };
+  return { __html: mdLimited.renderInline(text) };
 }
 
 const spoilerConfig = {


### PR DESCRIPTION
## Description
Fixes #1976 by only allowing a very limited set of markdown rules for inline markdown rendering. 
Also fixes #1232

## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before
![image](https://github.com/LemmyNet/lemmy-ui/assets/2502190/f186c664-e113-42bd-9fa9-0af6727bebad)


### After
![image](https://github.com/LemmyNet/lemmy-ui/assets/2502190/5238836c-660b-425b-a315-c4ffb8f449c2)

