### PR TITLE
allow limited markdown in spoiler summary

### DIFF
--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -61,10 +61,11 @@ const spoilerConfig = {
 
   render: (tokens: any, idx: any) => {
     var m = tokens[idx].info.trim().match(/^spoiler\s+(.*)$/);
+    var summary = mdToHtmlInline(md.utils.escapeHtml(m[1])).__html;
 
     if (tokens[idx].nesting === 1) {
       // opening tag
-      return `<details><summary> ${md.utils.escapeHtml(m[1])} </summary>\n`;
+      return `<details><summary> ${summary} </summary>\n`;
     } else {
       // closing tag
       return "</details>\n";

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -60,8 +60,8 @@ const spoilerConfig = {
   },
 
   render: (tokens: any, idx: any) => {
-    var m = tokens[idx].info.trim().match(/^spoiler\s+(.*)$/);
-    var summary = mdToHtmlInline(md.utils.escapeHtml(m[1])).__html;
+    const m = tokens[idx].info.trim().match(/^spoiler\s+(.*)$/);
+    const summary = mdToHtmlInline(md.utils.escapeHtml(m[1])).__html;
 
     if (tokens[idx].nesting === 1) {
       // opening tag
@@ -111,7 +111,7 @@ function localInstanceLinkParser(md: MarkdownIt) {
               newTokens.push(textToken);
             }
 
-            let href;
+            let href: string;
             if (match[0].startsWith("!")) {
               href = "/c/" + match[0].substring(1);
             } else if (match[0].startsWith("/m/")) {


### PR DESCRIPTION
## Description

Parse markdown in spoiler summaries (the text you see before expanding it)
Only the limited markdown parser with only emphasis, backticks and strikethrough allowed to prevent issues with unexpected content there.

## Screenshots

![spoiler](https://github.com/LemmyNet/lemmy-ui/assets/64695423/d5e274f0-16fc-461f-87d2-0c56bdefa917)