### PR TITLE
Make alternate way of displaying user names

### DIFF
--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -486,13 +486,7 @@ export class Profile extends Component<
                   )}
                   <ul className="list-inline mb-2">
                     <li className="list-inline-item">
-                      <PersonListing
-                        person={pv.person}
-                        realLink
-                        useApubName
-                        muted
-                        hideAvatar
-                      />
+                      <PersonListing person={pv.person} profile />
                     </li>
                     <li className="list-inline-item">
                       <UserBadges

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -417,18 +417,17 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const post_view = this.postView;
 
     return (
-      <div className="small mb-1 mb-md-0">
+      <div className="small mb-1 mb-md-0 d-flex align-items-center flex-wrap">
         <PersonListing person={post_view.creator} />
         <UserBadges
-          classNames="ms-1"
+          classNames="mx-1"
           isMod={this.creatorIsMod_}
           isAdmin={this.creatorIsAdmin_}
           isBot={post_view.creator.bot_account}
         />
         {this.props.showCommunity && (
           <>
-            {" "}
-            {I18NextService.i18n.t("to")}{" "}
+            <span className="mx-1">{I18NextService.i18n.t("to")}</span>
             <CommunityLink community={post_view.community} />
           </>
         )}
@@ -440,8 +439,8 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               )?.name
             }
           </span>
-        )}{" "}
-        •{" "}
+        )}
+        <span className="mx-1">•</span>
         <MomentTime
           published={post_view.post.published}
           updated={post_view.post.updated}

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -214,7 +214,7 @@ const communityListing = ({
 
 const personListing = ({ person, counts: { comment_count } }: PersonView) =>
   getListing(
-    <PersonListing person={person} showApubName />,
+    <PersonListing person={person} />,
     comment_count,
     "number_of_comments",
   );


### PR DESCRIPTION
## Description

As discussed in #1975, this is an attempt at displaying apub names alongside display names in a way as to not take up too much horizontal space.

## Screenshots

### Before
![image](https://github.com/LemmyNet/lemmy-ui/assets/28871516/f4061adb-e69d-4a6b-a636-b16aedb1c5bd)

### After
![image](https://github.com/LemmyNet/lemmy-ui/assets/28871516/ce3f5c7d-e0a2-4cf1-ac60-85db97f0ae28)

