### PR TITLE
Smart url parsing

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -21,6 +21,7 @@ import { EmojiPicker } from "./emoji-picker";
 import { Icon, Spinner } from "./icon";
 import { LanguageSelect } from "./language-select";
 import ProgressBar from "./progress-bar";
+import validUrl from "@utils/helpers/valid-url";
 interface MarkdownTextAreaProps {
   /**
    * Initial content inside the textarea
@@ -385,14 +386,13 @@ export class MarkdownTextArea extends Component<
     }
 
     // check clipboard url
-    const url = i.isValidUrl(event.clipboardData.getData("text"));
-    if (url) {
+    const url = event.clipboardData.getData("text");
+    if (validUrl(url)) {
       i.handleUrlPaste(url, i, event);
-      return;
     }
   }
 
-  handleUrlPaste(url: URL, i: MarkdownTextArea, event: ClipboardEvent) {
+  handleUrlPaste(url: string, i: MarkdownTextArea, event: ClipboardEvent) {
     // query textarea element
     const textarea = document.getElementById(i.id);
 
@@ -409,9 +409,7 @@ export class MarkdownTextArea extends Component<
       i.setState(({ content }) => ({
         content: `${
           content?.substring(0, selectionStart) ?? ""
-        }[${selectedText}](${url.toString()})${
-          content?.substring(selectionEnd) ?? ""
-        }`,
+        }[${selectedText}](${url})${content?.substring(selectionEnd) ?? ""}`,
       }));
       i.contentChange();
 
@@ -420,17 +418,6 @@ export class MarkdownTextArea extends Component<
         selectionStart + 1,
         selectionStart + 1 + selectedText.length,
       );
-    }
-  }
-
-  isValidUrl(value: string) {
-    if (!value) return false;
-
-    try {
-      const url = new URL(value);
-      return url;
-    } catch {
-      return false;
     }
   }
 

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -397,18 +397,22 @@ export class MarkdownTextArea extends Component<
     const textarea = document.getElementById(i.id);
 
     if (textarea instanceof HTMLTextAreaElement) {
-      event.preventDefault();
       const { selectionStart, selectionEnd } = textarea;
-      const selectedText = i.getSelectedText() || url.toString();
+
+      // if no selection, just insert url
+      if (selectionStart === selectionEnd) return;
+
+      event.preventDefault();
+      const selectedText = i.getSelectedText();
 
       // update textarea content
-      i.setState({
+      i.setState(({ content }) => ({
         content: `${
-          i.state.content ? i.state.content.substring(0, selectionStart) : ""
+          content?.substring(0, selectionStart) ?? ""
         }[${selectedText}](${url.toString()})${
-          i.state.content ? i.state.content.substring(selectionEnd) : ""
+          content?.substring(selectionEnd) ?? ""
         }`,
-      });
+      }));
       i.contentChange();
 
       // shift selection 1 to the right

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -385,42 +385,46 @@ export class MarkdownTextArea extends Component<
     }
 
     // check clipboard url
-    const url = event.clipboardData.getData("text");
-    if (i.isValidUrl(url)) {
+    const url = i.isValidUrl(event.clipboardData.getData("text"));
+    if (url) {
       i.handleUrlPaste(url, i, event);
       return;
     }
   }
 
-  handleUrlPaste(url: string, i: MarkdownTextArea, event: ClipboardEvent) {
+  handleUrlPaste(url: URL, i: MarkdownTextArea, event: ClipboardEvent) {
     // query textarea element
     const textarea = document.getElementById(i.id);
 
     if (textarea instanceof HTMLTextAreaElement) {
       event.preventDefault();
       const { selectionStart, selectionEnd } = textarea;
+      const selectedText = i.getSelectedText() || url.toString();
 
       // update textarea content
       i.setState({
         content: `${
           i.state.content ? i.state.content.substring(0, selectionStart) : ""
-        }[${i.getSelectedText()}](${url})${
+        }[${selectedText}](${url.toString()})${
           i.state.content ? i.state.content.substring(selectionEnd) : ""
         }`,
       });
       i.contentChange();
 
       // shift selection 1 to the right
-      textarea.setSelectionRange(selectionStart + 1, selectionEnd + 1);
+      textarea.setSelectionRange(
+        selectionStart + 1,
+        selectionStart + 1 + selectedText.length,
+      );
     }
   }
 
-  isValidUrl(value: string): boolean {
+  isValidUrl(value: string) {
     if (!value) return false;
 
     try {
-      new URL(value);
-      return true;
+      const url = new URL(value);
+      return url;
     } catch {
       return false;
     }


### PR DESCRIPTION
## Description

This PR resolves #2116 

Update: The behaviour is now a bit more similar to how Github handles this. I have also updated the video to show the new behaviour

Adds logic to detect if a paste event contains a URL. If true the URL will be formatted with the appropriate markdown. Open to suggestions on how to handle text selection after the paste event. The current implementation is demonstrated in the videos below.

It might also be better to implement this in the same way github does this, only adding formatting if text is already selected and otherwise just pasting the plain link, which might make things easier to read in the editor if no alternative link text is desired.

## Screenshots

### Before
[Screencast from 2023-09-24 17-30-03.webm](https://github.com/LemmyNet/lemmy-ui/assets/19306765/9b175520-77fa-42af-880c-fe16012c092f)

### After
[Screencast from 2023-09-26 21-59-39.webm](https://github.com/LemmyNet/lemmy-ui/assets/19306765/55bcdac4-c705-4301-adb6-c10a9487c266)



