### PR TITLE
Improve notifications

### DIFF
--- a/src/shared/components/app/navbar.tsx
+++ b/src/shared/components/app/navbar.tsx
@@ -51,12 +51,16 @@ export class Navbar extends Component<NavbarProps, NavbarState> {
     unreadApplicationCount: 0,
   };
 
-  updateUnreads = (service: UnreadCounterService) => {
+  updateUnreads = ({
+    unreadInboxCount,
+    unreadReportCount,
+    unreadApplicationCount,
+  }: UnreadCounterService) => {
     this.setState({
       ...this.state,
-      unreadInboxCount: service.unreadInboxCount,
-      unreadReportCount: service.unreadReportCount,
-      unreadApplicationCount: service.unreadApplicationCount,
+      unreadInboxCount,
+      unreadReportCount,
+      unreadApplicationCount,
     });
   };
 

--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -64,6 +64,7 @@ import { fetchLimit, relTags } from "../../config";
 import { CommentViewType, InitialFetchRequest } from "../../interfaces";
 import { FirstLoadService, I18NextService, UserService } from "../../services";
 import { HttpService, RequestState } from "../../services/HttpService";
+import { UnreadCounterService } from "../../services";
 import { toast } from "../../toast";
 import { CommentNodes } from "../comment/comment-nodes";
 import { CommentSortSelect } from "../common/comment-sort-select";
@@ -791,6 +792,7 @@ export class Inbox extends Component<any, InboxState> {
         auth,
       }),
     });
+    UnreadCounterService.Instance.update();
   }
 
   async handleSortChange(val: CommentSortType) {

--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -67,7 +67,8 @@ import {
   EmptyRequestState,
   HttpService,
   RequestState,
-} from "../../services/HttpService";import { toast } from "../../toast";
+} from "../../services/HttpService";
+import { toast } from "../../toast";
 import { CommentNodes } from "../comment/comment-nodes";
 import { CommentSortSelect } from "../common/comment-sort-select";
 import { HtmlTags } from "../common/html-tags";

--- a/src/shared/services/UnreadCounterService.ts
+++ b/src/shared/services/UnreadCounterService.ts
@@ -4,6 +4,7 @@ import { poll } from "@utils/helpers";
 import { myAuth } from "@utils/app";
 import { amAdmin } from "@utils/roles";
 import { isBrowser } from "@utils/browser";
