### PR TITLE
Remove previous button for PaginatorCursor

### DIFF
--- a/src/shared/components/common/paginator-cursor.tsx
+++ b/src/shared/components/common/paginator-cursor.tsx
@@ -3,14 +3,8 @@ import { I18NextService } from "../../services";
 import { PaginationCursor } from "lemmy-js-client";
 
 interface PaginatorCursorProps {
-  prevPage?: PaginationCursor;
   nextPage?: PaginationCursor;
   onNext(val: PaginationCursor): void;
-  onPrev(): void;
-}
-
-function handlePrev(i: PaginatorCursor) {
-  i.props.onPrev();
 }
 
 function handleNext(i: PaginatorCursor) {
@@ -26,13 +20,6 @@ export class PaginatorCursor extends Component<PaginatorCursorProps, any> {
   render() {
     return (
       <div className="paginator my-2">
-        <button
-          className="btn btn-secondary me-2"
-          disabled={!this.props.prevPage}
-          onClick={linkEvent(this, handlePrev)}
-        >
-          {I18NextService.i18n.t("prev")}
-        </button>
         <button
           className="btn btn-secondary"
           onClick={linkEvent(this, handleNext)}

--- a/src/shared/components/common/paginator.tsx
+++ b/src/shared/components/common/paginator.tsx
@@ -14,20 +14,22 @@ export class Paginator extends Component<PaginatorProps, any> {
   render() {
     return (
       <div className="paginator my-2">
-        <button
-          className="btn btn-secondary me-2"
-          disabled={this.props.page === 1}
-          onClick={linkEvent(this, this.handlePrev)}
-        >
-          {I18NextService.i18n.t("prev")}
-        </button>
-        <button
-          className="btn btn-secondary"
-          onClick={linkEvent(this, this.handleNext)}
-          disabled={this.props.nextDisabled || false}
-        >
-          {I18NextService.i18n.t("next")}
-        </button>
+        {this.props.page !== 1 && (
+          <button
+            className="btn btn-secondary me-2"
+            onClick={linkEvent(this, this.handlePrev)}
+          >
+            {I18NextService.i18n.t("prev")}
+          </button>
+        )}
+        {!this.props.nextDisabled && (
+          <button
+            className="btn btn-secondary"
+            onClick={linkEvent(this, this.handleNext)}
+          >
+            {I18NextService.i18n.t("next")}
+          </button>
+        )}
       </div>
     );
   }

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -294,7 +294,6 @@ export class Community extends Component<
   }
 
   renderCommunity() {
-    const { pageCursor } = getCommunityQueryParams();
     switch (this.state.communityRes.state) {
       case "loading":
         return (
@@ -341,10 +340,8 @@ export class Community extends Component<
                 {this.selects(res)}
                 {this.listings(res)}
                 <PaginatorCursor
-                  prevPage={pageCursor}
                   nextPage={this.getNextPage}
                   onNext={this.handlePageNext}
-                  onPrev={this.handlePagePrev}
                 />
               </main>
               <aside className="d-none d-md-block col-md-4 col-lg-3">

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -635,18 +635,14 @@ export class Home extends Component<any, HomeState> {
   }
 
   get posts() {
-    const { pageCursor } = getHomeQueryParams();
-
     return (
       <div className="main-content-wrapper">
         <div>
           {this.selects}
           {this.listings}
           <PaginatorCursor
-            prevPage={pageCursor}
             nextPage={this.getNextPage}
             onNext={this.handlePageNext}
-            onPrev={this.handlePagePrev}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description

As described in https://github.com/LemmyNet/lemmy/issues/4057 , it really doesn't make sense to show the previous button for paginatorcursor style paging. We can rely on the browser back button more reliably anyway.

Fixes #2197 
