### PR TITLE
Fixing broken docker build due to missing rxjs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.2-alpine as builder
+FROM node:alpine as builder
 RUN apk update && apk add curl yarn python3 build-base gcc wget git --no-cache
 RUN curl -sf https://gobinaries.com/tj/node-prune | sh
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "mini-css-extract-plugin": "^2.7.5",
     "register-service-worker": "^1.7.2",
     "run-node-webpack-plugin": "^1.3.0",
+    "rxjs": "^7.8.1",
     "sanitize-html": "^2.11.0",
     "sass": "^1.64.1",
     "sass-loader": "^13.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8356,7 +8356,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^7.8.0:
+rxjs@^7.8.0, rxjs@^7.8.1:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==


### PR DESCRIPTION
Woodpecker can't build these because rxjs is missing. Not sure how it passes lint without it.