### PR TITLE
Added aspect ratio to the videos

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -271,7 +271,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     // if direct video link
     if (url && isVideo(url)) {
       return (
-        <div className="embed-responsive mt-3">
+        <div className="embed-responsive ratio ratio-16x9 mt-3">
           <video muted controls className="embed-responsive-item col-12">
             <source src={url} type="video/mp4" />
           </video>


### PR DESCRIPTION
## Description

Vertical videos are sometimes 2 times bigger than window height. This is very disturbing in terms of UX. I added 16x9 ratio, if there is no other overlooked reason, can you peep accept it?

## Screenshots

### Before
![Screenshot 2023-12-05 at 00 23 10](https://github.com/LemmyNet/lemmy-ui/assets/17887754/67b4c614-4dbb-4740-8ec2-8c8580738b04)

### After
![Screenshot 2023-12-05 at 00 23 19](https://github.com/LemmyNet/lemmy-ui/assets/17887754/85f3b1cc-e9d6-47f7-91f5-49610197131d)
