### PR TITLE
Move banned users to a separate admin tab.

### DIFF
--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -150,12 +150,23 @@ export class AdminSettings extends Component<any, AdminSettingsState> {
                         loading={this.state.loading}
                       />
                     </div>
-                    <div className="col-12 col-md-6">
-                      {this.admins()}
-                      <hr />
-                      {this.bannedUsers()}
-                    </div>
+                    <div className="col-12 col-md-6">{this.admins()}</div>
                   </div>
+                </div>
+              ),
+            },
+            {
+              key: "banned_users",
+              label: I18NextService.i18n.t("banned_users"),
+              getNode: isSelected => (
+                <div
+                  className={classNames("tab-pane", {
+                    active: isSelected,
+                  })}
+                  role="tabpanel"
+                  id="banned_users-tab-pane"
+                >
+                  {this.bannedUsers()}
                 </div>
               ),
             },
@@ -295,7 +306,7 @@ export class AdminSettings extends Component<any, AdminSettingsState> {
         const bans = this.state.bannedRes.data.banned;
         return (
           <>
-            <h2 className="h5">{I18NextService.i18n.t("banned_users")}</h2>
+            <h1 className="h4 mb-4">{I18NextService.i18n.t("banned_users")}</h1>
             <ul className="list-unstyled">
               {bans.map(banned => (
                 <li key={banned.person.id} className="list-inline-item">


### PR DESCRIPTION
## Description
This moves the banned users admin area to its own tab. This makes it nicer to view the other admin settings when there's a large number of banned users and usernames aren't necessarily pleasant to see :slightly_smiling_face: 

## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before
![before](https://github.com/LemmyNet/lemmy-ui/assets/494446/00ce9c8a-601e-40f1-bc67-4fa3c9cf94a2)

### After
![after](https://github.com/LemmyNet/lemmy-ui/assets/494446/50303562-eb66-47bc-ba8b-55e2cc194d22)
![after_tab](https://github.com/LemmyNet/lemmy-ui/assets/494446/6e9c9da6-0629-4d66-8e0b-73a7986d19af)
