### PR TITLE
Adding decoding for html entities in post titles - rebased on main

### DIFF
--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -336,9 +336,8 @@ export class Communities extends Component<any, CommunitiesState> {
     };
 
     return {
-      listCommunitiesResponse: await client.listCommunities(
-        listCommunitiesForm,
-      ),
+      listCommunitiesResponse:
+        await client.listCommunities(listCommunitiesForm),
     };
   }
 

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -794,9 +794,8 @@ export class Community extends Component<
   }
 
   async handleTransferCommunity(form: TransferCommunity) {
-    const transferCommunityRes = await HttpService.client.transferCommunity(
-      form,
-    );
+    const transferCommunityRes =
+      await HttpService.client.transferCommunity(form);
     toast(I18NextService.i18n.t("transfer_community"));
     this.updateCommunityFull(transferCommunityRes);
   }

--- a/src/shared/components/person/registration-applications.tsx
+++ b/src/shared/components/person/registration-applications.tsx
@@ -236,9 +236,8 @@ export class RegistrationApplications extends Component<
   }
 
   async handleApproveApplication(form: ApproveRegistrationApplication) {
-    const approveRes = await HttpService.client.approveRegistrationApplication(
-      form,
-    );
+    const approveRes =
+      await HttpService.client.approveRegistrationApplication(form);
     this.setState(s => {
       if (s.appsRes.state === "success" && approveRes.state === "success") {
         s.appsRes.data.registration_applications = editRegistrationApplication(

--- a/src/shared/components/person/reports.tsx
+++ b/src/shared/components/person/reports.tsx
@@ -603,9 +603,8 @@ export class Reports extends Component<any, ReportsState> {
 
     if (amAdmin()) {
       this.setState({
-        messageReportsRes: await HttpService.client.listPrivateMessageReports(
-          form,
-        ),
+        messageReportsRes:
+          await HttpService.client.listPrivateMessageReports(form),
       });
     }
   }

--- a/src/shared/components/post/metadata-card.tsx
+++ b/src/shared/components/post/metadata-card.tsx
@@ -1,6 +1,7 @@
 import { Component } from "inferno";
 import { Post } from "lemmy-js-client";
 import * as sanitizeHtml from "sanitize-html";
+import { unescapeHTML } from "@utils/helpers";
 import { relTags } from "../../config";
 import { Icon } from "../common/icon";
 
@@ -25,14 +26,18 @@ export class MetadataCard extends Component<MetadataCardProps> {
                 {post.name !== post.embed_title && (
                   <>
                     <h5 className="card-title d-inline">
-                      <a className="text-body" href={post.url} rel={relTags}>
-                        {post.embed_title}
+                      <a
+                        className="text-body"
+                        href={unescapeHTML(post.url)}
+                        rel={relTags}
+                      >
+                        {unescapeHTML(post.embed_title)}
                       </a>
                     </h5>
                     <span className="d-inline-block ms-2 mb-2 small text-muted">
                       <a
                         className="text-muted fst-italic"
-                        href={post.url}
+                        href={unescapeHTML(post.url)}
                         rel={relTags}
                       >
                         {new URL(post.url).hostname}

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -465,7 +465,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       >
         <span
           className="d-inline"
-          dangerouslySetInnerHTML={unescapeHTML(mdToHtmlInline(post.name))}
+          dangerouslySetInnerHTML={mdToHtmlInline(post.name)}
         />
       </Link>
     );

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -5,6 +5,7 @@ import {
   capitalizeFirstLetter,
   futureDaysToUnixTime,
   hostname,
+  unescapeHTML,
 } from "@utils/helpers";
 import { isImage, isVideo } from "@utils/media";
 import {
@@ -291,7 +292,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             allowFullScreen
             className="post-metadata-iframe"
             src={post.embed_video_url}
-            title={post.embed_title}
+            title={post.embed_title ? unescapeHTML(post.embed_title) : " "}
           ></iframe>
         </div>
       );
@@ -464,7 +465,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       >
         <span
           className="d-inline"
-          dangerouslySetInnerHTML={mdToHtmlInline(post.name)}
+          dangerouslySetInnerHTML={unescapeHTML(mdToHtmlInline(post.name))}
         />
       </Link>
     );
@@ -485,10 +486,12 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
                     ? "link-dark"
                     : "link-primary"
                 }
-                href={url}
-                title={url}
+                href={unescapeHTML(url)}
+                title={unescapeHTML(url)}
                 rel={relTags}
-                dangerouslySetInnerHTML={mdToHtmlInline(post.name)}
+                dangerouslySetInnerHTML={mdToHtmlInline(
+                  unescapeHTML(post.name),
+                )}
               ></a>
             ) : (
               this.postLink

--- a/src/shared/components/post/post-report.tsx
+++ b/src/shared/components/post/post-report.tsx
@@ -44,7 +44,9 @@ export class PostReport extends Component<PostReportProps, PostReportState> {
 
     // Set the original post data ( a troll could change it )
     post.name = unescapeHTML(r.post_report.original_post_name);
-    post.url = unescapeHTML(r.post_report.original_post_url);
+    post.url = r.post_report.original_post_url
+      ? unescapeHTML(r.post_report.original_post_url)
+      : r.post_report.original_post_url;
     post.body = r.post_report.original_post_body;
     const pv: PostView = {
       post,

--- a/src/shared/components/post/post-report.tsx
+++ b/src/shared/components/post/post-report.tsx
@@ -1,4 +1,5 @@
 import { myAuthRequired } from "@utils/app";
+import { unescapeHTML } from "@utils/helpers";
 import { Component, InfernoNode, linkEvent } from "inferno";
 import { T } from "inferno-i18next-dess";
 import { PostReportView, PostView, ResolvePostReport } from "lemmy-js-client";
@@ -42,8 +43,8 @@ export class PostReport extends Component<PostReportProps, PostReportState> {
     );
 
     // Set the original post data ( a troll could change it )
-    post.name = r.post_report.original_post_name;
-    post.url = r.post_report.original_post_url;
+    post.name = unescapeHTML(r.post_report.original_post_name);
+    post.url = unescapeHTML(r.post_report.original_post_url);
     post.body = r.post_report.original_post_body;
     const pv: PostView = {
       post,

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -19,7 +19,7 @@ import {
   restoreScrollPosition,
   saveScrollPosition,
 } from "@utils/browser";
-import { debounce, randomStr } from "@utils/helpers";
+import { debounce, randomStr, unescapeHTML } from "@utils/helpers";
 import { isImage } from "@utils/media";
 import { RouteDataResponse } from "@utils/types";
 import autosize from "autosize";
@@ -353,7 +353,7 @@ export class Post extends Component<any, PostState> {
           <div className="row">
             <main className="col-12 col-md-8 col-lg-9 mb-3">
               <HtmlTags
-                title={this.documentTitle}
+                title={unescapeHTML(this.documentTitle)}
                 path={this.context.router.route.match.url}
                 canonicalPath={res.post_view.post.ap_id}
                 image={this.imageTag}
@@ -909,9 +909,8 @@ export class Post extends Component<any, PostState> {
   }
 
   async handleTransferCommunity(form: TransferCommunity) {
-    const transferCommunityRes = await HttpService.client.transferCommunity(
-      form,
-    );
+    const transferCommunityRes =
+      await HttpService.client.transferCommunity(form);
     this.updateCommunityFull(transferCommunityRes);
   }
 

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -385,9 +385,8 @@ export class Search extends Component<any, SearchState> {
         auth,
       };
 
-      listCommunitiesResponse = await client.listCommunities(
-        listCommunitiesForm,
-      );
+      listCommunitiesResponse =
+        await client.listCommunities(listCommunitiesForm);
     }
 
     const creator_id = getIdFromString(creatorId);
@@ -430,9 +429,8 @@ export class Search extends Component<any, SearchState> {
             q: query,
             auth,
           };
-          resolveObjectResponse = await HttpService.silent_client.resolveObject(
-            resolveObjectForm,
-          );
+          resolveObjectResponse =
+            await HttpService.silent_client.resolveObject(resolveObjectForm);
 
           // If we return this object with a state of failed, the catch-all-handler will redirect
           // to an error page, so we ignore it by covering up the error with the empty state.

--- a/src/shared/utils/helpers/html-entities.ts
+++ b/src/shared/utils/helpers/html-entities.ts
@@ -42,7 +42,7 @@ export function escapeHTML(str: string): string {
   return lastIndex !== index ? html + str.substring(lastIndex, index) : html;
 }
 
-export function unescapeHTML(str: string | undefined): string {
+export function unescapeHTML(str: string): string {
   const matchUnEsc = matchUnEscRx.exec(str);
   if (!matchUnEsc) {
     return str;

--- a/src/shared/utils/helpers/html-entities.ts
+++ b/src/shared/utils/helpers/html-entities.ts
@@ -1,0 +1,60 @@
+const matchEscHtmlRx = /["'&<>]/;
+const matchUnEscRx = /&(?:amp|#38|lt|#60|gt|#62|apos|#39|quot|#34);/g;
+
+export function escapeHTML(str: string): string {
+  const matchEscHtml = matchEscHtmlRx.exec(str);
+  if (!matchEscHtml) {
+    return str;
+  }
+  let escape;
+  let html = "";
+  let index = 0;
+  let lastIndex = 0;
+  for (index = matchEscHtml.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escape = "&quot;";
+        break;
+      case 38: // &
+        escape = "&amp;";
+        break;
+      case 39: // '
+        escape = "&#39;";
+        break;
+      case 60: // <
+        escape = "&lt;";
+        break;
+      case 62: // >
+        escape = "&gt;";
+        break;
+      default:
+        continue;
+    }
+
+    if (lastIndex !== index) {
+      html += str.substring(lastIndex, index);
+    }
+
+    lastIndex = index + 1;
+    html += escape;
+  }
+
+  return lastIndex !== index ? html + str.substring(lastIndex, index) : html;
+}
+
+export function unescapeHTML(str: string): string {
+  const matchUnEsc = matchUnEscRx.exec(str);
+  if (!matchUnEsc) {
+    return str;
+  }
+
+  const res = str
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x3A;/g, ":")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+
+  return unescapeHTML(res);
+}

--- a/src/shared/utils/helpers/html-entities.ts
+++ b/src/shared/utils/helpers/html-entities.ts
@@ -42,7 +42,7 @@ export function escapeHTML(str: string): string {
   return lastIndex !== index ? html + str.substring(lastIndex, index) : html;
 }
 
-export function unescapeHTML(str: string): string {
+export function unescapeHTML(str: string | undefined): string {
   const matchUnEsc = matchUnEscRx.exec(str);
   if (!matchUnEsc) {
     return str;

--- a/src/shared/utils/helpers/index.ts
+++ b/src/shared/utils/helpers/index.ts
@@ -23,11 +23,13 @@ import validEmail from "./valid-email";
 import validInstanceTLD from "./valid-instance-tld";
 import validTitle from "./valid-title";
 import validURL from "./valid-url";
+import { escapeHTML, unescapeHTML } from "./html-entities";
 
 export {
   capitalizeFirstLetter,
   debounce,
   editListImmutable,
+  escapeHTML,
   formatPastDate,
   futureDaysToUnixTime,
   getIdFromString,
@@ -46,6 +48,7 @@ export {
   randomStr,
   removeAuthParam,
   sleep,
+  unescapeHTML,
   validEmail,
   validInstanceTLD,
   validTitle,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,7 +148,7 @@ module.exports = (env, argv) => {
 
     const RunNodeWebpackPlugin = require("run-node-webpack-plugin");
     serverConfig.plugins.push(
-      new RunNodeWebpackPlugin({ runOnlyInWatchMode: true })
+      new RunNodeWebpackPlugin({ runOnlyInWatchMode: true }),
     );
   } else if (mode === "none") {
     const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");


### PR DESCRIPTION
does not fix backend, only frontend/lemmy-ui display

## Description

Convert simple html entities such as `&amp;` to `&` as expected for display of post titles.

Fixes: 

## Screenshots

### Before
![](https://i.postimg.cc/wMhKjTp4/pre-amp.png)


### After
![](https://i.postimg.cc/kGr3CRkt/post-amp.png)
