### PR TITLE
Don't hide the 'show source' button for anonymous users

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -604,7 +604,8 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   }
 
   commentsLine(mobile = false) {
-    const post = this.postView.post;
+    const post_view = this.postView;
+    const post = post_view.post;
 
     return (
       <div className="d-flex align-items-center justify-content-start flex-wrap text-muted">
@@ -637,6 +638,9 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             my_vote={this.postView.my_vote}
           />
         )}
+
+        {this.props.showBody && post_view.post.body && this.viewSourceButton}
+
         {UserService.Instance.myUserInfo &&
           !this.props.viewOnly &&
           this.postActions()}
@@ -654,8 +658,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <>
         {this.saveButton}
         {this.crossPostButton}
-
-        {this.props.showBody && post_view.post.body && this.viewSourceButton}
 
         <div className="dropdown">
           <button


### PR DESCRIPTION
## Description

Users that are not logged in should be able to use the existing button to show the raw markdown for a post.
The button can also be hidden with the viewOnly option in post-listing but I think this is the intended behaviour

## Screenshots

![postSource](https://github.com/LemmyNet/lemmy-ui/assets/64695423/52a6d06a-c4cc-4869-977a-8e4b5711b02b)

Fixes https://github.com/LemmyNet/lemmy-ui/issues/2086