### PR TITLE
fix: add a default margin bottom to ul and ol in a comment field

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -189,10 +189,16 @@ blockquote {
   margin-top: -4px;
 }
 
+/* comments */
 .new-comments {
   max-height: 50vh;
   overflow-x: hidden;
   overflow-y: auto;
+}
+
+.comment-content ul,
+.comment-content ol {
+  margin-bottom: 1rem;
 }
 
 .comments {


### PR DESCRIPTION
## Description

Fixes #2394 

Add default bottom margin to `ul` and `ol` elements.

## Screenshots

### Before

![2394-before](https://github.com/LemmyNet/lemmy-ui/assets/474024/d920553f-72c0-47f1-b191-c5e3bd0288ec)


### After

![2304-after](https://github.com/LemmyNet/lemmy-ui/assets/474024/e8e9dd3d-bfa0-4bf8-a642-995a8fd859ea)
