### PR TITLE
Increase cache-control max-age to 60s

### DIFF
--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -55,7 +55,7 @@ export function setCacheControl(
     if (hasJwtCookie(req)) {
       caching = "private";
     } else {
-      caching = "public, max-age=5";
+      caching = "public, max-age=60";
     }
   }
 


### PR DESCRIPTION
## Description

Cache headers have been active in production for a while now, and I didnt see any issues reported. So it should be save to increase the max-age to reduce server load further.

