### PR TITLE
Adding cursor pagination. Fixes #2155

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -20,21 +20,26 @@ const [hostname, port] = process.env["LEMMY_UI_HOST"]
 
 server.use(express.json());
 server.use(express.urlencoded({ extended: false }));
-server.use(
-  getStaticDir(),
-  express.static(path.resolve("./dist"), {
-    maxAge: 24 * 60 * 60 * 1000, // 1 day
-    immutable: true,
-  }),
-);
-server.use(setCacheControl);
+
+const serverPath = path.resolve("./dist");
 
 if (
   !process.env["LEMMY_UI_DISABLE_CSP"] &&
   !process.env["LEMMY_UI_DEBUG"] &&
   process.env["NODE_ENV"] !== "development"
 ) {
+  server.use(
+    getStaticDir(),
+    express.static(serverPath, {
+      maxAge: 24 * 60 * 60 * 1000, // 1 day
+      immutable: true,
+    }),
+  );
   server.use(setDefaultCsp);
+  server.use(setCacheControl);
+} else {
+  // In debug mode, don't use the maxAge and immutable, or it breaks live reload for dev
+  server.use(getStaticDir(), express.static(serverPath));
 }
 
 server.get("/.well-known/security.txt", SecurityHandler);

--- a/src/shared/components/common/paginator-cursor.tsx
+++ b/src/shared/components/common/paginator-cursor.tsx
@@ -1,0 +1,46 @@
+import { Component, linkEvent } from "inferno";
+import { I18NextService } from "../../services";
+import { PaginationCursor } from "lemmy-js-client";
+
+interface PaginatorCursorProps {
+  prevPage?: PaginationCursor;
+  nextPage?: PaginationCursor;
+  onNext(val: PaginationCursor): any;
+  onPrev(): any;
+}
+
+export class PaginatorCursor extends Component<PaginatorCursorProps, any> {
+  constructor(props: any, context: any) {
+    super(props, context);
+  }
+  render() {
+    return (
+      <div className="paginator my-2">
+        <button
+          className="btn btn-secondary me-2"
+          disabled={!this.props.prevPage}
+          onClick={linkEvent(this, this.handlePrev)}
+        >
+          {I18NextService.i18n.t("prev")}
+        </button>
+        <button
+          className="btn btn-secondary"
+          onClick={linkEvent(this, this.handleNext)}
+          disabled={!this.props.nextPage}
+        >
+          {I18NextService.i18n.t("next")}
+        </button>
+      </div>
+    );
+  }
+
+  handlePrev(i: PaginatorCursor) {
+    i.props.onPrev();
+  }
+
+  handleNext(i: PaginatorCursor) {
+    if (i.props.nextPage) {
+      i.props.onNext(i.props.nextPage);
+    }
+  }
+}

--- a/src/shared/components/common/paginator-cursor.tsx
+++ b/src/shared/components/common/paginator-cursor.tsx
@@ -5,8 +5,18 @@ import { PaginationCursor } from "lemmy-js-client";
 interface PaginatorCursorProps {
   prevPage?: PaginationCursor;
   nextPage?: PaginationCursor;
-  onNext(val: PaginationCursor): any;
-  onPrev(): any;
+  onNext(val: PaginationCursor): void;
+  onPrev(): void;
+}
+
+function handlePrev(i: PaginatorCursor) {
+  i.props.onPrev();
+}
+
+function handleNext(i: PaginatorCursor) {
+  if (i.props.nextPage) {
+    i.props.onNext(i.props.nextPage);
+  }
 }
 
 export class PaginatorCursor extends Component<PaginatorCursorProps, any> {
@@ -19,28 +29,18 @@ export class PaginatorCursor extends Component<PaginatorCursorProps, any> {
         <button
           className="btn btn-secondary me-2"
           disabled={!this.props.prevPage}
-          onClick={linkEvent(this, this.handlePrev)}
+          onClick={linkEvent(this, handlePrev)}
         >
           {I18NextService.i18n.t("prev")}
         </button>
         <button
           className="btn btn-secondary"
-          onClick={linkEvent(this, this.handleNext)}
+          onClick={linkEvent(this, handleNext)}
           disabled={!this.props.nextPage}
         >
           {I18NextService.i18n.t("next")}
         </button>
       </div>
     );
-  }
-
-  handlePrev(i: PaginatorCursor) {
-    i.props.onPrev();
-  }
-
-  handleNext(i: PaginatorCursor) {
-    if (i.props.nextPage) {
-      i.props.onNext(i.props.nextPage);
-    }
   }
 }


### PR DESCRIPTION
## Description

Adds cursor pagination by adding a `pageCursor` in place of `page` in the home and community urls.

Since the API doesn't return a `previous_cursor`, I had to use the back button for a previous, but it works well.

This breaks next page comment pagination (the first page shows fine), but we should probably do away with those at some point anyway.

