### PR TITLE
Only conditionally render most of content action dropdown and workaround for tippy warning

### DIFF
--- a/src/shared/components/common/confirmation-modal.tsx
+++ b/src/shared/components/common/confirmation-modal.tsx
@@ -1,10 +1,18 @@
-import { Component, RefObject, createRef, linkEvent } from "inferno";
+import {
+  Component,
+  InfernoNode,
+  RefObject,
+  createRef,
+  linkEvent,
+} from "inferno";
 import { I18NextService } from "../../services";
 import type { Modal } from "bootstrap";
 import { Spinner } from "./icon";
 import { LoadingEllipses } from "./loading-ellipses";
+import { modalMixin } from "../mixins/modal-mixin";
 
 interface ConfirmationModalProps {
+  children?: InfernoNode;
   onYes: () => Promise<void>;
   onNo: () => void;
   message: string;
@@ -22,6 +30,7 @@ async function handleYes(i: ConfirmationModal) {
   i.setState({ loading: false });
 }
 
+@modalMixin
 export default class ConfirmationModal extends Component<
   ConfirmationModalProps,
   ConfirmationModalState
@@ -38,45 +47,6 @@ export default class ConfirmationModal extends Component<
 
     this.modalDivRef = createRef();
     this.yesButtonRef = createRef();
-
-    this.handleShow = this.handleShow.bind(this);
-  }
-
-  async componentDidMount() {
-    const Modal = (await import("bootstrap/js/dist/modal")).default;
-
-    if (!this.modalDivRef.current) {
-      return;
-    }
-
-    this.modalDivRef.current?.addEventListener(
-      "shown.bs.modal",
-      this.handleShow,
-    );
-    this.modal = new Modal(this.modalDivRef.current!);
-
-    if (this.props.show) {
-      this.modal.show();
-    }
-  }
-
-  componentWillUnmount() {
-    this.modalDivRef.current?.removeEventListener(
-      "shown.bs.modal",
-      this.handleShow,
-    );
-
-    this.modal?.dispose();
-  }
-
-  componentDidUpdate({ show: prevShow }: ConfirmationModalProps) {
-    if (!!prevShow !== !!this.props.show) {
-      if (this.props.show) {
-        this.modal?.show();
-      } else {
-        this.modal?.hide();
-      }
-    }
   }
 
   render() {

--- a/src/shared/components/common/confirmation-modal.tsx
+++ b/src/shared/components/common/confirmation-modal.tsx
@@ -28,7 +28,7 @@ export default class ConfirmationModal extends Component<
 > {
   readonly modalDivRef: RefObject<HTMLDivElement>;
   readonly yesButtonRef: RefObject<HTMLButtonElement>;
-  modal: Modal;
+  modal?: Modal;
   state: ConfirmationModalState = {
     loading: false,
   };
@@ -43,12 +43,16 @@ export default class ConfirmationModal extends Component<
   }
 
   async componentDidMount() {
+    const Modal = (await import("bootstrap/js/dist/modal")).default;
+
+    if (!this.modalDivRef.current) {
+      return;
+    }
+
     this.modalDivRef.current?.addEventListener(
       "shown.bs.modal",
       this.handleShow,
     );
-
-    const Modal = (await import("bootstrap/js/dist/modal")).default;
     this.modal = new Modal(this.modalDivRef.current!);
 
     if (this.props.show) {
@@ -62,15 +66,15 @@ export default class ConfirmationModal extends Component<
       this.handleShow,
     );
 
-    this.modal.dispose();
+    this.modal?.dispose();
   }
 
   componentDidUpdate({ show: prevShow }: ConfirmationModalProps) {
     if (!!prevShow !== !!this.props.show) {
       if (this.props.show) {
-        this.modal.show();
+        this.modal?.show();
       } else {
-        this.modal.hide();
+        this.modal?.hide();
       }
     }
   }

--- a/src/shared/components/common/content-actions/content-action-dropdown.tsx
+++ b/src/shared/components/common/content-actions/content-action-dropdown.tsx
@@ -82,7 +82,12 @@ type RenderState = {
   [key in `render${DialogType}`]: boolean;
 };
 
-type ContentActionDropdownState = ActionTypeState & ShowState & RenderState;
+type DropdownState = { dropdownOpenedOnce: boolean };
+
+type ContentActionDropdownState = ActionTypeState &
+  ShowState &
+  RenderState &
+  DropdownState;
 
 @tippyMixin
 export default class ContentActionDropdown extends Component<
@@ -106,6 +111,7 @@ export default class ContentActionDropdown extends Component<
     renderReportDialog: false,
     renderTransferCommunityDialog: false,
     renderViewVotesDialog: false,
+    dropdownOpenedOnce: false,
   };
   constructor(props: ContentActionDropdownProps, context: any) {
     super(props, context);
@@ -182,291 +188,304 @@ export default class ContentActionDropdown extends Component<
             aria-expanded="false"
             aria-controls={dropdownId}
             aria-label={I18NextService.i18n.t("more")}
+            onClick={() => this.setState({ dropdownOpenedOnce: true })}
           >
             <Icon icon="more-vertical" inline />
           </button>
 
           <ul className="dropdown-menu" id={dropdownId}>
-            {type === "post" && (
-              <li>
-                <ActionButton
-                  icon={this.props.postView.hidden ? "eye" : "eye-slash"}
-                  label={I18NextService.i18n.t(
-                    this.props.postView.hidden ? "unhide_post" : "hide_post",
-                  )}
-                  onClick={this.props.onHidePost}
-                />
-              </li>
-            )}
-            {this.amCreator ? (
+            {this.state.dropdownOpenedOnce && (
               <>
-                <li>
-                  <ActionButton
-                    icon="edit"
-                    label={I18NextService.i18n.t("edit")}
-                    noLoading
-                    onClick={onEdit}
-                  />
-                </li>
-                <li>
-                  <ActionButton
-                    onClick={onDelete}
-                    icon={deleted ? "undo-trash" : "trash"}
-                    label={I18NextService.i18n.t(
-                      deleted ? "undelete" : "delete",
-                    )}
-                    iconClass={`text-${deleted ? "success" : "danger"}`}
-                  />
-                </li>
-              </>
-            ) : (
-              <>
-                {type === "comment" && (
+                {type === "post" && (
                   <li>
-                    <Link
-                      className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
-                      to={`/create_private_message/${creator.id}`}
-                      title={I18NextService.i18n.t("message")}
-                      aria-label={I18NextService.i18n.t("message")}
-                      data-tippy-content={I18NextService.i18n.t("message")}
-                    >
-                      <Icon icon="mail" inline classes="me-2" />
-                      {I18NextService.i18n.t("message")}
-                    </Link>
+                    <ActionButton
+                      icon={this.props.postView.hidden ? "eye" : "eye-slash"}
+                      label={I18NextService.i18n.t(
+                        this.props.postView.hidden
+                          ? "unhide_post"
+                          : "hide_post",
+                      )}
+                      onClick={this.props.onHidePost}
+                    />
                   </li>
                 )}
-                <li>
-                  <ActionButton
-                    icon="flag"
-                    label={I18NextService.i18n.t("create_report")}
-                    onClick={this.toggleReportDialogShow}
-                    noLoading
-                  />
-                </li>
-                <li>
-                  <ActionButton
-                    icon="slash"
-                    label={I18NextService.i18n.t("block_user")}
-                    onClick={onBlock}
-                  />
-                </li>
-              </>
-            )}
-            {amAdmin() && (
-              <li>
-                <ActionButton
-                  onClick={this.toggleViewVotesShow}
-                  label={I18NextService.i18n.t("view_votes")}
-                  icon={"arrow-up"}
-                  noLoading
-                />
-              </li>
-            )}
-
-            {(amMod(community.id) || amAdmin()) && (
-              <>
-                <li>
-                  <hr className="dropdown-divider" />
-                </li>
-                {type === "post" && (
+                {this.amCreator ? (
                   <>
                     <li>
                       <ActionButton
-                        onClick={this.props.onLock}
-                        label={I18NextService.i18n.t(
-                          locked ? "unlock" : "lock",
-                        )}
-                        icon={locked ? "unlock" : "lock"}
+                        icon="edit"
+                        label={I18NextService.i18n.t("edit")}
+                        noLoading
+                        onClick={onEdit}
                       />
                     </li>
                     <li>
                       <ActionButton
-                        onClick={this.props.onFeatureCommunity}
+                        onClick={onDelete}
+                        icon={deleted ? "undo-trash" : "trash"}
                         label={I18NextService.i18n.t(
-                          this.props.postView.post.featured_community
-                            ? "unfeature_from_community"
-                            : "feature_in_community",
+                          deleted ? "undelete" : "delete",
                         )}
-                        icon={
-                          this.props.postView.post.featured_community
-                            ? "pin-off"
-                            : "pin"
-                        }
+                        iconClass={`text-${deleted ? "success" : "danger"}`}
                       />
                     </li>
-                    {amAdmin() && (
+                  </>
+                ) : (
+                  <>
+                    {type === "comment" && (
+                      <li>
+                        <Link
+                          className="btn btn-link btn-sm d-flex align-items-center rounded-0 dropdown-item"
+                          to={`/create_private_message/${creator.id}`}
+                          title={I18NextService.i18n.t("message")}
+                          aria-label={I18NextService.i18n.t("message")}
+                          data-tippy-content={I18NextService.i18n.t("message")}
+                        >
+                          <Icon icon="mail" inline classes="me-2" />
+                          {I18NextService.i18n.t("message")}
+                        </Link>
+                      </li>
+                    )}
+                    <li>
+                      <ActionButton
+                        icon="flag"
+                        label={I18NextService.i18n.t("create_report")}
+                        onClick={this.toggleReportDialogShow}
+                        noLoading
+                      />
+                    </li>
+                    <li>
+                      <ActionButton
+                        icon="slash"
+                        label={I18NextService.i18n.t("block_user")}
+                        onClick={onBlock}
+                      />
+                    </li>
+                  </>
+                )}
+                {amAdmin() && (
+                  <li>
+                    <ActionButton
+                      onClick={this.toggleViewVotesShow}
+                      label={I18NextService.i18n.t("view_votes")}
+                      icon={"arrow-up"}
+                      noLoading
+                    />
+                  </li>
+                )}
+
+                {(amMod(community.id) || amAdmin()) && (
+                  <>
+                    <li>
+                      <hr className="dropdown-divider" />
+                    </li>
+                    {type === "post" && (
+                      <>
+                        <li>
+                          <ActionButton
+                            onClick={this.props.onLock}
+                            label={I18NextService.i18n.t(
+                              locked ? "unlock" : "lock",
+                            )}
+                            icon={locked ? "unlock" : "lock"}
+                          />
+                        </li>
+                        <li>
+                          <ActionButton
+                            onClick={this.props.onFeatureCommunity}
+                            label={I18NextService.i18n.t(
+                              this.props.postView.post.featured_community
+                                ? "unfeature_from_community"
+                                : "feature_in_community",
+                            )}
+                            icon={
+                              this.props.postView.post.featured_community
+                                ? "pin-off"
+                                : "pin"
+                            }
+                          />
+                        </li>
+                        {amAdmin() && (
+                          <li>
+                            <ActionButton
+                              onClick={this.props.onFeatureLocal}
+                              label={I18NextService.i18n.t(
+                                this.props.postView.post.featured_local
+                                  ? "unfeature_from_local"
+                                  : "feature_in_local",
+                              )}
+                              icon={
+                                this.props.postView.post.featured_local
+                                  ? "pin-off"
+                                  : "pin"
+                              }
+                            />
+                          </li>
+                        )}
+                      </>
+                    )}
+                  </>
+                )}
+                {type === "comment" &&
+                  this.amCreator &&
+                  (this.canModOnSelf || this.canAdminOnSelf) && (
+                    <li>
+                      <ActionButton
+                        onClick={this.props.onDistinguish}
+                        icon={
+                          this.props.commentView.comment.distinguished
+                            ? "shield-off"
+                            : "shield"
+                        }
+                        label={I18NextService.i18n.t(
+                          this.props.commentView.comment.distinguished
+                            ? "undistinguish"
+                            : "distinguish",
+                        )}
+                      />
+                    </li>
+                  )}
+                {(this.canMod || this.canAdmin) && (
+                  <li>
+                    <ActionButton
+                      label={
+                        removed
+                          ? `${I18NextService.i18n.t(
+                              "restore",
+                            )} ${I18NextService.i18n.t(
+                              type === "post" ? "post" : "comment",
+                            )}`
+                          : I18NextService.i18n.t(
+                              type === "post"
+                                ? "remove_post"
+                                : "remove_comment",
+                            )
+                      }
+                      icon={removed ? "restore" : "x"}
+                      noLoading
+                      onClick={this.toggleRemoveShow}
+                      iconClass={`text-${removed ? "success" : "danger"}`}
+                    />
+                  </li>
+                )}
+                {this.canMod &&
+                  (!creator_is_moderator || canAppointCommunityMod) && (
+                    <>
+                      <li>
+                        <hr className="dropdown-divider" />
+                      </li>
+                      {!creator_is_moderator && (
+                        <li>
+                          <ActionButton
+                            onClick={this.toggleBanFromCommunityShow}
+                            label={I18NextService.i18n.t(
+                              creator_banned_from_community
+                                ? "unban_from_community"
+                                : "ban_from_community",
+                            )}
+                            icon={
+                              creator_banned_from_community ? "unban" : "ban"
+                            }
+                            noLoading
+                            iconClass={`text-${
+                              creator_banned_from_community
+                                ? "success"
+                                : "danger"
+                            }`}
+                          />
+                        </li>
+                      )}
+                      {canAppointCommunityMod && (
+                        <li>
+                          <ActionButton
+                            onClick={this.toggleAppointModShow}
+                            label={I18NextService.i18n.t(
+                              `${
+                                creator_is_moderator ? "remove" : "appoint"
+                              }_as_mod`,
+                            )}
+                            icon={creator_is_moderator ? "demote" : "promote"}
+                            iconClass={`text-${
+                              creator_is_moderator ? "danger" : "success"
+                            }`}
+                            noLoading
+                          />
+                        </li>
+                      )}
+                    </>
+                  )}
+                {(amCommunityCreator(this.id, moderators) || this.canAdmin) &&
+                  creator_is_moderator && (
+                    <li>
+                      <ActionButton
+                        label={I18NextService.i18n.t("transfer_community")}
+                        onClick={this.toggleTransferCommunityShow}
+                        icon="transfer"
+                        noLoading
+                      />
+                    </li>
+                  )}
+
+                {this.canAdmin && (showToggleAdmin || !creator_is_admin) && (
+                  <>
+                    <li>
+                      <hr className="dropdown-divider" />
+                    </li>
+                    {!creator_is_admin && (
+                      <>
+                        <li>
+                          <ActionButton
+                            label={I18NextService.i18n.t(
+                              creatorBannedFromLocal
+                                ? "unban_from_site"
+                                : "ban_from_site",
+                            )}
+                            onClick={this.toggleBanFromSiteShow}
+                            icon={creatorBannedFromLocal ? "unban" : "ban"}
+                            iconClass={`text-${
+                              creatorBannedFromLocal ? "success" : "danger"
+                            }`}
+                            noLoading
+                          />
+                        </li>
+                        <li>
+                          <ActionButton
+                            label={I18NextService.i18n.t("purge_user")}
+                            onClick={this.togglePurgePersonShow}
+                            icon="purge"
+                            noLoading
+                            iconClass="text-danger"
+                          />
+                        </li>
+                        <li>
+                          <ActionButton
+                            label={I18NextService.i18n.t(
+                              `purge_${type === "post" ? "post" : "comment"}`,
+                            )}
+                            onClick={this.togglePurgeContentShow}
+                            icon="purge"
+                            noLoading
+                            iconClass="text-danger"
+                          />
+                        </li>
+                      </>
+                    )}
+                    {showToggleAdmin && (
                       <li>
                         <ActionButton
-                          onClick={this.props.onFeatureLocal}
                           label={I18NextService.i18n.t(
-                            this.props.postView.post.featured_local
-                              ? "unfeature_from_local"
-                              : "feature_in_local",
+                            `${creator_is_admin ? "remove" : "appoint"}_as_admin`,
                           )}
-                          icon={
-                            this.props.postView.post.featured_local
-                              ? "pin-off"
-                              : "pin"
-                          }
+                          onClick={this.toggleAppointAdminShow}
+                          icon={creator_is_admin ? "demote" : "promote"}
+                          iconClass={`text-${
+                            creator_is_admin ? "danger" : "success"
+                          }`}
+                          noLoading
                         />
                       </li>
                     )}
                   </>
-                )}
-              </>
-            )}
-            {type === "comment" &&
-              this.amCreator &&
-              (this.canModOnSelf || this.canAdminOnSelf) && (
-                <li>
-                  <ActionButton
-                    onClick={this.props.onDistinguish}
-                    icon={
-                      this.props.commentView.comment.distinguished
-                        ? "shield-off"
-                        : "shield"
-                    }
-                    label={I18NextService.i18n.t(
-                      this.props.commentView.comment.distinguished
-                        ? "undistinguish"
-                        : "distinguish",
-                    )}
-                  />
-                </li>
-              )}
-            {(this.canMod || this.canAdmin) && (
-              <li>
-                <ActionButton
-                  label={
-                    removed
-                      ? `${I18NextService.i18n.t(
-                          "restore",
-                        )} ${I18NextService.i18n.t(
-                          type === "post" ? "post" : "comment",
-                        )}`
-                      : I18NextService.i18n.t(
-                          type === "post" ? "remove_post" : "remove_comment",
-                        )
-                  }
-                  icon={removed ? "restore" : "x"}
-                  noLoading
-                  onClick={this.toggleRemoveShow}
-                  iconClass={`text-${removed ? "success" : "danger"}`}
-                />
-              </li>
-            )}
-            {this.canMod &&
-              (!creator_is_moderator || canAppointCommunityMod) && (
-                <>
-                  <li>
-                    <hr className="dropdown-divider" />
-                  </li>
-                  {!creator_is_moderator && (
-                    <li>
-                      <ActionButton
-                        onClick={this.toggleBanFromCommunityShow}
-                        label={I18NextService.i18n.t(
-                          creator_banned_from_community
-                            ? "unban_from_community"
-                            : "ban_from_community",
-                        )}
-                        icon={creator_banned_from_community ? "unban" : "ban"}
-                        noLoading
-                        iconClass={`text-${
-                          creator_banned_from_community ? "success" : "danger"
-                        }`}
-                      />
-                    </li>
-                  )}
-                  {canAppointCommunityMod && (
-                    <li>
-                      <ActionButton
-                        onClick={this.toggleAppointModShow}
-                        label={I18NextService.i18n.t(
-                          `${
-                            creator_is_moderator ? "remove" : "appoint"
-                          }_as_mod`,
-                        )}
-                        icon={creator_is_moderator ? "demote" : "promote"}
-                        iconClass={`text-${
-                          creator_is_moderator ? "danger" : "success"
-                        }`}
-                        noLoading
-                      />
-                    </li>
-                  )}
-                </>
-              )}
-            {(amCommunityCreator(this.id, moderators) || this.canAdmin) &&
-              creator_is_moderator && (
-                <li>
-                  <ActionButton
-                    label={I18NextService.i18n.t("transfer_community")}
-                    onClick={this.toggleTransferCommunityShow}
-                    icon="transfer"
-                    noLoading
-                  />
-                </li>
-              )}
-
-            {this.canAdmin && (showToggleAdmin || !creator_is_admin) && (
-              <>
-                <li>
-                  <hr className="dropdown-divider" />
-                </li>
-                {!creator_is_admin && (
-                  <>
-                    <li>
-                      <ActionButton
-                        label={I18NextService.i18n.t(
-                          creatorBannedFromLocal
-                            ? "unban_from_site"
-                            : "ban_from_site",
-                        )}
-                        onClick={this.toggleBanFromSiteShow}
-                        icon={creatorBannedFromLocal ? "unban" : "ban"}
-                        iconClass={`text-${
-                          creatorBannedFromLocal ? "success" : "danger"
-                        }`}
-                        noLoading
-                      />
-                    </li>
-                    <li>
-                      <ActionButton
-                        label={I18NextService.i18n.t("purge_user")}
-                        onClick={this.togglePurgePersonShow}
-                        icon="purge"
-                        noLoading
-                        iconClass="text-danger"
-                      />
-                    </li>
-                    <li>
-                      <ActionButton
-                        label={I18NextService.i18n.t(
-                          `purge_${type === "post" ? "post" : "comment"}`,
-                        )}
-                        onClick={this.togglePurgeContentShow}
-                        icon="purge"
-                        noLoading
-                        iconClass="text-danger"
-                      />
-                    </li>
-                  </>
-                )}
-                {showToggleAdmin && (
-                  <li>
-                    <ActionButton
-                      label={I18NextService.i18n.t(
-                        `${creator_is_admin ? "remove" : "appoint"}_as_admin`,
-                      )}
-                      onClick={this.toggleAppointAdminShow}
-                      icon={creator_is_admin ? "demote" : "promote"}
-                      iconClass={`text-${
-                        creator_is_admin ? "danger" : "success"
-                      }`}
-                      noLoading
-                    />
-                  </li>
                 )}
               </>
             )}

--- a/src/shared/components/common/content-actions/content-action-dropdown.tsx
+++ b/src/shared/components/common/content-actions/content-action-dropdown.tsx
@@ -113,6 +113,7 @@ export default class ContentActionDropdown extends Component<
     renderViewVotesDialog: false,
     dropdownOpenedOnce: false,
   };
+
   constructor(props: ContentActionDropdownProps, context: any) {
     super(props, context);
 
@@ -131,6 +132,7 @@ export default class ContentActionDropdown extends Component<
     this.toggleAppointAdminShow = this.toggleAppointAdminShow.bind(this);
     this.toggleViewVotesShow = this.toggleViewVotesShow.bind(this);
     this.wrapHandler = this.wrapHandler.bind(this);
+    this.handleDropdownToggleClick = this.handleDropdownToggleClick.bind(this);
   }
 
   render() {
@@ -188,7 +190,7 @@ export default class ContentActionDropdown extends Component<
             aria-expanded="false"
             aria-controls={dropdownId}
             aria-label={I18NextService.i18n.t("more")}
-            onClick={() => this.setState({ dropdownOpenedOnce: true })}
+            onClick={this.handleDropdownToggleClick}
           >
             <Icon icon="more-vertical" inline />
           </button>
@@ -494,6 +496,11 @@ export default class ContentActionDropdown extends Component<
         {this.moderationDialogs}
       </>
     );
+  }
+
+  handleDropdownToggleClick() {
+    // This only renders the dropdown. Bootstrap handles the show/hide part.
+    this.setState({ dropdownOpenedOnce: true });
   }
 
   toggleModDialogShow(

--- a/src/shared/components/common/mod-action-form-modal.tsx
+++ b/src/shared/components/common/mod-action-form-modal.tsx
@@ -1,4 +1,10 @@
-import { Component, RefObject, createRef, linkEvent } from "inferno";
+import {
+  Component,
+  InfernoNode,
+  RefObject,
+  createRef,
+  linkEvent,
+} from "inferno";
 import { I18NextService } from "../../services/I18NextService";
 import { PurgeWarning, Spinner } from "./icon";
 import { getApubName, randomStr } from "@utils/helpers";
@@ -6,6 +12,7 @@ import type { Modal } from "bootstrap";
 import classNames from "classnames";
 import { Community, Person } from "lemmy-js-client";
 import { LoadingEllipses } from "./loading-ellipses";
+import { modalMixin } from "../mixins/modal-mixin";
 
 export interface BanUpdateForm {
   reason?: string;
@@ -56,7 +63,7 @@ type ModActionFormModalProps = (
   | ModActionFormModalPropsRest
   | ModActionFormModalPropsPurgePerson
   | ModActionFormModalPropsRemove
-) & { onCancel: () => void; show: boolean };
+) & { onCancel: () => void; show: boolean; children?: InfernoNode };
 
 interface ModActionFormFormState {
   loading: boolean;
@@ -109,11 +116,12 @@ async function handleSubmit(i: ModActionFormModal, event: any) {
   });
 }
 
+@modalMixin
 export default class ModActionFormModal extends Component<
   ModActionFormModalProps,
   ModActionFormFormState
 > {
-  private modalDivRef: RefObject<HTMLDivElement>;
+  modalDivRef: RefObject<HTMLDivElement>;
   private reasonRef: RefObject<HTMLInputElement>;
   modal?: Modal;
   state: ModActionFormFormState = {
@@ -128,45 +136,6 @@ export default class ModActionFormModal extends Component<
 
     if (this.isBanModal) {
       this.state.shouldRemoveData = false;
-    }
-
-    this.handleShow = this.handleShow.bind(this);
-  }
-
-  async componentDidMount() {
-    const Modal = (await import("bootstrap/js/dist/modal")).default;
-
-    if (!this.modalDivRef.current) {
-      return;
-    }
-
-    this.modalDivRef.current?.addEventListener(
-      "shown.bs.modal",
-      this.handleShow,
-    );
-    this.modal = new Modal(this.modalDivRef.current!);
-
-    if (this.props.show) {
-      this.modal.show();
-    }
-  }
-
-  componentWillUnmount() {
-    this.modalDivRef.current?.removeEventListener(
-      "shown.bs.modal",
-      this.handleShow,
-    );
-
-    this.modal?.dispose();
-  }
-
-  componentDidUpdate({ show: prevShow }: ModActionFormModalProps) {
-    if (!!prevShow !== !!this.props.show) {
-      if (this.props.show) {
-        this.modal?.show();
-      } else {
-        this.modal?.hide();
-      }
     }
   }
 

--- a/src/shared/components/common/mod-action-form-modal.tsx
+++ b/src/shared/components/common/mod-action-form-modal.tsx
@@ -115,7 +115,7 @@ export default class ModActionFormModal extends Component<
 > {
   private modalDivRef: RefObject<HTMLDivElement>;
   private reasonRef: RefObject<HTMLInputElement>;
-  modal: Modal;
+  modal?: Modal;
   state: ModActionFormFormState = {
     loading: false,
     reason: "",
@@ -134,12 +134,16 @@ export default class ModActionFormModal extends Component<
   }
 
   async componentDidMount() {
+    const Modal = (await import("bootstrap/js/dist/modal")).default;
+
+    if (!this.modalDivRef.current) {
+      return;
+    }
+
     this.modalDivRef.current?.addEventListener(
       "shown.bs.modal",
       this.handleShow,
     );
-
-    const Modal = (await import("bootstrap/js/dist/modal")).default;
     this.modal = new Modal(this.modalDivRef.current!);
 
     if (this.props.show) {
@@ -153,15 +157,15 @@ export default class ModActionFormModal extends Component<
       this.handleShow,
     );
 
-    this.modal.dispose();
+    this.modal?.dispose();
   }
 
   componentDidUpdate({ show: prevShow }: ModActionFormModalProps) {
     if (!!prevShow !== !!this.props.show) {
       if (this.props.show) {
-        this.modal.show();
+        this.modal?.show();
       } else {
-        this.modal.hide();
+        this.modal?.hide();
       }
     }
   }

--- a/src/shared/components/common/totp-modal.tsx
+++ b/src/shared/components/common/totp-modal.tsx
@@ -1,5 +1,6 @@
 import {
   Component,
+  InfernoNode,
   MouseEventHandler,
   RefObject,
   createRef,
@@ -8,14 +9,16 @@ import {
 import { I18NextService } from "../../services";
 import { toast } from "../../toast";
 import type { Modal } from "bootstrap";
+import { modalMixin } from "../mixins/modal-mixin";
 
 interface TotpModalProps {
+  children?: InfernoNode;
   /**Takes totp as param, returns whether submit was successful*/
   onSubmit: (totp: string) => Promise<boolean>;
   onClose: MouseEventHandler;
   type: "login" | "remove" | "generate";
   secretUrl?: string;
-  show?: boolean;
+  show: boolean;
 }
 
 interface TotpModalState {
@@ -68,6 +71,7 @@ function handlePaste(i: TotpModal, event: any) {
   }
 }
 
+@modalMixin
 export default class TotpModal extends Component<
   TotpModalProps,
   TotpModalState
@@ -85,57 +89,6 @@ export default class TotpModal extends Component<
 
     this.modalDivRef = createRef();
     this.inputRef = createRef();
-
-    this.clearTotp = this.clearTotp.bind(this);
-    this.handleShow = this.handleShow.bind(this);
-  }
-
-  async componentDidMount() {
-    const Modal = (await import("bootstrap/js/dist/modal")).default;
-
-    if (!this.modalDivRef.current) {
-      return;
-    }
-
-    this.modalDivRef.current?.addEventListener(
-      "shown.bs.modal",
-      this.handleShow,
-    );
-
-    this.modalDivRef.current?.addEventListener(
-      "hidden.bs.modal",
-      this.clearTotp,
-    );
-
-    this.modal = new Modal(this.modalDivRef.current!);
-
-    if (this.props.show) {
-      this.modal.show();
-    }
-  }
-
-  componentWillUnmount() {
-    this.modalDivRef.current?.removeEventListener(
-      "shown.bs.modal",
-      this.handleShow,
-    );
-
-    this.modalDivRef.current?.removeEventListener(
-      "hidden.bs.modal",
-      this.clearTotp,
-    );
-
-    this.modal?.dispose();
-  }
-
-  componentDidUpdate({ show: prevShow }: TotpModalProps) {
-    if (!!prevShow !== !!this.props.show) {
-      if (this.props.show) {
-        this.modal?.show();
-      } else {
-        this.modal?.hide();
-      }
-    }
   }
 
   render() {
@@ -258,5 +211,9 @@ export default class TotpModal extends Component<
         ),
       });
     }
+  }
+
+  handleHide() {
+    this.clearTotp();
   }
 }

--- a/src/shared/components/common/totp-modal.tsx
+++ b/src/shared/components/common/totp-modal.tsx
@@ -74,7 +74,7 @@ export default class TotpModal extends Component<
 > {
   readonly modalDivRef: RefObject<HTMLDivElement>;
   readonly inputRef: RefObject<HTMLInputElement>;
-  modal: Modal;
+  modal?: Modal;
   state: TotpModalState = {
     totp: "",
     pending: false,
@@ -91,6 +91,12 @@ export default class TotpModal extends Component<
   }
 
   async componentDidMount() {
+    const Modal = (await import("bootstrap/js/dist/modal")).default;
+
+    if (!this.modalDivRef.current) {
+      return;
+    }
+
     this.modalDivRef.current?.addEventListener(
       "shown.bs.modal",
       this.handleShow,
@@ -101,7 +107,6 @@ export default class TotpModal extends Component<
       this.clearTotp,
     );
 
-    const Modal = (await import("bootstrap/js/dist/modal")).default;
     this.modal = new Modal(this.modalDivRef.current!);
 
     if (this.props.show) {
@@ -120,15 +125,15 @@ export default class TotpModal extends Component<
       this.clearTotp,
     );
 
-    this.modal.dispose();
+    this.modal?.dispose();
   }
 
   componentDidUpdate({ show: prevShow }: TotpModalProps) {
     if (!!prevShow !== !!this.props.show) {
       if (this.props.show) {
-        this.modal.show();
+        this.modal?.show();
       } else {
-        this.modal.hide();
+        this.modal?.hide();
       }
     }
   }

--- a/src/shared/components/common/view-votes-modal.tsx
+++ b/src/shared/components/common/view-votes-modal.tsx
@@ -63,7 +63,7 @@ export default class ViewVotesModal extends Component<
 > {
   readonly modalDivRef: RefObject<HTMLDivElement>;
   readonly yesButtonRef: RefObject<HTMLButtonElement>;
-  modal: Modal;
+  modal?: Modal;
   state: ViewVotesModalState = {
     postLikesRes: EMPTY_REQUEST,
     commentLikesRes: EMPTY_REQUEST,
@@ -82,13 +82,17 @@ export default class ViewVotesModal extends Component<
   }
 
   async componentDidMount() {
+    const Modal = (await import("bootstrap/js/dist/modal")).default;
+
+    if (!this.modalDivRef.current) {
+      return;
+    }
+
+    this.modal = new Modal(this.modalDivRef.current!);
     this.modalDivRef.current?.addEventListener(
       "shown.bs.modal",
       this.handleShow,
     );
-
-    const Modal = (await import("bootstrap/js/dist/modal")).default;
-    this.modal = new Modal(this.modalDivRef.current!);
 
     if (this.props.show) {
       this.modal.show();
@@ -102,16 +106,16 @@ export default class ViewVotesModal extends Component<
       this.handleShow,
     );
 
-    this.modal.dispose();
+    this.modal?.dispose();
   }
 
   async componentDidUpdate({ show: prevShow }: ViewVotesModalProps) {
     if (!!prevShow !== !!this.props.show) {
       if (this.props.show) {
-        this.modal.show();
+        this.modal?.show();
         await this.refetch();
       } else {
-        this.modal.hide();
+        this.modal?.hide();
       }
     }
   }
@@ -191,7 +195,7 @@ export default class ViewVotesModal extends Component<
 
   handleDismiss() {
     this.props.onCancel();
-    this.modal.hide();
+    this.modal?.hide();
   }
 
   async handlePageChange(page: number) {

--- a/src/shared/components/common/view-votes-modal.tsx
+++ b/src/shared/components/common/view-votes-modal.tsx
@@ -1,4 +1,10 @@
-import { Component, RefObject, createRef, linkEvent } from "inferno";
+import {
+  Component,
+  InfernoNode,
+  RefObject,
+  createRef,
+  linkEvent,
+} from "inferno";
 import { I18NextService } from "../../services";
 import type { Modal } from "bootstrap";
 import { Icon, Spinner } from "./icon";
@@ -16,8 +22,10 @@ import {
 } from "../../services/HttpService";
 import { fetchLimit } from "../../config";
 import { PersonListing } from "../person/person-listing";
+import { modalMixin } from "../mixins/modal-mixin";
 
 interface ViewVotesModalProps {
+  children?: InfernoNode;
   type: "comment" | "post";
   id: number;
   show: boolean;
@@ -57,6 +65,7 @@ function scoreToIcon(score: number) {
   );
 }
 
+@modalMixin
 export default class ViewVotesModal extends Component<
   ViewVotesModalProps,
   ViewVotesModalState
@@ -76,46 +85,20 @@ export default class ViewVotesModal extends Component<
     this.modalDivRef = createRef();
     this.yesButtonRef = createRef();
 
-    this.handleShow = this.handleShow.bind(this);
     this.handleDismiss = this.handleDismiss.bind(this);
     this.handlePageChange = this.handlePageChange.bind(this);
   }
 
   async componentDidMount() {
-    const Modal = (await import("bootstrap/js/dist/modal")).default;
-
-    if (!this.modalDivRef.current) {
-      return;
-    }
-
-    this.modal = new Modal(this.modalDivRef.current!);
-    this.modalDivRef.current?.addEventListener(
-      "shown.bs.modal",
-      this.handleShow,
-    );
-
     if (this.props.show) {
-      this.modal.show();
       await this.refetch();
     }
   }
 
-  componentWillUnmount() {
-    this.modalDivRef.current?.removeEventListener(
-      "shown.bs.modal",
-      this.handleShow,
-    );
-
-    this.modal?.dispose();
-  }
-
-  async componentDidUpdate({ show: prevShow }: ViewVotesModalProps) {
-    if (!!prevShow !== !!this.props.show) {
-      if (this.props.show) {
-        this.modal?.show();
+  async componentWillReceiveProps({ show: nextShow }: ViewVotesModalProps) {
+    if (nextShow !== this.props.show) {
+      if (nextShow) {
         await this.refetch();
-      } else {
-        this.modal?.hide();
       }
     }
   }

--- a/src/shared/components/mixins/modal-mixin.ts
+++ b/src/shared/components/mixins/modal-mixin.ts
@@ -1,0 +1,81 @@
+import { Modal } from "bootstrap";
+import { Component, InfernoNode, RefObject } from "inferno";
+
+export function modalMixin<
+  P extends { show: boolean },
+  S,
+  Base extends new (...args: any[]) => Component<P, S> & {
+    readonly modalDivRef: RefObject<HTMLDivElement>;
+    handleShow?(): void;
+    handleHide?(): void;
+  },
+>(base: Base, _context?: ClassDecoratorContext<Base>) {
+  return class extends base {
+    modal?: Modal;
+    constructor(...args: any[]) {
+      super(...args);
+      this.handleHide = this.handleHide?.bind(this);
+      this.handleShow = this.handleShow?.bind(this);
+    }
+
+    private addModalListener(type: string, listener?: () => void) {
+      if (listener) {
+        this.modalDivRef.current?.addEventListener(type, listener);
+      }
+    }
+
+    private removeModalListener(type: string, listener?: () => void) {
+      if (listener) {
+        this.modalDivRef.current?.addEventListener(type, listener);
+      }
+    }
+
+    componentDidMount() {
+      // Keeping this sync to allow the super implementation to be sync
+      import("bootstrap/js/dist/modal").then(
+        (res: { default: typeof Modal }) => {
+          if (!this.modalDivRef.current) {
+            return;
+          }
+
+          // bootstrap tries to touch `document` during import, which makes
+          // the import fail on the server.
+
+          const Modal = res.default;
+
+          this.addModalListener("shown.bs.modal", this.handleShow);
+          this.addModalListener("hidden.bs.modal", this.handleHide);
+
+          this.modal = new Modal(this.modalDivRef.current!);
+
+          if (this.props.show) {
+            this.modal.show();
+          }
+        },
+      );
+      return super.componentDidMount?.();
+    }
+
+    componentWillUnmount() {
+      this.removeModalListener("shown.bs.modal", this.handleShow);
+      this.removeModalListener("hidden.bs.modal", this.handleHide);
+
+      this.modal?.dispose();
+      return super.componentWillUnmount?.();
+    }
+
+    componentWillReceiveProps(
+      nextProps: Readonly<{ children?: InfernoNode } & P>,
+      nextContext: any,
+    ) {
+      if (nextProps.show !== this.props.show) {
+        if (nextProps.show) {
+          this.modal?.show();
+        } else {
+          this.modal?.hide();
+        }
+      }
+      return super.componentWillReceiveProps?.(nextProps, nextContext);
+    }
+  };
+}

--- a/src/shared/tippy.ts
+++ b/src/shared/tippy.ts
@@ -44,6 +44,14 @@ export function setupTippy(root: RefObject<Element>) {
 }
 
 export function cleanupTippy() {
+  // Hide tooltips for elements that are no longer connected to the document.
+  shownInstances.forEach(i => {
+    if (!i.reference.isConnected) {
+      console.assert(!i.state.isDestroyed, "hide called on destroyed tippy");
+      i.hide();
+    }
+  });
+
   if (shownInstances.size || instanceCounter < 10) {
     // Avoid randomly closing tooltips.
     return;


### PR DESCRIPTION
This only starts rendering the dropdown and each modal dialog when they are shown for first time. For simplicity they keep getting rendered until the component unmounts.

A small fix when the Modal promise resolves after the component umounts. I don't remember how to trigger this, but saw this occasionally happen.

Also a work around for the tippy warning. Turns out tippy doesn't remove all event listeners when it destroys an instance.