### PR TITLE
Husky fix for production build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemmy-ui",
-  "version": "0.19.0-rc.1",
+  "version": "0.19.0-beta.1",
   "description": "An isomorphic UI for lemmy",
   "repository": "https://github.com/LemmyNet/lemmy-ui",
   "license": "AGPL-3.0",
@@ -23,9 +23,16 @@
     "translations:update": "git submodule update --remote --recursive"
   },
   "lint-staged": {
-    "*.{ts,tsx,js}": ["prettier --write", "eslint --fix"],
-    "*.{css, scss}": ["prettier --write"],
-    "package.json": ["sortpack"]
+    "*.{ts,tsx,js}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{css, scss}": [
+      "prettier --write"
+    ],
+    "package.json": [
+      "sortpack"
+    ]
   },
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.21.5",
@@ -52,6 +59,7 @@
     "express": "~4.18.2",
     "history": "^5.3.0",
     "html-to-text": "^9.0.5",
+    "husky": "^8.0.3",
     "i18next": "^23.3.0",
     "inferno": "^8.2.2",
     "inferno-create-element": "^8.2.2",
@@ -82,7 +90,6 @@
     "sharp": "^0.32.4",
     "tippy.js": "^6.3.7",
     "toastify-js": "^1.12.0",
-    "husky": "^8.0.3",
     "tributejs": "^5.1.3",
     "webpack": "5.88.2",
     "webpack-cli": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -23,16 +23,9 @@
     "translations:update": "git submodule update --remote --recursive"
   },
   "lint-staged": {
-    "*.{ts,tsx,js}": [
-      "prettier --write",
-      "eslint --fix"
-    ],
-    "*.{css, scss}": [
-      "prettier --write"
-    ],
-    "package.json": [
-      "sortpack"
-    ]
+    "*.{ts,tsx,js}": ["prettier --write", "eslint --fix"],
+    "*.{css, scss}": ["prettier --write"],
+    "package.json": ["sortpack"]
   },
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.21.5",
@@ -89,6 +82,7 @@
     "sharp": "^0.32.4",
     "tippy.js": "^6.3.7",
     "toastify-js": "^1.12.0",
+    "husky": "^8.0.3",
     "tributejs": "^5.1.3",
     "webpack": "5.88.2",
     "webpack-cli": "^5.1.4",
@@ -116,7 +110,6 @@
     "eslint-plugin-inferno": "^7.32.2",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-prettier": "^5.0.0",
-    "husky": "^8.0.3",
     "import-sort-style-module": "^6.0.0",
     "lint-staged": "^13.2.3",
     "prettier": "^3.0.0",


### PR DESCRIPTION
Really weird husky issue that's causing the prod build to fail: https://github.com/typicode/husky/issues/945

Moved it from devDependencies to dependencies. It doesn't get bundled anyway so its nbd.