### PR TITLE
Fix parent comment linking when not showing context

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -501,14 +501,14 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
       ? I18NextService.i18n.t("show_context")
       : I18NextService.i18n.t("link");
 
-    // The context button should show the parent comment by default
-    const parentCommentId = getCommentParentId(cv.comment) ?? cv.comment.id;
-
     return (
       <>
         <Link
           className={classnames}
-          to={`/comment/${parentCommentId}`}
+          to={`/comment/${
+            (this.props.showContext && getCommentParentId(cv.comment)) ||
+            cv.comment.id
+          }`}
           title={title}
         >
           <Icon icon="link" classes="icon-inline" />


### PR DESCRIPTION
The same code is reused for the "show context" button as for the "link
to self" button. I'm not sure that's such a good idea in the long run.

There was a const `parentCommentId` that was always set even when not
having the `showContext` prop, causing the bug #2401.