### PR TITLE
Improve build performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as builder
+FROM --platform=$BUILDPLATFORM node:20-alpine as builder
 
 # Upgrade to edge to fix sharp/libvips issues
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories


### PR DESCRIPTION
## Description

This change improves the buildtime of the Docker container massively, by executing the build stage only once, instead of multiple times for each platform.

Currently when building the ARM64 image it is executing the build-stage under QEMU emulation, but after this change it re-uses the files build for AMD64 (since they are all javascript that does not matter).
