### PR TITLE
Fix dark theme highlight color for recent comments, restores colors to 0.18 values

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -451,7 +451,3 @@ br.big {
 .totp-link {
   width: fit-content;
 }
-
-[data-bs-theme="dark"] .mark {
-  background: rgba(243, 208, 101, 0.3);
-}

--- a/src/assets/css/themes/_variables.darkly-pureblack.scss
+++ b/src/assets/css/themes/_variables.darkly-pureblack.scss
@@ -27,6 +27,7 @@ $body-bg: $black;
 $link-color: $success;
 $border-color: rgba($body-color, 0.25);
 $mark-bg: $gray-900;
+$mark-bg-dark: $gray-900;
 $text-muted: $gray-600;
 $yiq-contrasted-threshold: 175;
 

--- a/src/assets/css/themes/_variables.darkly.scss
+++ b/src/assets/css/themes/_variables.darkly.scss
@@ -26,6 +26,7 @@ $body-bg: $gray-900;
 $link-color: $success;
 $border-color: rgba($body-color, 0.25);
 $mark-bg: #333;
+$mark-bg-dark: #333;
 $text-muted: $gray-600;
 $yiq-contrasted-threshold: 175;
 

--- a/src/assets/css/themes/_variables.i386.scss
+++ b/src/assets/css/themes/_variables.i386.scss
@@ -56,3 +56,4 @@ $input-disabled-bg: $gray-800;
 $card-bg: $gray-800;
 $card-border-color: $white;
 $mark-bg: #463b00;
+$mark-bg-dark: #463b00;

--- a/src/assets/css/themes/_variables.vaporwave-dark.scss
+++ b/src/assets/css/themes/_variables.vaporwave-dark.scss
@@ -25,4 +25,5 @@ $input-color: $white;
 $input-disabled-bg: $gray-800;
 $input-border-color: $gray-800;
 $mark-bg: $gray-600;
+$mark-bg-dark: $gray-600;
 $pre-color: $gray-200;

--- a/src/assets/css/themes/darkly-compact.css
+++ b/src/assets/css/themes/darkly-compact.css
@@ -211,6 +211,7 @@ hr.my-3 {
   --bs-link-color-rgb: 102, 215, 186;
   --bs-link-hover-color-rgb: 133, 223, 200;
   --bs-code-color: #e685b5;
+  --bs-highlight-bg: #333;
   --bs-border-color: #444;
   --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
   --bs-form-valid-color: #66d7ba;

--- a/src/assets/css/themes/darkly-pureblack.css
+++ b/src/assets/css/themes/darkly-pureblack.css
@@ -171,6 +171,7 @@
   --bs-link-color-rgb: 102, 215, 186;
   --bs-link-hover-color-rgb: 133, 223, 200;
   --bs-code-color: #e685b5;
+  --bs-highlight-bg: #111;
   --bs-border-color: #333;
   --bs-border-color-translucent: rgba(243, 243, 243, 0.15);
   --bs-form-valid-color: #66d7ba;

--- a/src/assets/css/themes/darkly-red.css
+++ b/src/assets/css/themes/darkly-red.css
@@ -171,6 +171,7 @@
   --bs-link-color-rgb: 135, 156, 178;
   --bs-link-hover-color-rgb: 159, 176, 193;
   --bs-code-color: #e685b5;
+  --bs-highlight-bg: #333;
   --bs-border-color: #444;
   --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
   --bs-form-valid-color: #66d7ba;

--- a/src/assets/css/themes/darkly.css
+++ b/src/assets/css/themes/darkly.css
@@ -171,6 +171,7 @@
   --bs-link-color-rgb: 102, 215, 186;
   --bs-link-hover-color-rgb: 133, 223, 200;
   --bs-code-color: #e685b5;
+  --bs-highlight-bg: #333;
   --bs-border-color: #444;
   --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
   --bs-form-valid-color: #66d7ba;

--- a/src/assets/css/themes/i386.css
+++ b/src/assets/css/themes/i386.css
@@ -171,6 +171,7 @@
   --bs-link-color-rgb: 254, 254, 152;
   --bs-link-hover-color-rgb: 254, 254, 173;
   --bs-code-color: #fe98fe;
+  --bs-highlight-bg: #463b00;
   --bs-border-color: #444;
   --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
   --bs-form-valid-color: #99ff99;

--- a/src/assets/css/themes/vaporwave-dark.css
+++ b/src/assets/css/themes/vaporwave-dark.css
@@ -171,6 +171,7 @@
   --bs-link-color-rgb: 255, 140, 214;
   --bs-link-hover-color-rgb: 255, 163, 222;
   --bs-code-color: #ff8cd6;
+  --bs-highlight-bg: #888;
   --bs-border-color: #444;
   --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
   --bs-form-valid-color: #69ffc7;


### PR DESCRIPTION
## Description

Fixes #2264. Reverts changes from #2295.

Restores the background color for recent comments on dark themes to what they were in 0.18. 

In the Darkly theme on 0.18, recent comments used to be light grey, then in 0.19 they became yellow. I think this was caused by an update of Bootstrap to v5.3.2, which added a default value for the dark theme `bs-highlight-bg` variable in [bootstrap-utilities.css](https://github.com/twbs/bootstrap/commit/344e912d04b5b6a04482113eff20ab416ff01048#diff-26799cef23e0ac7c1c6e60651e6b4cf43b7a3effe86ad3bf616740b0bd783106R174). 

The correct highlighted comment background colors were in the `:root, [data-bs-theme=light] { }` section of each theme, but not in the `[data-bs-theme=dark] { }` section, so the values were getting overridden by Bootstrap's defaults. I copied the `bs-highlight-bg` values into the `theme=dark` section for each of the dark theme CSS files.

Edit: After learning more about Bootstrap I realized that the theme CSS files normally aren't edited manually and are instead compiled from the _variables .scss files. Not sure if it's a bug in Bootstrap that it goes with it's own dark theme defaults for this value. From reading the documentation on [Bootstrap color modes](https://getbootstrap.com/docs/5.3/customize/color-modes/), I think a fix is to set `$mark-bg-dark:` to the same value as `$mark-bg:` in each of the dark theme scss files.


## Screenshots

### Before
#### 0.19.0
![lemmy0190](https://github.com/LemmyNet/lemmy-ui/assets/1400562/b9ffb992-cd3b-4c83-ba91-0fc4ea0e3ae0)
#### 0.19.1
![lemmy0191](https://github.com/LemmyNet/lemmy-ui/assets/1400562/b3e7f0b6-3b39-429a-8a48-8fc4bbe1eda6)

### After
![lemmy0191 proposed](https://github.com/LemmyNet/lemmy-ui/assets/1400562/34a88e2a-3bfd-4c6d-9a8c-efc0b44b94d4)