### PR TITLE
Fixing QR code CSP.

### DIFF
--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -21,6 +21,7 @@ export function setDefaultCsp({
      style-src 'self' 'unsafe-inline';
      form-action 'self';
      base-uri 'self';
+     blob: 'self';
      frame-src *;
      media-src * data:`.replace(/\s+/g, " "),
   );


### PR DESCRIPTION
## Description

voyager.lemmy.ml shows an image error when trying to add a QR code, because `blob:` is not in the csp. We wouldn't see this is testing as csp is disabled for testing.