### PR TITLE
fix wrapped http client

### DIFF
--- a/src/server/handlers/catch-all-handler.tsx
+++ b/src/server/handlers/catch-all-handler.tsx
@@ -38,7 +38,7 @@ export default async (req: Request, res: Response) => {
 
     if (auth) {
       headers["Authorization"] = `Bearer ${auth}`;
-      client.setHeaders(headers);
+      client.rawClient.setHeaders(headers);
     }
     const { path, url, query } = req;
 

--- a/src/shared/services/HttpService.ts
+++ b/src/shared/services/HttpService.ts
@@ -36,7 +36,7 @@ export type RequestState<T> =
   | FailedRequestState
   | SuccessRequestState<T>;
 
-export type WrappedLemmyHttp = {
+export type WrappedLemmyHttp = WrappedLemmyHttpClient & {
   [K in keyof LemmyHttp]: LemmyHttp[K] extends (...args: any[]) => any
     ? ReturnType<LemmyHttp[K]> extends Promise<infer U>
       ? (...args: Parameters<LemmyHttp[K]>) => Promise<RequestState<U>>
@@ -47,18 +47,18 @@ export type WrappedLemmyHttp = {
 };
 
 class WrappedLemmyHttpClient {
-  #client: LemmyHttp;
+  rawClient: LemmyHttp;
 
   constructor(client: LemmyHttp, silent = false) {
-    this.#client = client;
+    this.rawClient = client;
 
     for (const key of Object.getOwnPropertyNames(
-      Object.getPrototypeOf(this.#client),
+      Object.getPrototypeOf(this.rawClient),
     )) {
       if (key !== "constructor") {
-        WrappedLemmyHttpClient.prototype[key] = async (...args) => {
+        this[key] = async (...args) => {
           try {
-            const res = await this.#client[key](...args);
+            const res = await this.rawClient[key](...args);
 
             return {
               data: res,


### PR DESCRIPTION
wrappedhttpclient has two bugs:

1. setHeaders becomes async with errors gobbled up. this is probably not intentional and the result is not awaited at the call site
2. wrappedhttpclient overrides methods in the prototype and not the instance. this means that when a new instance is created, from then on all methdos on all wrappedhttpclients call the inner methods on the newly created client instead of their respective clients

this PR tries to fix both. it is untested so idk if it works

related: #2243

this might explain why the issue has only appeared now - previously the auth param was passed into all the http functions directly, but now it is fetched from the this on each lemmyhttpclient. and the this is often wrong due to the wrapper race condition
