### PR TITLE
Clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN du -sh ./node_modules/* | sort -nr | grep '\dM.*'
 FROM node:20-alpine as runner
 ENV NODE_ENV=production
 
-RUN apk update && apk upgrade && apk add curl vips-cpp
+RUN apk update && apk add --no-cache curl vips-cpp && rm -rf /var/cache/apk/*
 
 COPY --from=builder /usr/src/app/dist /app/dist
 COPY --from=builder /usr/src/app/node_modules /app/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM node:20-alpine as builder
 
-# Upgrade to edge to fix sharp/libvips issues
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-
 # Added vips-dev and pkgconfig so that local vips is used instead of prebuilt
 # Done for two reasons:
 # - libvips binaries are not available for ARM32
@@ -38,7 +34,7 @@ COPY .git .git
 RUN echo "export const VERSION = '$(git describe --tag)';" > "src/shared/version.ts"
 
 RUN yarn --production --prefer-offline --network-timeout 100000
-RUN NODE_OPTIONS="--max-old-space-size=8192" yarn build:prod
+RUN yarn build:prod
 
 RUN rm -rf ./node_modules/import-sort-parser-typescript
 RUN rm -rf ./node_modules/typescript
@@ -48,10 +44,6 @@ RUN du -sh ./node_modules/* | sort -nr | grep '\dM.*'
 
 FROM node:20-alpine as runner
 ENV NODE_ENV=production
-
-# Upgrade to edge to fix sharp/libvips issues
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
 RUN apk update && apk upgrade && apk add curl vips-cpp
 


### PR DESCRIPTION
## Description

The changes to Lemmy-UI's Dockerfile introduced by https://github.com/LemmyNet/lemmy-ui/pull/2235 were written by me for my fork of Lemmy's images in [ubergeek77/lemmy-docker-multiarch](https://github.com/ubergeek77/lemmy-docker-multiarch)

Back then, Alpine Edge was needed due to a versioning conflict between `sharp` and `libvips`. Since then, Lemmy-UI has started using a newer version of `sharp` that does not have this conflict anymore. This means hackily upgrading to `edge` is no longer needed.

I've also revered the manual override of `max-old-space-size`, because a limit of 8GB is rather large, and may cause any machine with lower than 8GB of RAM to fail with an out of memory error, even if that amount of memory is not needed for the actual build. In particular, this made my ARM build fail when my machine was otherwise perfectly capable of building the image. Removing this fixed the build.

Logs of these changes being built are available on this workflow run under the step titled `Build and push Frontend (0.19.2, linux/amd64)`:

https://github.com/ubergeek77/lemmy-docker-multiarch/actions/runs/7481590478/job/20363531388

You can also pull the images I have pushed to that repository to verify the changes are working.

If removing `max-old-space-size` is problematic for the Lemmy team's CI/CD, I can add it back.

### Before

- The Dockerfile had a hack that force-upgraded to `alpine:edge`

### After

- No more hacks 🥳 
