### PR TITLE
change dockerfile build to use a standard glibc image, LTS-Debian (and others)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /usr/src/app
 ENV npm_config_target_arch=x64
 ENV npm_config_target_platform=linux
 ENV npm_config_target_libc=glibc
-ENV NODE_ENV=production
 
 # Cache deps
 COPY package.json yarn.lock ./


### PR DESCRIPTION
Increasing performance and compatibility, changed entrypoint to dumb-init which allows the container to respect signals sent to kill/sighup/restart and moved the `chown` action to the copy action which reduces build time substantially. Use Docker buildkit when building `DOCKER_BUILDKIT=1 docker build`
