### PR TITLE
always show community name with instance for easy copy-pasting to friends

### DIFF
--- a/src/shared/components/community/community-link.tsx
+++ b/src/shared/components/community/community-link.tsx
@@ -23,18 +23,18 @@ export class CommunityLink extends Component<CommunityLinkProps, any> {
     const community = this.props.community;
     let name_: string, title: string, link: string;
     const local = community.local === null ? true : community.local;
+    const domain = hostname(community.actor_id);
     if (local) {
       name_ = community.name;
       title = community.title;
       link = `/c/${community.name}`;
     } else {
-      const domain = hostname(community.actor_id);
       name_ = `${community.name}@${domain}`;
       title = `${community.title}@${domain}`;
       link = !this.props.realLink ? `/c/${name_}` : community.actor_id;
     }
 
-    const apubName = `!${name_}`;
+    const apubName = `!${community.name}@${domain}`;
     const displayName = this.props.useApubName ? apubName : title;
     return !this.props.realLink ? (
       <Link

--- a/src/shared/components/community/community-link.tsx
+++ b/src/shared/components/community/community-link.tsx
@@ -21,15 +21,14 @@ export class CommunityLink extends Component<CommunityLinkProps, any> {
 
   render() {
     const community = this.props.community;
-    let name_: string, title: string, link: string;
+    let title: string, link: string;
     const local = community.local === null ? true : community.local;
     const domain = hostname(community.actor_id);
     if (local) {
-      name_ = community.name;
       title = community.title;
       link = `/c/${community.name}`;
     } else {
-      name_ = `${community.name}@${domain}`;
+      const name_ = `${community.name}@${domain}`;
       title = `${community.title}@${domain}`;
       link = !this.props.realLink ? `/c/${name_}` : community.actor_id;
     }


### PR DESCRIPTION
## Description

I don't like the inconsistency of community names currently, the UI shouldn't be presenting things differently because of technical reasons that are hard for users to understand. This makes it easier to share communities with your friends!

## Screenshots

### Before

![image](https://github.com/LemmyNet/lemmy-ui/assets/30947252/93468eb6-85cf-49a0-a903-f0d1b301e48e)

### After

![image](https://github.com/LemmyNet/lemmy-ui/assets/30947252/af4edb69-f1f3-4522-8dce-8d4145590235)
