### PR TITLE
Fixing errors. Fixes #2216

### DIFF
--- a/src/server/handlers/catch-all-handler.tsx
+++ b/src/server/handlers/catch-all-handler.tsx
@@ -49,7 +49,10 @@ export default async (req: Request, res: Response) => {
     let errorPageData: ErrorPageData | undefined = undefined;
     let try_site = await client.getSite();
 
-    if (try_site.state === "failed" && try_site.msg === "not_logged_in") {
+    if (
+      try_site.state === "failed" &&
+      try_site.err.message === "not_logged_in"
+    ) {
       console.error(
         "Incorrect JWT token, skipping auth so frontend can remove jwt cookie",
       );
@@ -85,22 +88,23 @@ export default async (req: Request, res: Response) => {
       }
     } else if (try_site.state === "failed") {
       res.status(500);
-      errorPageData = getErrorPageData(new Error(try_site.msg), site);
+      errorPageData = getErrorPageData(new Error(try_site.err.message), site);
     }
 
     const error = Object.values(routeData).find(
-      res => res.state === "failed" && res.msg !== "couldnt_find_object", // TODO: find a better way of handling errors
+      res =>
+        res.state === "failed" && res.err.message !== "couldnt_find_object", // TODO: find a better way of handling errors
     ) as FailedRequestState | undefined;
 
     // Redirect to the 404 if there's an API error
     if (error) {
-      console.error(error.msg);
+      console.error(error.err);
 
-      if (error.msg === "instance_is_private") {
+      if (error.err.message === "instance_is_private") {
         return res.redirect(`/signup`);
       } else {
         res.status(500);
-        errorPageData = getErrorPageData(new Error(error.msg), site);
+        errorPageData = getErrorPageData(new Error(error.err.message), site);
       }
     }
 

--- a/src/shared/components/common/image-upload-form.tsx
+++ b/src/shared/components/common/image-upload-form.tsx
@@ -88,8 +88,7 @@ export class ImageUploadForm extends Component<
           toast(JSON.stringify(res), "danger");
         }
       } else if (res.state === "failed") {
-        console.error(res.msg);
-        toast(res.msg, "danger");
+        toast(res.err.message, "danger");
       }
 
       i.setState({ loading: false });

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -494,10 +494,10 @@ export class MarkdownTextArea extends Component<
       }
     } else if (res.state === "failed") {
       i.setState({ imageUploadStatus: undefined });
-      console.error(res.msg);
-      toast(res.msg, "danger");
+      console.error(res.err.message);
+      toast(res.err.message, "danger");
 
-      throw res.msg;
+      throw res.err;
     }
   }
 

--- a/src/shared/components/home/emojis-form.tsx
+++ b/src/shared/components/home/emojis-form.tsx
@@ -510,8 +510,8 @@ export class EmojiForm extends Component<EmojiFormProps, EmojiFormState> {
           toast(JSON.stringify(res), "danger");
         }
       } else if (res.state === "failed") {
-        console.error(res.msg);
-        toast(res.msg, "danger");
+        console.error(res.err.message);
+        toast(res.err.message, "danger");
       }
     });
   }

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -73,10 +73,10 @@ async function handleLoginSubmit(i: Login, event: any) {
     });
     switch (loginRes.state) {
       case "failed": {
-        if (loginRes.msg === "missing_totp_token") {
+        if (loginRes.err.message === "missing_totp_token") {
           i.setState({ show2faModal: true });
         } else {
-          toast(I18NextService.i18n.t(loginRes.msg), "danger");
+          toast(I18NextService.i18n.t(loginRes.err.message), "danger");
         }
 
         i.setState({ loginRes });

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -388,7 +388,7 @@ export class Signup extends Component<any, State> {
       });
       switch (registerRes.state) {
         case "failed": {
-          toast(registerRes.msg, "danger");
+          toast(registerRes.err.message, "danger");
           i.setState({ registerRes: EMPTY_REQUEST });
           break;
         }

--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -864,7 +864,7 @@ export class Inbox extends Component<any, InboxState> {
       toast(I18NextService.i18n.t("edit"));
       this.findAndUpdateComment(res);
     } else if (res.state === "failed") {
-      toast(res.msg, "danger");
+      toast(res.err.message, "danger");
     }
 
     return res;

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -163,7 +163,7 @@ async function handleGenerateTotp(i: Settings) {
   const generateTotpRes = await HttpService.client.generateTotpSecret();
 
   if (generateTotpRes.state === "failed") {
-    toast(generateTotpRes.msg, "danger");
+    toast(generateTotpRes.err.message, "danger");
   } else {
     i.setState({ show2faModal: true });
   }

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -190,8 +190,8 @@ function handleImageUpload(i: PostForm, event: any) {
         toast(JSON.stringify(res), "danger");
       }
     } else if (res.state === "failed") {
-      console.error(res.msg);
-      toast(res.msg, "danger");
+      console.error(res.err.message);
+      toast(res.err.message, "danger");
       i.setState({ imageLoading: false });
     }
   });

--- a/src/shared/services/HttpService.ts
+++ b/src/shared/services/HttpService.ts
@@ -17,7 +17,7 @@ type LoadingRequestState = typeof LOADING_REQUEST;
 
 export type FailedRequestState = {
   state: "failed";
-  msg: string;
+  err: Error;
 };
 
 type SuccessRequestState<T> = {
@@ -71,7 +71,7 @@ class WrappedLemmyHttpClient {
             }
             return {
               state: "failed",
-              msg: error,
+              err: error,
             };
           }
         };


### PR DESCRIPTION
## Description

lemmy-js-client now uses `Error` instead of string, breaking a few things. I changed the return type on the failed state, and fixed the other ones.
