### PR TITLE
Use highlight color for new comments on dark themes that won't burn your eyes out

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -451,3 +451,7 @@ br.big {
 .totp-link {
   width: fit-content;
 }
+
+[data-bs-theme="dark"] .mark {
+  background: rgba(243, 208, 101, 0.3);
+}


### PR DESCRIPTION
## Description

Closes #2264. The color I picked isn't perfect, but it's definitely easier on the eyes than what was there before.

![image](https://github.com/LemmyNet/lemmy-ui/assets/28871516/d8aea6bc-7feb-4563-8b7a-387a3769a6c6)
