### PR TITLE
Allow selecting from all languages in person settings (fixes #1971)

### DIFF
--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -587,6 +587,7 @@ export class Settings extends Component<any, SettingsState> {
             selectedLanguageIds={selectedLangs}
             multiple={true}
             showLanguageWarning={true}
+            showAll={true}
             showSite
             onChange={this.handleDiscussionLanguageChange}
           />


### PR DESCRIPTION
## Description

The language selection in person settings currently only allows selecting from site languages. This doesnt make sense, as an instance may only allow eg German language for moderation purposes, but individual users still should be able to interact with remote content in different languages. This PR changes the selection to show all languages.
