### PR TITLE
Fix shutdown behaviour

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -55,7 +55,9 @@ server.get("/*", CatchAllHandler);
 
 const listener = server.listen(Number(port), hostname, () => {
   setupDateFns();
-  console.log(`Lemmy-ui v${VERSION} started listening on http://${hostname}:${port}`);
+  console.log(
+    `Lemmy-ui v${VERSION} started listening on http://${hostname}:${port}`,
+  );
 });
 
 const signals = {


### PR DESCRIPTION
## Description

The current code does not handle the stop signal Docker sends, which causes it to always get a SIGKILL from the Docker daemon after a 10 second timeout. 

The reason for this is that Docker sends a SIGTERM signal first, but the code only listens for SIGINT (CTRL+C) and because of that it does not initiate any shutdown procedure.

To fix this, I added a handler for SIGTERM so that the container stops gracefully and much quicker.