### PR TITLE
Add moderator view button

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "inferno-router": "^8.2.2",
     "inferno-server": "^8.2.2",
     "jwt-decode": "^3.1.2",
-    "lemmy-js-client": "0.18.1",
+    "lemmy-js-client": "0.19.0-rc.1",
     "lodash.isequal": "^4.5.0",
     "markdown-it": "^13.0.1",
     "markdown-it-container": "^3.0.0",

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -284,7 +284,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
       node.comment_view.counts.child_count > 0;
 
     return (
-      <li className="comment">
+      <li className="comment list-unstyled">
         <article
           id={`comment-${cv.comment.id}`}
           className={classNames(`details comment-node py-2`, {
@@ -348,7 +348,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
               {showScores() && (
                 <>
                   <span
-                    className="me-1 fw-bold"
+                    className={`me-1 fw-bold ${this.scoreColor}`}
                     aria-label={I18NextService.i18n.t("number_of_points", {
                       count: Number(this.commentView.counts.score),
                       formattedCount: numToSI(this.commentView.counts.score),

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -118,6 +118,7 @@ interface HomeProps {
   dataType: DataType;
   sort: SortType;
   page: number;
+  moderatorView: boolean;
 }
 
 type HomeData = RouteDataResponse<{
@@ -179,12 +180,17 @@ function getSortTypeFromQuery(type?: string): SortType {
   return (type ? (type as SortType) : mySortType) ?? "Active";
 }
 
+function getModeratorViewFromQuery(moderatorView?: string): boolean {
+  return moderatorView?.toLowerCase() == "true";
+}
+
 const getHomeQueryParams = () =>
   getQueryParams<HomeProps>({
     sort: getSortTypeFromQuery,
     listingType: getListingTypeFromQuery,
     page: getPageFromString,
     dataType: getDataTypeFromQuery,
+    moderatorView: getModeratorViewFromQuery,
   });
 
 const MobileButton = ({
@@ -310,7 +316,13 @@ export class Home extends Component<any, HomeState> {
   static async fetchInitialData({
     client,
     auth,
-    query: { dataType: urlDataType, listingType, page: urlPage, sort: urlSort },
+    query: {
+      dataType: urlDataType,
+      listingType,
+      page: urlPage,
+      sort: urlSort,
+      moderatorView,
+    },
     site,
   }: InitialFetchRequest<QueryParams<HomeProps>>): Promise<HomeData> {
     const dataType = getDataTypeFromQuery(urlDataType);
@@ -333,6 +345,7 @@ export class Home extends Component<any, HomeState> {
         limit: fetchLimit,
         sort,
         saved_only: false,
+        moderator_view: moderatorView?.toLowerCase() == "true",
         auth,
       };
 
@@ -616,12 +629,19 @@ export class Home extends Component<any, HomeState> {
     );
   }
 
-  async updateUrl({ dataType, listingType, page, sort }: Partial<HomeProps>) {
+  async updateUrl({
+    dataType,
+    listingType,
+    page,
+    sort,
+    moderatorView,
+  }: Partial<HomeProps>) {
     const {
       dataType: urlDataType,
       listingType: urlListingType,
       page: urlPage,
       sort: urlSort,
+      moderatorView: urlModeratorView,
     } = getHomeQueryParams();
 
     const queryParams: QueryParams<HomeProps> = {
@@ -629,6 +649,7 @@ export class Home extends Component<any, HomeState> {
       listingType: listingType ?? urlListingType,
       page: (page ?? urlPage).toString(),
       sort: sort ?? urlSort,
+      moderatorView: (moderatorView ?? urlModeratorView).toString(),
     };
 
     this.props.history.push({
@@ -798,7 +819,8 @@ export class Home extends Component<any, HomeState> {
 
   async fetchData() {
     const auth = myAuth();
-    const { dataType, page, listingType, sort } = getHomeQueryParams();
+    const { dataType, page, listingType, sort, moderatorView } =
+      getHomeQueryParams();
 
     if (dataType === DataType.Post) {
       if (HomeCacheService.active) {
@@ -820,6 +842,7 @@ export class Home extends Component<any, HomeState> {
             saved_only: false,
             type_: listingType,
             auth,
+            moderator_view: moderatorView,
           }),
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5772,10 +5772,10 @@ leac@^0.6.0:
   resolved "https://registry.yarnpkg.com/leac/-/leac-0.6.0.tgz#dcf136e382e666bd2475f44a1096061b70dc0912"
   integrity sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==
 
-lemmy-js-client@0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.18.1.tgz#28df266eded0ef4a72b05ee6eabebddadfd81a27"
-  integrity sha512-maafUZ9ZJkXthRZmM0+limJmymF2kmN/8SiKufS3V4OVNM72s+wUFFiyhKmA370g23iZRW6SUagE7jNKnqNyYQ==
+lemmy-js-client@0.19.0-rc.1:
+  version "0.19.0-rc.1"
+  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.19.0-rc.1.tgz#e6bf9abdd82ea7bb7035a120925498f6dd8851c9"
+  integrity sha512-d0rDCvGV8lh8JkRjeEZdWjuE2OAvrDSei+4LUUSrcJVVMqG9PdjPRstKJ3JG4kT1aH3Nsp5AQynMyh9iQrfgTg==
   dependencies:
     cross-fetch "^3.1.5"
     form-data "^4.0.0"


### PR DESCRIPTION
## Description

Fixes  #1294.

This PR will add a moderator view button to the home page and uses the newly added moderator view parameter from https://github.com/LemmyNet/lemmy/pull/3176 to give moderators easy access to all the communities they moderate.

The moderator view button should only be visible for logged in users that moderate at least one community.

## Screenshots

### Before

TODO

### After

TODO