### PR TITLE
Adding creator_is_admin and creator_is_mod, removing pointless functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "inferno-router": "^8.2.2",
     "inferno-server": "^8.2.2",
     "jwt-decode": "^3.1.2",
-    "lemmy-js-client": "0.19.0-alpha.16",
+    "lemmy-js-client": "0.19.0-rc.15",
     "lodash.isequal": "^4.5.0",
     "markdown-it": "^13.0.1",
     "markdown-it-bidi": "^0.1.0",

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -1,13 +1,6 @@
 import { colorList, getCommentParentId, showScores } from "@utils/app";
 import { futureDaysToUnixTime, numToSI } from "@utils/helpers";
-import {
-  amCommunityCreator,
-  canAdmin,
-  canMod,
-  isAdmin,
-  isBanned,
-  isMod,
-} from "@utils/roles";
+import { amCommunityCreator, canAdmin, canMod, isBanned } from "@utils/roles";
 import classNames from "classnames";
 import isBefore from "date-fns/isBefore";
 import parseISO from "date-fns/parseISO";
@@ -257,8 +250,8 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
       UserService.Instance.myUserInfo,
       true,
     );
-    const isMod_ = isMod(cv.creator.id, this.props.moderators);
-    const isAdmin_ = isAdmin(cv.creator.id, this.props.admins);
+    const isMod_ = cv.creator_is_moderator;
+    const isAdmin_ = cv.creator_is_admin;
     const amCommunityCreator_ = amCommunityCreator(
       cv.creator.id,
       this.props.moderators,
@@ -1461,7 +1454,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
   handleAddModToCommunity(i: CommentNode) {
     i.setState({ addModLoading: true });
 
-    const added = !isMod(i.commentView.comment.creator_id, i.props.moderators);
+    const added = !i.commentView.creator_is_moderator;
     i.props.onAddModToCommunity({
       community_id: i.commentView.community.id,
       person_id: i.commentView.creator.id,
@@ -1472,7 +1465,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
   handleAddAdmin(i: CommentNode) {
     i.setState({ addAdminLoading: true });
 
-    const added = !isAdmin(i.commentView.comment.creator_id, i.props.admins);
+    const added = !i.commentView.creator_is_admin;
     i.props.onAddAdmin({
       person_id: i.commentView.creator.id,
       added,

--- a/src/shared/components/comment/comment-report.tsx
+++ b/src/shared/components/comment/comment-report.tsx
@@ -57,6 +57,7 @@ export class CommentReport extends Component<
       community: r.community,
       creator_banned_from_community: r.creator_banned_from_community,
       creator_is_moderator: false,
+      creator_is_admin: false,
       counts: r.counts,
       subscribed: "NotSubscribed",
       saved: false,

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -268,7 +268,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
     return (
       <>
         <ul className="list-inline mb-1 text-muted fw-bold">
-          {amMod(this.props.moderators) && (
+          {amMod(this.props.community_view.community.id) && (
             <>
               <li className="list-inline-item-action">
                 <button
@@ -468,7 +468,7 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
   get canPost(): boolean {
     return (
       !this.props.community_view.community.posting_restricted_to_mods ||
-      amMod(this.props.moderators) ||
+      amMod(this.props.community_view.community.id) ||
       amAdmin()
     );
   }

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -747,7 +747,7 @@ export class Modlog extends Component<
   get amAdminOrMod(): boolean {
     const amMod_ =
       this.state.communityRes.state === "success" &&
-      amMod(this.state.communityRes.data.moderators);
+      amMod(this.state.communityRes.data.community_view.community.id);
     return amAdmin() || amMod_;
   }
 

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -18,7 +18,7 @@ import {
   numToSI,
   randomStr,
 } from "@utils/helpers";
-import { canMod, isAdmin, isBanned } from "@utils/roles";
+import { canMod, isBanned } from "@utils/roles";
 import type { QueryParams } from "@utils/types";
 import { RouteDataResponse } from "@utils/types";
 import classNames from "classnames";
@@ -497,7 +497,7 @@ export class Profile extends Component<
                         classNames="ms-1"
                         isBanned={isBanned(pv.person)}
                         isDeleted={pv.person.deleted}
-                        isAdmin={isAdmin(pv.person.id, admins)}
+                        isAdmin={pv.is_admin}
                         isBot={pv.person.bot_account}
                       />
                     </li>
@@ -553,7 +553,7 @@ export class Profile extends Component<
                 )}
 
                 {canMod(pv.person.id, undefined, admins) &&
-                  !isAdmin(pv.person.id, admins) &&
+                  !pv.is_admin &&
                   !showBanDialog &&
                   (!isBanned(pv.person) ? (
                     <button

--- a/src/shared/components/post/post-report.tsx
+++ b/src/shared/components/post/post-report.tsx
@@ -57,6 +57,7 @@ export class PostReport extends Component<PostReportProps, PostReportState> {
       my_vote: r.my_vote,
       unread_comments: 0,
       creator_is_moderator: false,
+      creator_is_admin: false,
     };
 
     return (

--- a/src/shared/utils/roles/am-mod.ts
+++ b/src/shared/utils/roles/am-mod.ts
@@ -1,10 +1,11 @@
-import { isMod } from "@utils/roles";
-import { CommunityModeratorView } from "lemmy-js-client";
+import { CommunityId } from "lemmy-js-client";
 import { UserService } from "../../services";
 
 export default function amMod(
-  mods?: CommunityModeratorView[],
+  communityId: CommunityId,
   myUserInfo = UserService.Instance.myUserInfo,
 ): boolean {
-  return myUserInfo ? isMod(myUserInfo.local_user_view.person.id, mods) : false;
+  return myUserInfo
+    ? myUserInfo.moderates.map(cmv => cmv.community.id).includes(communityId)
+    : false;
 }

--- a/src/shared/utils/roles/index.ts
+++ b/src/shared/utils/roles/index.ts
@@ -6,9 +6,7 @@ import amTopMod from "./am-top-mod";
 import canAdmin from "./can-admin";
 import canCreateCommunity from "./can-create-community";
 import canMod from "./can-mod";
-import isAdmin from "./is-admin";
 import isBanned from "./is-banned";
-import isMod from "./is-mod";
 
 export {
   amAdmin,
@@ -19,7 +17,5 @@ export {
   canAdmin,
   canCreateCommunity,
   canMod,
-  isAdmin,
   isBanned,
-  isMod,
 };

--- a/src/shared/utils/roles/is-admin.ts
+++ b/src/shared/utils/roles/is-admin.ts
@@ -1,8 +1,0 @@
-import { PersonView } from "lemmy-js-client";
-
-export default function isAdmin(
-  creatorId: number,
-  admins?: PersonView[],
-): boolean {
-  return admins?.some(({ person: { id } }) => id === creatorId) ?? false;
-}

--- a/src/shared/utils/roles/is-mod.ts
+++ b/src/shared/utils/roles/is-mod.ts
@@ -1,8 +1,0 @@
-import { CommunityModeratorView } from "lemmy-js-client";
-
-export default function isMod(
-  creatorId: number,
-  mods?: CommunityModeratorView[],
-): boolean {
-  return mods?.map(m => m.moderator.id).includes(creatorId) ?? false;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6069,10 +6069,10 @@ leac@^0.6.0:
   resolved "https://registry.yarnpkg.com/leac/-/leac-0.6.0.tgz#dcf136e382e666bd2475f44a1096061b70dc0912"
   integrity sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==
 
-lemmy-js-client@0.19.0-alpha.16:
-  version "0.19.0-alpha.16"
-  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.19.0-alpha.16.tgz#4ec26e393856db7ddf86dba83f24633eeacee7c4"
-  integrity sha512-pmfrkPrHBkhEFhw/BDiTPy2/aQLoURLwBftMa4Lc+ZYiRfVClCOPkbKiqDSYXYlWcPz5MtwM/bjSNxasvVHfTA==
+lemmy-js-client@0.19.0-rc.15:
+  version "0.19.0-rc.15"
+  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.19.0-rc.15.tgz#03d600841f5e809bdc5d817c7295b8e6952c48dd"
+  integrity sha512-lCNvke29fPWTX4CIqDnewgNAtDk4D/syHiedyih7wXqW0yHfg2Z1+lm+GVao2QUa2NCNGIMO1vV7FJPiXl95rA==
   dependencies:
     cross-fetch "^3.1.5"
     form-data "^4.0.0"


### PR DESCRIPTION
## Description

Adds the new `creator_is_moderator` and `creator_is_admin` properties. Removes some pointless functions.

One other unfortunate thing: I still need to fill the list of moderators and admins into each post and comment listing. This is because the `canMod` functions still need the hierarchies of admins then mods, to make sure you can't do actions on mods / admins above you. Just knowing the creator is a moderator is unfortunately not enough info to know if you can do actions on them.