### PR TITLE
Show the community name instead of the creator name when appointing mod

### DIFF
--- a/src/shared/components/common/content-actions/content-action-dropdown.tsx
+++ b/src/shared/components/common/content-actions/content-action-dropdown.tsx
@@ -653,7 +653,7 @@ export default class ContentActionDropdown extends Component<
                 : "appoint_as_mod_are_you_sure",
               {
                 user: getApubName(creator),
-                community: getApubName(creator),
+                community: getApubName(community),
               },
             )}
             loadingMessage={I18NextService.i18n.t(


### PR DESCRIPTION
… mod

## Description

When appointing or removing a mod the user name is printed instead of the community name. 

## Screenshots

### Before
![image](https://github.com/LemmyNet/lemmy-ui/assets/81911574/944975bd-e3ce-4fff-a07f-c37e488899d2)

### After
