### PR TITLE
Disable "Next" button in Paginator when the next page is empty

### DIFF
--- a/src/shared/components/common/paginator.tsx
+++ b/src/shared/components/common/paginator.tsx
@@ -4,6 +4,7 @@ import { I18NextService } from "../../services";
 interface PaginatorProps {
   page: number;
   onChange(val: number): any;
+  nextDisabled?: boolean;
 }
 
 export class Paginator extends Component<PaginatorProps, any> {
@@ -23,6 +24,7 @@ export class Paginator extends Component<PaginatorProps, any> {
         <button
           className="btn btn-secondary"
           onClick={linkEvent(this, this.handleNext)}
+          disabled={props.nextDisabled || false}
         >
           {I18NextService.i18n.t("next")}
         </button>

--- a/src/shared/components/common/paginator.tsx
+++ b/src/shared/components/common/paginator.tsx
@@ -4,7 +4,7 @@ import { I18NextService } from "../../services";
 interface PaginatorProps {
   page: number;
   onChange(val: number): any;
-  nextDisabled?: boolean;
+  nextDisabled: boolean;
 }
 
 export class Paginator extends Component<PaginatorProps, any> {

--- a/src/shared/components/common/paginator.tsx
+++ b/src/shared/components/common/paginator.tsx
@@ -24,7 +24,7 @@ export class Paginator extends Component<PaginatorProps, any> {
         <button
           className="btn btn-secondary"
           onClick={linkEvent(this, this.handleNext)}
-          disabled={props.nextDisabled || false}
+          disabled={this.props.nextDisabled || false}
         >
           {I18NextService.i18n.t("next")}
         </button>

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -32,7 +32,7 @@ import { Paginator } from "../common/paginator";
 import { SortSelect } from "../common/sort-select";
 import { CommunityLink } from "./community-link";
 
-const communityLimit = 50;
+import { communityLimit } from "../../config";
 
 type CommunitiesData = RouteDataResponse<{
   listCommunitiesResponse: ListCommunitiesResponse;

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -226,7 +226,7 @@ export class Communities extends Component<any, CommunitiesState> {
               onChange={this.handlePageChange}
               nextDisabled={
                 communityLimit >
-                this.state.listCommunitiesResponse.data.communities
+                this.state.listCommunitiesResponse.data.communities.length
               }
             />
           </div>

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -221,7 +221,14 @@ export class Communities extends Component<any, CommunitiesState> {
                 </tbody>
               </table>
             </div>
-            <Paginator page={page} onChange={this.handlePageChange} />
+            <Paginator
+              page={page}
+              onChange={this.handlePageChange}
+              nextDisabled={
+                communityLimit >
+                this.state.listCommunitiesResponse.data.communities
+              }
+            />
           </div>
         );
       }

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -344,7 +344,14 @@ export class Community extends Component<
                 </div>
                 {this.selects(res)}
                 {this.listings(res)}
-                <Paginator page={page} onChange={this.handlePageChange} />
+                <Paginator
+                  page={page}
+                  onChange={this.handlePageChange}
+                  nextDisabled={
+                    this.state.postsRes.state === "success" &&
+                    this.state.postsRes.data.posts.length > fetchLimit
+                  }
+                />
               </main>
               <aside className="d-none d-md-block col-md-4 col-lg-3">
                 {this.sidebar(res)}

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -348,8 +348,8 @@ export class Community extends Component<
                   page={page}
                   onChange={this.handlePageChange}
                   nextDisabled={
-                    this.state.postsRes.state === "success" &&
-                    this.state.postsRes.data.posts.length > fetchLimit
+                    this.state.postsRes.state !== "success" ||
+                    fetchLimit > this.state.postsRes.data.posts.length
                   }
                 />
               </main>

--- a/src/shared/components/home/emojis-form.tsx
+++ b/src/shared/components/home/emojis-form.tsx
@@ -267,7 +267,11 @@ export class EmojiForm extends Component<EmojiFormProps, EmojiFormState> {
             {I18NextService.i18n.t("add_custom_emoji")}
           </button>
 
-          <Paginator page={this.state.page} onChange={this.handlePageChange} />
+          <Paginator
+            page={this.state.page}
+            onChange={this.handlePageChange}
+            nextDisabled={false}
+          />
         </div>
       </div>
     );

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -653,7 +653,14 @@ export class Home extends Component<any, HomeState> {
         <div>
           {this.selects}
           {this.listings}
-          <Paginator page={page} onChange={this.handlePageChange} />
+          <Paginator
+            page={page}
+            onChange={this.handlePageChange}
+            nextDisabled={
+              this.state.postsRes?.state !== "success" ||
+              fetchLimit > this.state.postsRes.data.posts.length
+            }
+          />
         </div>
       </div>
     );

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -860,7 +860,11 @@ export class Modlog extends Component<
               </thead>
               {this.combined}
             </table>
-            <Paginator page={page} onChange={this.handlePageChange} />
+            <Paginator
+              page={page}
+              onChange={this.handlePageChange}
+              nextDisabled={false}
+            />
           </div>
         );
       }

--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -256,6 +256,7 @@ export class Inbox extends Component<any, InboxState> {
             <Paginator
               page={this.state.page}
               onChange={this.handlePageChange}
+              nextDisabled={false}
             />
           </div>
         </div>

--- a/src/shared/components/person/person-details.tsx
+++ b/src/shared/components/person/person-details.tsx
@@ -115,7 +115,16 @@ export class PersonDetails extends Component<PersonDetailsProps, any> {
       <div className="person-details">
         {this.viewSelector(this.props.view)}
 
-        <Paginator page={this.props.page} onChange={this.handlePageChange} />
+        <Paginator
+          page={this.props.page}
+          onChange={this.handlePageChange}
+          nextDisabled={
+            (this.props.view === PersonDetailsView.Comments &&
+              this.props.limit > this.props.personRes.comments.length) ||
+            (this.props.view === PersonDetailsView.Posts &&
+              this.props.limit > this.props.personRes.posts.length)
+          }
+        />
       </div>
     );
   }

--- a/src/shared/components/person/registration-applications.tsx
+++ b/src/shared/components/person/registration-applications.tsx
@@ -110,6 +110,7 @@ export class RegistrationApplications extends Component<
               <Paginator
                 page={this.state.page}
                 onChange={this.handlePageChange}
+                nextDisabled={fetchLimit > apps.length}
               />
             </div>
           </div>

--- a/src/shared/components/person/reports.tsx
+++ b/src/shared/components/person/reports.tsx
@@ -160,6 +160,16 @@ export class Reports extends Component<any, ReportsState> {
             <Paginator
               page={this.state.page}
               onChange={this.handlePageChange}
+              nextDisabled={
+                (this.state.messageType === MessageType.All &&
+                  fetchLimit > this.buildCombined.length) ||
+                (this.state.messageType === MessageType.CommentReport &&
+                  fetchLimit > this.commentReports.length) ||
+                (this.state.messageType === MessageType.PostReport &&
+                  fetchLimit > this.postReports.length) ||
+                (this.state.messageType === MessageType.PrivateMessageReport &&
+                  fetchLimit > this.privateMessageReports.length)
+              }
             />
           </div>
         </div>

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -479,7 +479,14 @@ export class Search extends Component<any, SearchState> {
           this.state.searchRes.state === "success" && (
             <span>{I18NextService.i18n.t("no_results")}</span>
           )}
-        <Paginator page={page} onChange={this.handlePageChange} />
+        <Paginator
+          page={page}
+          onChange={this.handlePageChange}
+          nextDisabled={
+            this.state.searchRes.state !== "success" ||
+            fetchLimit > this.resultsCount
+          }
+        />
       </div>
     );
   }

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -28,6 +28,10 @@ export const relTags = "noopener nofollow";
 export const emDash = "\u2014";
 export const authCookieName = "jwt";
 
+// No. of max displayed communities per
+// page on route "/communities"
+export const communityLimit = 50;
+
 /**
  * Accepted formats:
  * !community@server.com


### PR DESCRIPTION
## Description
It may cause confusion to the user why pages in the community list are empty when there are no more communities to display. This small change fixes this issue by disabling the Next button if the number of fetched communities is less than the limit.

Additionally, I have moved the communityLimit constant to the config file.

## Possible issues with this approach
The Next button will be still enabled, if there are exactly _{communityLimit}_ communities on the instance, to mitigate this the API would have to tell the client if currently viewed page is last, or the client could fetch next page in advance.