+import { BehaviorSubject } from "rxjs";
 
 /**
  * Service to poll and keep track of unread messages / notifications.
@@ -13,20 +14,21 @@ export class UnreadCounterService {
   unreadPrivateMessages = 0;
   unreadReplies = 0;
   unreadMentions = 0;
-  public unreadInboxCount = 0;
+  public unreadInboxCountSubject: BehaviorSubject<number> =
+    new BehaviorSubject<number>(0);
 
   // fetched by HttpService.getReportCount, appear in report page
   commentReportCount = 0;
   postReportCount = 0;
   messageReportCount = 0;
-  public unreadReportCount = 0;
+  public unreadReportCountSubject: BehaviorSubject<number> =
+    new BehaviorSubject<number>(0);
 
   // fetched by HttpService.getUnreadRegistrationApplicationCount, appear in registration application page
-  public unreadApplicationCount = 0;
+  public unreadApplicationCountSubject: BehaviorSubject<number> =
+    new BehaviorSubject<number>(0);
 
   static #instance: UnreadCounterService;
-  private subscriptions = new Set<(service: UnreadCounterService) => void>();
-  private fetching = false;
 
   constructor() {
     if (isBrowser()) {
@@ -41,14 +43,14 @@ export class UnreadCounterService {
     if (!myAuth()) {
       return;
     }
-    this.fetching = true;
     const unreadCountRes = await HttpService.client.getUnreadCount();
     if (unreadCountRes.state === "success") {
       this.unreadPrivateMessages = unreadCountRes.data.private_messages;
       this.unreadReplies = unreadCountRes.data.replies;
       this.unreadMentions = unreadCountRes.data.mentions;
-      this.unreadInboxCount =
-        this.unreadPrivateMessages + this.unreadReplies + this.unreadMentions;
+      this.unreadInboxCountSubject.next(
+        this.unreadPrivateMessages + this.unreadReplies + this.unreadMentions,
+      );
     }
     if (UserService.Instance.moderatesSomething) {
       const reportCountRes = await HttpService.client.getReportCount({});
@@ -57,34 +59,23 @@ export class UnreadCounterService {
         this.postReportCount = reportCountRes.data.post_reports ?? 0;
         this.messageReportCount =
           reportCountRes.data.private_message_reports ?? 0;
-        this.unreadReportCount =
+        this.unreadReportCountSubject.next(
           this.commentReportCount +
-          this.postReportCount +
-          this.messageReportCount;
+            this.postReportCount +
+            this.messageReportCount,
+        );
       }
     }
     if (amAdmin()) {
       const unreadApplicationsRes =
         await HttpService.client.getUnreadRegistrationApplicationCount();
       if (unreadApplicationsRes.state === "success") {
-        this.unreadApplicationCount =
-          unreadApplicationsRes.data.registration_applications;
+        this.unreadApplicationCountSubject.next(
+          unreadApplicationsRes.data.registration_applications,
+        );
       }
     }
-    this.fetching = false;
-    this.subscriptions.forEach(action => action(this));
   };
-
-  subscribe(action: (service: UnreadCounterService) => any) {
-    this.subscriptions.add(action);
-    if (!this.fetching) {
-      this.update();
-    }
-  }
-
-  unsubscribe(action: (service: UnreadCounterService) => any) {
-    this.subscriptions.delete(action);
-  }
 
   static get Instance() {
     return this.#instance ?? (this.#instance = new this());

--- a/src/shared/services/UnreadCounterService.ts
+++ b/src/shared/services/UnreadCounterService.ts
@@ -43,7 +43,7 @@ export class UnreadCounterService {
       return;
     }
     this.fetching = true;
-    const unreadCountRes = await HttpService.client.getUnreadCount({ auth });
+    const unreadCountRes = await HttpService.client.getUnreadCount();
     if (unreadCountRes.state === "success") {
       this.unreadPrivateMessages = unreadCountRes.data.private_messages;
       this.unreadReplies = unreadCountRes.data.replies;
@@ -52,7 +52,7 @@ export class UnreadCounterService {
         this.unreadPrivateMessages + this.unreadReplies + this.unreadMentions;
     }
     if (UserService.Instance.moderatesSomething) {
-      const reportCountRes = await HttpService.client.getReportCount({ auth });
+      const reportCountRes = await HttpService.client.getReportCount({});
       if (reportCountRes.state === "success") {
         this.commentReportCount = reportCountRes.data.comment_reports ?? 0;
         this.postReportCount = reportCountRes.data.post_reports ?? 0;
@@ -66,9 +66,7 @@ export class UnreadCounterService {
     }
     if (amAdmin()) {
       const unreadApplicationsRes =
-        await HttpService.client.getUnreadRegistrationApplicationCount({
-          auth,
-        });
+        await HttpService.client.getUnreadRegistrationApplicationCount();
       if (unreadApplicationsRes.state === "success") {
         this.unreadApplicationCount =
           unreadApplicationsRes.data.registration_applications;

--- a/src/shared/services/UnreadCounterService.ts
+++ b/src/shared/services/UnreadCounterService.ts
@@ -1,5 +1,4 @@
-import { HttpService } from "./HttpService";
-import { UserService } from "../services";
+import { UserService, HttpService } from "../services";
 import { updateUnreadCountsInterval } from "../config";
 import { poll } from "@utils/helpers";
 import { myAuth } from "@utils/app";
@@ -35,7 +34,7 @@ export class UnreadCounterService {
     }
   }
 
-  update = async () => {
+  public update = async () => {
     if (window.document.visibilityState === "hidden") {
       return;
     }

--- a/src/shared/services/UnreadCounterService.ts
+++ b/src/shared/services/UnreadCounterService.ts
@@ -1,0 +1,96 @@
+import { HttpService } from "./HttpService";
+import { UserService } from "../services";
+import { updateUnreadCountsInterval } from "../config";
+import { poll } from "@utils/helpers";
+import { myAuth } from "@utils/app";
+import { amAdmin } from "@utils/roles";
+import { isBrowser } from "@utils/browser";
+
+/**
+ * Service to poll and keep track of unread messages / notifications.
+ */
+export class UnreadCounterService {
+  // fetched by HttpService.getUnreadCount, appear in inbox
+  unreadPrivateMessages = 0;
+  unreadReplies = 0;
+  unreadMentions = 0;
+  public unreadInboxCount = 0;
+
+  // fetched by HttpService.getReportCount, appear in report page
+  commentReportCount = 0;
+  postReportCount = 0;
+  messageReportCount = 0;
+  public unreadReportCount = 0;
+
+  // fetched by HttpService.getUnreadRegistrationApplicationCount, appear in registration application page
+  public unreadApplicationCount = 0;
+
+  static #instance: UnreadCounterService;
+  private subscriptions = new Set<(service: UnreadCounterService) => any>();
+  private fetching = false;
+
+  constructor() {
+    if (isBrowser()) {
+      poll(this.update, updateUnreadCountsInterval);
+    }
+  }
+
+  update = async () => {
+    if (window.document.visibilityState === "hidden") {
+      return;
+    }
+    const auth = myAuth();
+    if (!auth) {
+      return;
+    }
+    this.fetching = true;
+    const unreadCountRes = await HttpService.client.getUnreadCount({ auth });
+    if (unreadCountRes.state === "success") {
+      this.unreadPrivateMessages = unreadCountRes.data.private_messages;
+      this.unreadReplies = unreadCountRes.data.replies;
+      this.unreadMentions = unreadCountRes.data.mentions;
+      this.unreadInboxCount =
+        this.unreadPrivateMessages + this.unreadReplies + this.unreadMentions;
+    }
+    if (UserService.Instance.moderatesSomething) {
+      const reportCountRes = await HttpService.client.getReportCount({ auth });
+      if (reportCountRes.state === "success") {
+        this.commentReportCount = reportCountRes.data.comment_reports ?? 0;
+        this.postReportCount = reportCountRes.data.post_reports ?? 0;
+        this.messageReportCount =
+          reportCountRes.data.private_message_reports ?? 0;
+        this.unreadReportCount =
+          this.commentReportCount +
+          this.postReportCount +
+          this.messageReportCount;
+      }
+    }
+    if (amAdmin()) {
+      const unreadApplicationsRes =
+        await HttpService.client.getUnreadRegistrationApplicationCount({
+          auth,
+        });
+      if (unreadApplicationsRes.state === "success") {
+        this.unreadApplicationCount =
+          unreadApplicationsRes.data.registration_applications;
+      }
+    }
+    this.fetching = false;
+    this.subscriptions.forEach(action => action(this));
+  };
+
+  subscribe(action: (service: UnreadCounterService) => any) {
+    this.subscriptions.add(action);
+    if (!this.fetching) {
+      this.update();
+    }
+  }
+
+  unsubscribe(action: (service: UnreadCounterService) => any) {
+    this.subscriptions.delete(action);
+  }
+
+  static get Instance() {
+    return this.#instance ?? (this.#instance = new this());
+  }
+}

