### PR TITLE
Display more information why has the login failed

### DIFF
--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -155,7 +155,13 @@ export class Login extends Component<any, State> {
             i.setState({ showTotp: true });
             toast(I18NextService.i18n.t("enter_two_factor_code"), "info");
           }
-          if (["incorrect_login", "email_not_verified", "registration_application_pending"].includes(loginRes.msg)) {
+          if (
+            [
+              "incorrect_login",
+              "email_not_verified",
+              "registration_application_pending",
+            ].includes(loginRes.msg)
+          ) {
             toast(I18NextService.i18n.t(loginRes.msg), "danger");
           }
 

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -155,8 +155,10 @@ export class Login extends Component<any, State> {
             i.setState({ showTotp: true });
             toast(I18NextService.i18n.t("enter_two_factor_code"), "info");
           }
-          if (loginRes.msg === "incorrect_login") {
-            toast(I18NextService.i18n.t("incorrect_login"), "danger");
+          if (["incorrect_login",
+               "email_not_verified",
+               "registration_application_pending"].includes(loginRes.msg)) {
+            toast(I18NextService.i18n.t(loginRes.msg), "danger");
           }
 
           i.setState({ loginRes: { state: "failed", msg: loginRes.msg } });

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -154,14 +154,7 @@ export class Login extends Component<any, State> {
           if (loginRes.msg === "missing_totp_token") {
             i.setState({ showTotp: true });
             toast(I18NextService.i18n.t("enter_two_factor_code"), "info");
-          }
-          if (
-            [
-              "incorrect_login",
-              "email_not_verified",
-              "registration_application_pending",
-            ].includes(loginRes.msg)
-          ) {
+          } else {
             toast(I18NextService.i18n.t(loginRes.msg), "danger");
           }
 

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -155,9 +155,7 @@ export class Login extends Component<any, State> {
             i.setState({ showTotp: true });
             toast(I18NextService.i18n.t("enter_two_factor_code"), "info");
           }
-          if (["incorrect_login",
-               "email_not_verified",
-               "registration_application_pending"].includes(loginRes.msg)) {
+          if (["incorrect_login", "email_not_verified", "registration_application_pending"].includes(loginRes.msg)) {
             toast(I18NextService.i18n.t(loginRes.msg), "danger");
           }
 


### PR DESCRIPTION
## Description
Before this change the user was not aware why the login failed unless they looked into the browser console, this simple change brings more errors to show up in a toast making it more clear and verbose what went wrong. Translations seem to be already in place. (https://github.com/LemmyNet/lemmy-translations/blob/38bb32f6898b227aaad06a48d8bf69a5b48416d6/translations/en.json#L433)

## Screenshots
![image](https://github.com/LemmyNet/lemmy-ui/assets/23512881/8f38b21b-525e-4444-86e7-e540ff7b90e3)
