### PR TITLE
Use proper modifier key in markdown text input on macOS

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -1,4 +1,4 @@
-import { isBrowser } from "@utils/browser";
+import { isBrowser, platform } from "@utils/browser";
 import { numToSI, randomStr } from "@utils/helpers";
 import autosize from "autosize";
 import classNames from "classnames";
@@ -21,7 +21,6 @@ import { EmojiPicker } from "./emoji-picker";
 import { Icon, Spinner } from "./icon";
 import { LanguageSelect } from "./language-select";
 import ProgressBar from "./progress-bar";
-
 interface MarkdownTextAreaProps {
   /**
    * Initial content inside the textarea
@@ -477,7 +476,7 @@ export class MarkdownTextArea extends Component<
   // Keybind handler
   // Keybinds inspired by github comment area
   handleKeyBinds(i: MarkdownTextArea, event: KeyboardEvent) {
-    if (event.ctrlKey || event.metaKey) {
+    if (platform.isMac() ? event.metaKey : event.ctrlKey) {
       switch (event.key) {
         case "k": {
           i.handleInsertLink(i, event);

--- a/src/shared/utils/browser/index.ts
+++ b/src/shared/utils/browser/index.ts
@@ -4,6 +4,7 @@ import dataBsTheme from "./data-bs-theme";
 import isBrowser from "./is-browser";
 import isDark from "./is-dark";
 import loadCss from "./load-css";
+import platform from "./platform";
 import restoreScrollPosition from "./restore-scroll-position";
 import saveScrollPosition from "./save-scroll-position";
 import setAuthCookie from "./set-auth-cookie";
@@ -16,6 +17,7 @@ export {
   isBrowser,
   isDark,
   loadCss,
+  platform,
   restoreScrollPosition,
   saveScrollPosition,
   setAuthCookie,

--- a/src/shared/utils/browser/platform.ts
+++ b/src/shared/utils/browser/platform.ts
@@ -2,9 +2,11 @@ import { isBrowser } from "@utils/browser";
 
 const platformString = () =>
   navigator.platform?.match(/mac|win|linux/i)?.[0].toLowerCase();
-const isWin = () => isBrowser() && platformString() == "win";
-const isMac = () => isBrowser() && platformString() == "mac";
-const isLinux = () => isBrowser() && platformString() == "linux";
+const getPlatformPredicate = (platform: string) => () =>
+  isBrowser() && platformString() === platform;
+const isWin = getPlatformPredicate("win");
+const isMac = getPlatformPredicate("mac");
+const isLinux = getPlatformPredicate("linux");
 
 const platform = { isWin, isMac, isLinux };
 

--- a/src/shared/utils/browser/platform.ts
+++ b/src/shared/utils/browser/platform.ts
@@ -1,0 +1,11 @@
+import { isBrowser } from "@utils/browser";
+
+const platformString = () =>
+  navigator.platform?.match(/mac|win|linux/i)?.[0].toLowerCase();
+const isWin = () => isBrowser() && platformString() == "win";
+const isMac = () => isBrowser() && platformString() == "mac";
+const isLinux = () => isBrowser() && platformString() == "linux";
+
+const platform = { isWin, isMac, isLinux };
+
+export default platform;


### PR DESCRIPTION
## Description

On macOS, check for only the metaKey for keyboard shortcuts, since the ctrlKey is used for OS-specific shortcuts for navigating/editing text (like ctrl-b, ctrl-e, ctrl-k). Otherwise, check for the ctrlKey, on other platforms.

Relevant PRs: https://github.com/LemmyNet/lemmy-ui/pull/1136 https://github.com/LemmyNet/lemmy-ui/pull/1145 https://github.com/LemmyNet/lemmy-ui/pull/1750
