### PR TITLE
Changed blocked instances to not be linked from instance page

### DIFF
--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -102,7 +102,9 @@ export class Instances extends Component<any, InstancesState> {
                           active: isSelected,
                         })}
                       >
-                        {this.itemList(instances[status])}
+                        {status === "blocked"
+                          ? this.itemList(instances[status], false)
+                          : this.itemList(instances[status])}
                       </div>
                     ),
                   }))}
@@ -128,7 +130,7 @@ export class Instances extends Component<any, InstancesState> {
     );
   }
 
-  itemList(items: Instance[]) {
+  itemList(items: Instance[], link = true) {
     return items.length > 0 ? (
       <div className="table-responsive">
         <table id="instances_table" className="table table-sm table-hover">
@@ -143,9 +145,13 @@ export class Instances extends Component<any, InstancesState> {
             {items.map(i => (
               <tr key={i.domain}>
                 <td>
-                  <a href={`https://${i.domain}`} rel={relTags}>
-                    {i.domain}
-                  </a>
+                  {link ? (
+                    <a href={`https://${i.domain}`} rel={relTags}>
+                      {i.domain}{" "}
+                    </a>
+                  ) : (
+                    <span>{i.domain}</span>
+                  )}
                 </td>
                 <td>{i.software}</td>
                 <td>{i.version}</td>


### PR DESCRIPTION
Remove  `a href` attribute from instances on the `blocked` tab.

Fixes <https://github.com/LemmyNet/lemmy-ui/issues/2065>

## Screenshots
[![blocked-instances.png](https://i.postimg.cc/7PSXzVqJ/blocked-instances.png)](https://postimg.cc/xqTKDLJ9)

Doesn't depend on but results are better, if the [Lemmy PR](https://github.com/LemmyNet/lemmy/pull/3957) - is approved as well.

