### PR TITLE
Modify instances page to not link to blocked instances

### DIFF
--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -134,7 +134,7 @@ export class Instances extends Component<any, InstancesState> {
     );
   }
 
-  itemList(items: Instance[], link?: boolean | undefined) {
+  itemList(items: Instance[], link = true) {
     return items.length > 0 ? (
       <div className="table-responsive">
         <table id="instances_table" className="table table-sm table-hover">

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -94,24 +94,25 @@ export class Instances extends Component<any, InstancesState> {
                 </h2>
                 {this.itemList(instances.linked)}
               </div>
-            </div>
-            <div className="row">
-              {instances.allowed && instances.allowed.length > 0 && (
-                <div className="col-md-6">
-                  <h2 className="h5 mb-3">
-                    {I18NextService.i18n.t("allowed_instances")}
-                  </h2>
-                  {this.itemList(instances.allowed)}
-                </div>
-              )}
-              {instances.blocked && instances.blocked.length > 0 && (
-                <div className="col-md-6">
-                  <h2 className="h5 mb-3">
-                    {I18NextService.i18n.t("blocked_instances")}
-                  </h2>
-                  {this.itemList(instances.blocked)}
-                </div>
-              )}
+              <div className="col-md-6">
+                {instances.allowed && instances.allowed.length > 0 && (
+                  <>
+                    <h2 className="h5 mb-3">
+                      {I18NextService.i18n.t("allowed_instances")}
+                    </h2>
+                    {this.itemList(instances.allowed)}
+                  </>
+                )}
+
+                {instances.blocked && instances.blocked.length > 0 && (
+                  <>
+                    <h2 className="h5 mb-3">
+                      {I18NextService.i18n.t("blocked_instances")}
+                    </h2>
+                    {this.itemList(instances.blocked, false)}
+                  </>
+                )}
+              </div>
             </div>
           </>
         ) : (
@@ -133,7 +134,7 @@ export class Instances extends Component<any, InstancesState> {
     );
   }
 
-  itemList(items: Instance[]) {
+  itemList(items: Instance[], link?: boolean | undefined) {
     return items.length > 0 ? (
       <div className="table-responsive">
         <table id="instances_table" className="table table-sm table-hover">
@@ -148,9 +149,15 @@ export class Instances extends Component<any, InstancesState> {
             {items.map(i => (
               <tr key={i.domain}>
                 <td>
-                  <a href={`https://${i.domain}`} rel={relTags}>
-                    {i.domain}
-                  </a>
+                  {link === true || link === undefined ? (
+                    <a href={`https://${i.domain}`} rel={relTags}>
+                      {" "}
+                      {i.domain}{" "}
+                    </a>
+                  ) : (
+                    <span> {i.domain} </span>
+                  )}
+                  ;
                 </td>
                 <td>{i.software}</td>
                 <td>{i.version}</td>

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -149,7 +149,7 @@ export class Instances extends Component<any, InstancesState> {
             {items.map(i => (
               <tr key={i.domain}>
                 <td>
-                  {link === true || link === undefined ? (
+                  {link ? (
                     <a href={`https://${i.domain}`} rel={relTags}>
                       {" "}
                       {i.domain}{" "}


### PR DESCRIPTION
Also changed layout to show allowed and blocked side by side in columns instead of one giant list

## Description

Fixes: #2065 and other feature requests


## Screenshots

### After

[![](https://i.postimg.cc/NFx2t3pq/instances-page.png)](https://postimg.cc/xNc1yFwt)