### PR TITLE
Added error handling to format-past-date to prevent timeouts on modlog

### DIFF
--- a/src/shared/utils/helpers/format-past-date.ts
+++ b/src/shared/utils/helpers/format-past-date.ts
@@ -2,13 +2,13 @@ import formatDistanceStrict from "date-fns/formatDistanceStrict";
 import parseISO from "date-fns/parseISO";
 
 export default function (dateString?: string) {
-  if (!dateString || dateString === undefined) {
+  if (!dateString) {
     console.error(err);
     return "DATE ERROR";
   }
 
   try {
-    const parsed = parseISO((dateString ?? Date.now().toString()) + "Z");
+    const parsed = parseISO(Date.now().toString() + "Z");
     return formatDistanceStrict(parsed, new Date(), {
       addSuffix: true,
     });

--- a/src/shared/utils/helpers/format-past-date.ts
+++ b/src/shared/utils/helpers/format-past-date.ts
@@ -2,8 +2,23 @@ import formatDistanceStrict from "date-fns/formatDistanceStrict";
 import parseISO from "date-fns/parseISO";
 
 export default function (dateString?: string) {
-  const parsed = parseISO((dateString ?? Date.now().toString()) + "Z");
-  return formatDistanceStrict(parsed, new Date(), {
-    addSuffix: true,
-  });
+  if (!dateString || dateString === undefined) {
+    console.error(err);
+    return "DATE ERROR";
+  }
+
+  try {
+    const parsed = parseISO((dateString ?? Date.now().toString()) + "Z");
+    return formatDistanceStrict(parsed, new Date(), {
+      addSuffix: true,
+    });
+  } catch (err) {
+    console.error(err);
+    if (err instanceof RangeError) {
+      console.error(
+        `Got the invalid value of ${dateString} when attempting to parse to ISO date`,
+      );
+      return "DATE ERROR";
+    }
+  }
 }


### PR DESCRIPTION
## Description

Improper date strings such as those very far into the future, or typo'd dates cause format-past-date to fail. This causes `modlog` page to load/spin forever instead of displaying any information as expected. This single file change adds error handling to the parse date function to skip improperly formatted dates, and log such to the console. 