### PR TITLE
Moved title field to the top of post-form (#2039, #2059)

### DIFF
--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -367,7 +367,7 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
             {this.renderSuggestedPosts()}
           </div>
         </div>
-        
+
         <div className="mb-3 row">
           <label className="col-sm-2 col-form-label" htmlFor="post-url">
             {I18NextService.i18n.t("url")}

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -342,6 +342,7 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
             ) && !this.state.submitted
           }
         />
+
         <div className="mb-3 row">
           <label className="col-sm-2 col-form-label" htmlFor="post-title">
             {I18NextService.i18n.t("title")}

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -342,7 +342,6 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
             ) && !this.state.submitted
           }
         />
-
         <div className="mb-3 row">
           <label className="col-sm-2 col-form-label" htmlFor="post-title">
             {I18NextService.i18n.t("title")}

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -343,6 +343,32 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
           }
         />
         <div className="mb-3 row">
+          <label className="col-sm-2 col-form-label" htmlFor="post-title">
+            {I18NextService.i18n.t("title")}
+          </label>
+          <div className="col-sm-10">
+            <textarea
+              value={this.state.form.name}
+              id="post-title"
+              onInput={linkEvent(this, handlePostNameChange)}
+              className={`form-control ${
+                !validTitle(this.state.form.name) && "is-invalid"
+              }`}
+              required
+              rows={1}
+              minLength={3}
+              maxLength={MAX_POST_TITLE_LENGTH}
+            />
+            {!validTitle(this.state.form.name) && (
+              <div className="invalid-feedback">
+                {I18NextService.i18n.t("invalid_post_title")}
+              </div>
+            )}
+            {this.renderSuggestedPosts()}
+          </div>
+        </div>
+        
+        <div className="mb-3 row">
           <label className="col-sm-2 col-form-label" htmlFor="post-url">
             {I18NextService.i18n.t("url")}
           </label>
@@ -451,32 +477,6 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
               />
             </>
           )}
-        </div>
-
-        <div className="mb-3 row">
-          <label className="col-sm-2 col-form-label" htmlFor="post-title">
-            {I18NextService.i18n.t("title")}
-          </label>
-          <div className="col-sm-10">
-            <textarea
-              value={this.state.form.name}
-              id="post-title"
-              onInput={linkEvent(this, handlePostNameChange)}
-              className={`form-control ${
-                !validTitle(this.state.form.name) && "is-invalid"
-              }`}
-              required
-              rows={1}
-              minLength={3}
-              maxLength={MAX_POST_TITLE_LENGTH}
-            />
-            {!validTitle(this.state.form.name) && (
-              <div className="invalid-feedback">
-                {I18NextService.i18n.t("invalid_post_title")}
-              </div>
-            )}
-            {this.renderSuggestedPosts()}
-          </div>
         </div>
 
         <div className="mb-3 row">


### PR DESCRIPTION
## Description

Moved title field to the top of the post-form.

## Screenshots

### Before
![image](https://github.com/LemmyNet/lemmy-ui/assets/138327213/01d356ef-7ba1-45b5-8782-45ff7c09d5f2)

### After
![image](https://github.com/LemmyNet/lemmy-ui/assets/138327213/a69525af-703f-46b4-a893-0f2cb1237d2b)

Resolves #2039 
Resolves #2059