--- a/src/shared/services/UnreadCounterService.ts
+++ b/src/shared/services/UnreadCounterService.ts
@@ -25,7 +25,7 @@ export class UnreadCounterService {
   public unreadApplicationCount = 0;
 
   static #instance: UnreadCounterService;
-  private subscriptions = new Set<(service: UnreadCounterService) => any>();
+  private subscriptions = new Set<(service: UnreadCounterService) => void>();
   private fetching = false;
 
   constructor() {
@@ -38,8 +38,7 @@ export class UnreadCounterService {
     if (window.document.visibilityState === "hidden") {
       return;
     }
-    const auth = myAuth();
-    if (!auth) {
+    if (!myAuth()) {
       return;
     }
     this.fetching = true;

--- a/src/shared/services/UserService.ts
+++ b/src/shared/services/UserService.ts
@@ -90,9 +90,7 @@ export class UserService {
   }
 
   public get moderatesSomething(): boolean {
-    const mods = this.myUserInfo?.moderates;
-    const moderatesS = (mods && mods.length > 0) || false;
-    return amAdmin() || moderatesS;
+    return amAdmin() || (this.myUserInfo?.moderates?.length ?? 0) > 0;
   }
 
   public static get Instance() {

--- a/src/shared/services/UserService.ts
+++ b/src/shared/services/UserService.ts
@@ -5,6 +5,7 @@ import jwt_decode from "jwt-decode";
 import { LoginResponse, MyUserInfo } from "lemmy-js-client";
 import { toast } from "../toast";
 import { I18NextService } from "./I18NextService";
+import { amAdmin } from "@utils/roles";
 
 interface Claims {
   sub: number;
@@ -84,6 +85,12 @@ export class UserService {
         this.jwtInfo = { jwt, claims: jwt_decode(jwt) };
       }
     }
+  }
+
+  public get moderatesSomething(): boolean {
+    const mods = this.myUserInfo?.moderates;
+    const moderatesS = (mods && mods.length > 0) || false;
+    return amAdmin() || moderatesS;
   }
 
   public static get Instance() {

--- a/src/shared/services/index.ts
+++ b/src/shared/services/index.ts
@@ -3,3 +3,4 @@ export { HomeCacheService } from "./HomeCacheService";
 export { HttpService } from "./HttpService";
 export { I18NextService } from "./I18NextService";
 export { UserService } from "./UserService";
+export { UnreadCounterService } from "./UnreadCounterService";


### PR DESCRIPTION
## Description

Streamline the user experience by making the inbox counter more responsive.

Fixes https://github.com/LemmyNet/lemmy-ui/issues/1744

Right now, lemmy sends a cache header for some frequently queried data, like api/v3/user/unread_count or /api/v3/private_message/list of 60s.

When updating a message to be displayed as read, I would ideally like to just refresh the notification counter, but get old cached data from the browser.

@Nutomic @dessalines Is this caching behaviour intended or should it be changed on the backend? If a client is acting correctly, it should just avoid sending a request more than every minute but shortly after making changes, I think it would be wise to allow it to update.

An alternative might be to just update the view on the client and purely hope the server registers the changes but a user might find it useful to get immediate feedback of the new data that is stored on the server (to avoid desync of client and server).