### PR TITLE
Do not auto expand media if blur_nsfw is active and the post is NSFW

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -128,7 +128,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
 
   componentDidMount(): void {
     if (UserService.Instance.myUserInfo) {
-      const user = UserService.Instance.myUserInfo.local_user_view.local_user;
+      const { auto_expand, blur_nsfw } = UserService.Instance.myUserInfo.local_user_view.local_user;
       this.setState({
         imageExpanded:
           user.auto_expand && (!user.blur_nsfw || !this.postView.post.nsfw),

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -131,7 +131,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       const { auto_expand, blur_nsfw } = UserService.Instance.myUserInfo.local_user_view.local_user;
       this.setState({
         imageExpanded:
-          user.auto_expand && (!user.blur_nsfw || !this.postView.post.nsfw),
+          auto_expand && !(blur_nsfw && this.postView.post.nsfw),
       });
     }
   }

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -128,10 +128,10 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
 
   componentDidMount(): void {
     if (UserService.Instance.myUserInfo) {
+      const user = UserService.Instance.myUserInfo.local_user_view.local_user;
       this.setState({
         imageExpanded:
-          UserService.Instance.myUserInfo.local_user_view.local_user
-            .auto_expand,
+          user.auto_expand && (!user.blur_nsfw || !this.postView.post.nsfw),
       });
     }
   }


### PR DESCRIPTION
## Description
Currently, if auto_expand and blur_nsfw are active at the same time, NSFW images are auto expanded. I think it makes sense to not automatically expand NSFW posts if blur_nsfw is active while expanding SFW ones.