### PR TITLE
Move allowed and blocked instance tables to the column right of linked instance table

### DIFF
--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -108,7 +108,7 @@ export class Instances extends Component<any, InstancesState> {
             />
           </>
         ) : (
-          <></>
+          <h5>No linked instance</h5>
         );
       }
     }

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -6,12 +6,14 @@ import {
   GetSiteResponse,
   Instance,
 } from "lemmy-js-client";
+import classNames from "classnames";
 import { relTags } from "../../config";
 import { InitialFetchRequest } from "../../interfaces";
 import { FirstLoadService, I18NextService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
 import { HtmlTags } from "../common/html-tags";
 import { Spinner } from "../common/icon";
+import Tabs from "../common/tabs";
 
 type InstancesData = RouteDataResponse<{
   federatedInstancesResponse: GetFederatedInstancesResponse;
@@ -86,34 +88,24 @@ export class Instances extends Component<any, InstancesState> {
         const instances = this.state.instancesRes.data.federated_instances;
         return instances ? (
           <>
-            <h1 className="h4 mb-4">{I18NextService.i18n.t("instances")}</h1>
-            <div className="row">
-              <div className="col-md-6">
-                <h2 className="h5 mb-3">
-                  {I18NextService.i18n.t("linked_instances")}
-                </h2>
-                {this.itemList(instances.linked)}
-              </div>
-              <div className="col-md-6">
-                {instances.allowed && instances.allowed.length > 0 && (
-                  <>
-                    <h2 className="h5 mb-3">
-                      {I18NextService.i18n.t("allowed_instances")}
-                    </h2>
-                    {this.itemList(instances.allowed)}
-                  </>
-                )}
-
-                {instances.blocked && instances.blocked.length > 0 && (
-                  <>
-                    <h2 className="h5 mb-3">
-                      {I18NextService.i18n.t("blocked_instances")}
-                    </h2>
-                    {this.itemList(instances.blocked)}
-                  </>
-                )}
-              </div>
-            </div>
+            <Tabs
+              tabs={["linked", "allowed", "blocked"]
+                .filter(status => instances[status].length)
+                .map(status => ({
+                  key: status,
+                  label: I18NextService.i18n.t(`${status}_instances`),
+                  getNode: isSelected => (
+                    <div
+                      role="tabpanel"
+                      className={classNames("tab-pane show", {
+                        active: isSelected,
+                      })}
+                    >
+                      {this.itemList(instances[status])}
+                    </div>
+                  ),
+                }))}
+            />
           </>
         ) : (
           <></>

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -87,26 +87,28 @@ export class Instances extends Component<any, InstancesState> {
       case "success": {
         const instances = this.state.instancesRes.data.federated_instances;
         return instances ? (
-          <>
-            <Tabs
-              tabs={["linked", "allowed", "blocked"]
-                .filter(status => instances[status].length)
-                .map(status => ({
-                  key: status,
-                  label: I18NextService.i18n.t(`${status}_instances`),
-                  getNode: isSelected => (
-                    <div
-                      role="tabpanel"
-                      className={classNames("tab-pane show", {
-                        active: isSelected,
-                      })}
-                    >
-                      {this.itemList(instances[status])}
-                    </div>
-                  ),
-                }))}
-            />
-          </>
+          <div className="row">
+            <div className="col-lg-8">
+              <Tabs
+                tabs={["linked", "allowed", "blocked"]
+                  .filter(status => instances[status].length)
+                  .map(status => ({
+                    key: status,
+                    label: I18NextService.i18n.t(`${status}_instances`),
+                    getNode: isSelected => (
+                      <div
+                        role="tabpanel"
+                        className={classNames("tab-pane show", {
+                          active: isSelected,
+                        })}
+                      >
+                        {this.itemList(instances[status])}
+                      </div>
+                    ),
+                  }))}
+              />
+            </div>
+          </div>
         ) : (
           <h5>No linked instance</h5>
         );

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -94,24 +94,25 @@ export class Instances extends Component<any, InstancesState> {
                 </h2>
                 {this.itemList(instances.linked)}
               </div>
-            </div>
-            <div className="row">
-              {instances.allowed && instances.allowed.length > 0 && (
-                <div className="col-md-6">
-                  <h2 className="h5 mb-3">
-                    {I18NextService.i18n.t("allowed_instances")}
-                  </h2>
-                  {this.itemList(instances.allowed)}
-                </div>
-              )}
-              {instances.blocked && instances.blocked.length > 0 && (
-                <div className="col-md-6">
-                  <h2 className="h5 mb-3">
-                    {I18NextService.i18n.t("blocked_instances")}
-                  </h2>
-                  {this.itemList(instances.blocked)}
-                </div>
-              )}
+              <div className="col-md-6">
+                {instances.allowed && instances.allowed.length > 0 && (
+                  <>
+                    <h2 className="h5 mb-3">
+                      {I18NextService.i18n.t("allowed_instances")}
+                    </h2>
+                    {this.itemList(instances.allowed)}
+                  </>
+                )}
+
+                {instances.blocked && instances.blocked.length > 0 && (
+                  <>
+                    <h2 className="h5 mb-3">
+                      {I18NextService.i18n.t("blocked_instances")}
+                    </h2>
+                    {this.itemList(instances.blocked)}
+                  </>
+                )}
+              </div>
             </div>
           </>
         ) : (


### PR DESCRIPTION
## Description

Addresses #2065 

I think for most instances, the linked instance list will be longer than the allowed and blocked list, combined or not. So it made sense to join the allowed and blocked instance tables into the same column, to the right of the linked instance table.

If there were blocked instances, they would be shown in another table below `Allowed Instances`.

## Screenshots

### Before
![before](https://github.com/LemmyNet/lemmy-ui/assets/35418785/2ec939c9-cbc2-46f3-85ca-a271bcd68373)
### After
![After](https://github.com/LemmyNet/lemmy-ui/assets/35418785/95a7320c-958e-46ca-9693-f5ed866ba1a6)