### PR TITLE
Fix document title of admin settings being overwritten by tagline and emoji forms

### DIFF
--- a/src/shared/components/home/emojis-form.tsx
+++ b/src/shared/components/home/emojis-form.tsx
@@ -11,7 +11,6 @@ import { customEmojisLookup } from "../../markdown";
 import { HttpService, I18NextService } from "../../services";
 import { pictrsDeleteToast, toast } from "../../toast";
 import { EmojiMart } from "../common/emoji-mart";
-import { HtmlTags } from "../common/html-tags";
 import { Icon, Spinner } from "../common/icon";
 import { Paginator } from "../common/paginator";
 

--- a/src/shared/components/home/emojis-form.tsx
+++ b/src/shared/components/home/emojis-form.tsx
@@ -66,17 +66,9 @@ export class EmojiForm extends Component<EmojiFormProps, EmojiFormState> {
     this.handlePageChange = this.handlePageChange.bind(this);
     this.handleEmojiClick = this.handleEmojiClick.bind(this);
   }
-  get documentTitle(): string {
-    return I18NextService.i18n.t("custom_emojis");
-  }
-
   render() {
     return (
       <div className="home-emojis-form col-12">
-        <HtmlTags
-          title={this.documentTitle}
-          path={this.context.router.route.match.url}
-        />
         <h1 className="h4 mb-4">{I18NextService.i18n.t("custom_emojis")}</h1>
         {customEmojisLookup.size > 0 && (
           <div>

--- a/src/shared/components/home/tagline-form.tsx
+++ b/src/shared/components/home/tagline-form.tsx
@@ -26,17 +26,10 @@ export class TaglineForm extends Component<TaglineFormProps, TaglineFormState> {
   constructor(props: any, context: any) {
     super(props, context);
   }
-  get documentTitle(): string {
-    return I18NextService.i18n.t("taglines");
-  }
 
   render() {
     return (
       <div className="tagline-form col-12">
-        <HtmlTags
-          title={this.documentTitle}
-          path={this.context.router.route.match.url}
-        />
         <h1 className="h4 mb-4">{I18NextService.i18n.t("taglines")}</h1>
         <div className="table-responsive col-12">
           <table id="taglines_table" className="table table-sm table-hover">

--- a/src/shared/components/home/tagline-form.tsx
+++ b/src/shared/components/home/tagline-form.tsx
@@ -3,7 +3,6 @@ import { capitalizeFirstLetter } from "@utils/helpers";
 import { Component, InfernoMouseEvent, linkEvent } from "inferno";
 import { EditSite, Tagline } from "lemmy-js-client";
 import { I18NextService } from "../../services";
-import { HtmlTags } from "../common/html-tags";
 import { Icon, Spinner } from "../common/icon";
 import { MarkdownTextArea } from "../common/markdown-textarea";
 


### PR DESCRIPTION
## Description

Fixes #2002

This restores the document title of the admin settings page by removing the document titles of the tagline and emoji forms, which appeared to be overwriting it. It seemed appropriate to outright remove them since these forms aren't being used anywhere else. 

## Screenshots

### Before

![image](https://github.com/LemmyNet/lemmy-ui/assets/65450174/a5f500ed-db33-4b04-8a69-1a4f64420b8a)

### After

![image](https://github.com/LemmyNet/lemmy-ui/assets/65450174/d3639286-8c09-4105-a366-aa8bf23f9d7d)
