### PR TITLE
On account deletion add 'delete content' checkbox (fixes #2384)

### DIFF
--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -108,6 +108,7 @@ interface SettingsState {
     old_password?: string;
   };
   deleteAccountForm: {
+    delete_content?: boolean;
     password?: string;
   };
   personBlocks: PersonBlockView[];
@@ -1094,6 +1095,17 @@ export class Settings extends Component<any, SettingsState> {
                   )}
                   className="my-2"
                 />
+                <input
+                  id="delete-account-content"
+                  type="checkbox"
+                  onInput={linkEvent(
+                    this,
+                    this.handleDeleteAccountDeleteContentChange,
+                  )}
+                />
+                <label className="my-2" htmlFor="delete-account-content">
+                  Delete content
+                </label>
                 <button
                   type="submit"
                   className="btn btn-danger me-4"
@@ -1676,6 +1688,12 @@ export class Settings extends Component<any, SettingsState> {
     i.setState({ deleteAccountShowConfirm: !i.state.deleteAccountShowConfirm });
   }
 
+  handleDeleteAccountDeleteContentChange(i: Settings, event: any) {
+    i.setState(
+      s => ((s.deleteAccountForm.delete_content = event.target.checked), s),
+    );
+  }
+
   handleDeleteAccountPasswordChange(i: Settings, event: any) {
     i.setState(s => ((s.deleteAccountForm.password = event.target.value), s));
   }
@@ -1687,8 +1705,7 @@ export class Settings extends Component<any, SettingsState> {
       i.setState({ deleteAccountRes: LOADING_REQUEST });
       const deleteAccountRes = await HttpService.client.deleteAccount({
         password,
-        // TODO: promt user weather he wants the content to be deleted
-        delete_content: false,
+        delete_content: i.state.deleteAccountForm.delete_content || false,
       });
       if (deleteAccountRes.state === "success") {
         UserService.Instance.logout();

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -1103,14 +1103,14 @@ export class Settings extends Component<any, SettingsState> {
                       className="form-check-input"
                       onInput={linkEvent(
                         this,
-                        this.handleDeleteAccountDeleteContentChange,
+                        this.handleDeleteAccountContentChange,
                       )}
                     />
                     <label
                       className="form-check-label"
                       htmlFor="delete-account-content"
                     >
-                      Delete content
+                      Delete all posts, comments and uploaded images
                     </label>
                   </div>
                 </div>
@@ -1696,7 +1696,7 @@ export class Settings extends Component<any, SettingsState> {
     i.setState({ deleteAccountShowConfirm: !i.state.deleteAccountShowConfirm });
   }
 
-  handleDeleteAccountDeleteContentChange(i: Settings, event: any) {
+  handleDeleteAccountContentChange(i: Settings, event: any) {
     i.setState(
       s => ((s.deleteAccountForm.delete_content = event.target.checked), s),
     );

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -1110,7 +1110,7 @@ export class Settings extends Component<any, SettingsState> {
                       className="form-check-label"
                       htmlFor="delete-account-content"
                     >
-                      Delete all posts, comments and uploaded images
+                      {I18NextService.i18n.t("delete_account_content")}
                     </label>
                   </div>
                 </div>

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -1095,17 +1095,25 @@ export class Settings extends Component<any, SettingsState> {
                   )}
                   className="my-2"
                 />
-                <input
-                  id="delete-account-content"
-                  type="checkbox"
-                  onInput={linkEvent(
-                    this,
-                    this.handleDeleteAccountDeleteContentChange,
-                  )}
-                />
-                <label className="my-2" htmlFor="delete-account-content">
-                  Delete content
-                </label>
+                <div className="input-group mb-3">
+                  <div className="form-check">
+                    <input
+                      id="delete-account-content"
+                      type="checkbox"
+                      className="form-check-input"
+                      onInput={linkEvent(
+                        this,
+                        this.handleDeleteAccountDeleteContentChange,
+                      )}
+                    />
+                    <label
+                      className="form-check-label"
+                      htmlFor="delete-account-content"
+                    >
+                      Delete content
+                    </label>
+                  </div>
+                </div>
                 <button
                   type="submit"
                   className="btn btn-danger me-4"


### PR DESCRIPTION
## Description

Since 0.19 there is a param `delete_content` for `/api/v3/user/delete_account` to avoid that deleting an account would automatically delete all posts. Looks like we forgot to add this option in the frontend.

https://github.com/LemmyNet/lemmy/pull/3817

Requires https://github.com/LemmyNet/lemmy-translations/pull/118

## Screenshots

<!-- Please include before and after screenshots if applicable -->

![Screenshot_20240305_134724](https://github.com/LemmyNet/lemmy-ui/assets/1044450/0735d5ce-c0eb-48b6-a0f2-4acf7c747c64)
