### PR TITLE
Fix scroll bug when modal closes from browser back button

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,3 +1,7 @@
+body {
+  overflow-y: scroll !important;
+}
+
 .navbar-expand-lg .navbar-nav .nav-link {
   padding-right: 0.75rem !important;
   padding-left: 0.75rem !important;


### PR DESCRIPTION
Fixes #2350.

Not the ideal solution, as the user can still scroll while the modal is open. However, that is much better than having scrolling be unexpectedly broken.