### PR TITLE
fix inbox read filtering

### DIFF
--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -918,12 +918,20 @@ export class Inbox extends Component<any, InboxState> {
 
   async handleCommentReplyRead(form: MarkCommentReplyAsRead) {
     const res = await HttpService.client.markCommentReplyAsRead(form);
-    this.findAndUpdateCommentReply(res);
+    if (this.state.unreadOrAll === UnreadOrAll.All) {
+      this.findAndUpdateCommentReply(res);
+    } else {
+      await this.refetch();
+    }
   }
 
   async handlePersonMentionRead(form: MarkPersonMentionAsRead) {
     const res = await HttpService.client.markPersonMentionAsRead(form);
-    this.findAndUpdateMention(res);
+    if (this.state.unreadOrAll === UnreadOrAll.All) {
+      this.findAndUpdateMention(res);
+    } else {
+      await this.refetch();
+    }
   }
 
   async handleBanFromCommunity(form: BanFromCommunity) {
@@ -948,7 +956,11 @@ export class Inbox extends Component<any, InboxState> {
 
   async handleMarkMessageAsRead(form: MarkPrivateMessageAsRead) {
     const res = await HttpService.client.markPrivateMessageAsRead(form);
-    this.findAndUpdateMessage(res);
+    if (this.state.unreadOrAll === UnreadOrAll.All) {
+      this.findAndUpdateMessage(res);
+    } else {
+      await this.refetch();
+    }
   }
 
   async handleMessageReport(form: CreatePrivateMessageReport) {


### PR DESCRIPTION
## Description

Refetch the inbox when marking a message as read.
I would advise against just refiltering the messages due to the pagination. When a user marks a message as read and has more than 10 (or 20?) messages as unread, they will eventually run out of messages in the page, while still having unread messages.

Fixes https://github.com/LemmyNet/lemmy-ui/issues/2094
