### PR TITLE
Correct mistake from block urls PR

### DIFF
--- a/src/shared/components/common/url-list-textarea.tsx
+++ b/src/shared/components/common/url-list-textarea.tsx
@@ -47,7 +47,7 @@ export default class UrlListTextarea extends Component<
   UrlListTextareaState
 > {
   state: UrlListTextareaState = {
-    text: "",
+    text: this.props.urls.join("\n"),
   };
 
   render() {


### PR DESCRIPTION
Made a mistake when implementing this feature. The existing blocked URLs wouldn't show on load.