### PR TITLE
fix: Prevent login screen from redirecting to signup

### DIFF
--- a/src/shared/components/app/app.tsx
+++ b/src/shared/components/app/app.tsx
@@ -1,4 +1,4 @@
-import { isAuthPath, setIsoData } from "@utils/app";
+import { isAnonymousPath, isAuthPath, setIsoData } from "@utils/app";
 import { dataBsTheme } from "@utils/browser";
 import { Component, RefObject, createRef, linkEvent } from "inferno";
 import { Provider } from "inferno-i18next-dess";
@@ -14,6 +14,7 @@ import { Footer } from "./footer";
 import { Navbar } from "./navbar";
 import "./styles.scss";
 import { Theme } from "./theme";
+import AnonymousGuard from "../common/anonymous-guard";
 
 interface AppProps {
   user?: MyUserInfo;
@@ -78,6 +79,10 @@ export class App extends Component<AppProps, any> {
                                   <AuthGuard {...routeProps}>
                                     <RouteComponent {...routeProps} />
                                   </AuthGuard>
+                                ) : isAnonymousPath(path ?? "") ? (
+                                  <AnonymousGuard>
+                                    <RouteComponent {...routeProps} />
+                                  </AnonymousGuard>
                                 ) : (
                                   <RouteComponent {...routeProps} />
                                 ))}

--- a/src/shared/components/common/anonymous-guard.tsx
+++ b/src/shared/components/common/anonymous-guard.tsx
@@ -1,0 +1,35 @@
+import { Component } from "inferno";
+import { RouteComponentProps } from "inferno-router/dist/Route";
+import { UserService } from "../../services";
+import { Spinner } from "./icon";
+
+interface AnonymousGuardState {
+  hasRedirected: boolean;
+}
+
+class AnonymousGuard extends Component<any, AnonymousGuardState> {
+  state = {
+    hasRedirected: false,
+  } as AnonymousGuardState;
+
+  constructor(
+    props: RouteComponentProps<Record<string, string>>,
+    context: any,
+  ) {
+    super(props, context);
+  }
+
+  componentDidMount() {
+    if (UserService.Instance.myUserInfo) {
+      this.context.router.history.replace(`/`);
+    } else {
+      this.setState({ hasRedirected: true });
+    }
+  }
+
+  render() {
+    return this.state.hasRedirected ? this.props.children : <Spinner />;
+  }
+}
+
+export default AnonymousGuard;

--- a/src/shared/components/common/anonymous-guard.tsx
+++ b/src/shared/components/common/anonymous-guard.tsx
@@ -1,5 +1,4 @@
 import { Component } from "inferno";
-import { RouteComponentProps } from "inferno-router/dist/Route";
 import { UserService } from "../../services";
 import { Spinner } from "./icon";
 
@@ -12,10 +11,7 @@ class AnonymousGuard extends Component<any, AnonymousGuardState> {
     hasRedirected: false,
   } as AnonymousGuardState;
 
-  constructor(
-    props: RouteComponentProps<Record<string, string>>,
-    context: any,
-  ) {
+  constructor(props: any, context: any) {
     super(props, context);
   }
 

--- a/src/shared/components/common/subscribe-button.tsx
+++ b/src/shared/components/common/subscribe-button.tsx
@@ -201,6 +201,8 @@ class RemoteFetchModal extends Component<
                 value={this.state.instanceText}
                 onInput={linkEvent(this, handleInput)}
                 required
+                enterKeyHint="go"
+                inputMode="url"
               />
             </form>
             <footer className="modal-footer">

--- a/src/shared/components/common/totp-modal.tsx
+++ b/src/shared/components/common/totp-modal.tsx
@@ -226,6 +226,7 @@ export default class TotpModal extends Component<
                       ref={element => {
                         this.inputRefs[i] = element;
                       }}
+                      enterKeyHint="done"
                     />
                   ))}
                 </div>

--- a/src/shared/components/home/login-reset.tsx
+++ b/src/shared/components/home/login-reset.tsx
@@ -2,7 +2,7 @@ import { setIsoData } from "@utils/app";
 import { capitalizeFirstLetter, validEmail } from "@utils/helpers";
 import { Component, linkEvent } from "inferno";
 import { GetSiteResponse } from "lemmy-js-client";
-import { HttpService, I18NextService, UserService } from "../../services";
+import { HttpService, I18NextService } from "../../services";
 import { toast } from "../../toast";
 import { HtmlTags } from "../common/html-tags";
 import { Spinner } from "../common/icon";
@@ -28,12 +28,6 @@ export class LoginReset extends Component<any, State> {
 
   constructor(props: any, context: any) {
     super(props, context);
-  }
-
-  componentDidMount() {
-    if (UserService.Instance.myUserInfo) {
-      this.context.router.history.push("/");
-    }
   }
 
   get documentTitle(): string {

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -124,13 +124,6 @@ export class Login extends Component<
     this.handleSubmitTotp = this.handleSubmitTotp.bind(this);
   }
 
-  componentDidMount() {
-    // Navigate to home if already logged in
-    if (UserService.Instance.myUserInfo) {
-      this.context.router.history.push("/");
-    }
-  }
-
   get documentTitle(): string {
     return `${I18NextService.i18n.t("login")} - ${
       this.state.siteRes.site_view.site.name

--- a/src/shared/utils/app/index.ts
+++ b/src/shared/utils/app/index.ts
@@ -54,6 +54,7 @@ import updateCommunityBlock from "./update-community-block";
 import updatePersonBlock from "./update-person-block";
 import instanceToChoice from "./instance-to-choice";
 import updateInstanceBlock from "./update-instance-block";
+import isAnonymousPath from "./is-anonymous-path";
 
 export {
   buildCommentsTree,
@@ -112,4 +113,5 @@ export {
   updatePersonBlock,
   instanceToChoice,
   updateInstanceBlock,
+  isAnonymousPath,
 };

--- a/src/shared/utils/app/is-anonymous-path.ts
+++ b/src/shared/utils/app/is-anonymous-path.ts
@@ -1,0 +1,5 @@
+export default function isAnonymousPath(pathname: string) {
+  return /^\/(login.*|signup|password_change.*|verify_email.*)\b/g.test(
+    pathname,
+  );
+}


### PR DESCRIPTION
Fixes an issue where login screen could redirect to signup page after login. Also make guard for pages that should only be viewed when not logged in.