### PR TITLE
Fix suggested title "&nbsp;" spaces

### DIFF
--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -582,8 +582,11 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
       case "loading":
         return <Spinner />;
       case "success": {
-        const suggestedTitle = this.state.metadataRes.data.metadata.title;
-
+        let suggestedTitle = this.state.metadataRes.data.metadata.title;
+        // Clean up the title of any extra whitespace and replace &nbsp; with a space
+        if (suggestedTitle) {
+          suggestedTitle = suggestedTitle.trim().replace(/\s+/g, " ");
+        }
         return (
           suggestedTitle && (
             <button

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -583,7 +583,9 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
         return <Spinner />;
       case "success": {
         // Clean up the title of any extra whitespace and replace &nbsp; with a space
-        const suggestedTitle = this.state.metadataRes.data.metadata.title?.trim().replace(/\s+/g, " ");
+        const suggestedTitle = this.state.metadataRes.data.metadata.title
+          ?.trim()
+          .replace(/\s+/g, " ");
         return (
           suggestedTitle && (
             <button

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -582,11 +582,8 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
       case "loading":
         return <Spinner />;
       case "success": {
-        let suggestedTitle = this.state.metadataRes.data.metadata.title;
         // Clean up the title of any extra whitespace and replace &nbsp; with a space
-        if (suggestedTitle) {
-          suggestedTitle = suggestedTitle.trim().replace(/\s+/g, " ");
-        }
+        const suggestedTitle = this.state.metadataRes.data.metadata.title?.trim().replace(/\s+/g, " ");
         return (
           suggestedTitle && (
             <button


### PR DESCRIPTION
## Description

When importing title from an URL in **PostForm** some title provided by metadata contain whitespace "\s" chars that are converter to `&nbsp;` string during the post call.

This only fix the issue for the suggested title feature in frontend. 
The backend has also the issue when generating `embed_title` from the provided url.

**EDIT:** 
Another PR is now submitted to the backend and may also fix the issue on the frontend side: 
https://github.com/LemmyNet/lemmy/pull/3829



Exemple of title that contain the issue:
https://www.20min.ch/fr/story/espace-mise-en-orbite-reussie-pour-une-mission-lunaire-indienne-905291103206

## Screenshots

### Before

![image](https://github.com/LemmyNet/lemmy-ui/assets/226090/352d4ada-c3a7-4f76-8802-08822daa6e73)

### After

![image](https://github.com/LemmyNet/lemmy-ui/assets/226090/9c098cfa-daad-4c11-807d-6ed8d20abcd8)
