### PR TITLE
Use muted display names, and always show instance for non-local. #1975 #2064

### DIFF
--- a/src/shared/components/community/community-link.tsx
+++ b/src/shared/components/community/community-link.tsx
@@ -20,42 +20,38 @@ export class CommunityLink extends Component<CommunityLinkProps, any> {
   }
 
   render() {
-    const community = this.props.community;
-    let title: string, link: string;
+    const { community, useApubName } = this.props;
     const local = community.local === null ? true : community.local;
-    const domain = hostname(community.actor_id);
+
+    let link: string;
+    let serverStr: string | undefined = undefined;
+
+    const title = useApubName
+      ? community.name
+      : community.title ?? community.name;
+
     if (local) {
-      title = community.title;
       link = `/c/${community.name}`;
     } else {
-      const name_ = `${community.name}@${domain}`;
-      title = `${community.title}@${domain}`;
-      link = !this.props.realLink ? `/c/${name_}` : community.actor_id;
+      serverStr = `@${hostname(community.actor_id)}`;
+      link = !this.props.realLink
+        ? `/c/${community.name}${serverStr}`
+        : community.actor_id;
     }
+    const classes = `community-link ${this.props.muted ? "text-muted" : ""}`;
 
-    const apubName = `!${community.name}@${domain}`;
-    const displayName = this.props.useApubName ? apubName : title;
     return !this.props.realLink ? (
-      <Link
-        title={apubName}
-        className={`community-link ${this.props.muted ? "text-muted" : ""}`}
-        to={link}
-      >
-        {this.avatarAndName(displayName)}
+      <Link title={title} className={classes} to={link}>
+        {this.avatarAndName(title, serverStr)}
       </Link>
     ) : (
-      <a
-        title={apubName}
-        className={`community-link ${this.props.muted ? "text-muted" : ""}`}
-        href={link}
-        rel={relTags}
-      >
-        {this.avatarAndName(displayName)}
+      <a title={title} className={classes} href={link} rel={relTags}>
+        {this.avatarAndName(title, serverStr)}
       </a>
     );
   }
 
-  avatarAndName(displayName: string) {
+  avatarAndName(title: string, serverStr?: string) {
     const icon = this.props.community.icon;
     const nsfw = this.props.community.nsfw;
 
@@ -65,7 +61,12 @@ export class CommunityLink extends Component<CommunityLinkProps, any> {
           !this.props.community.removed &&
           showAvatars() &&
           icon && <PictrsImage src={icon} icon nsfw={nsfw} />}
-        <span className="overflow-wrap-anywhere">{displayName}</span>
+        <span className="overflow-wrap-anywhere">
+          {title}
+          {serverStr !== undefined && (
+            <small className="text-muted">{serverStr}</small>
+          )}
+        </span>
       </>
     );
   }

--- a/src/shared/components/community/community-link.tsx
+++ b/src/shared/components/community/community-link.tsx
@@ -63,9 +63,7 @@ export class CommunityLink extends Component<CommunityLinkProps, any> {
           icon && <PictrsImage src={icon} icon nsfw={nsfw} />}
         <span className="overflow-wrap-anywhere">
           {title}
-          {serverStr !== undefined && (
-            <small className="text-muted">{serverStr}</small>
-          )}
+          {serverStr && <small className="text-muted">{serverStr}</small>}
         </span>
       </>
     );

--- a/src/shared/components/person/person-listing.tsx
+++ b/src/shared/components/person/person-listing.tsx
@@ -24,64 +24,47 @@ export class PersonListing extends Component<PersonListingProps, any> {
   }
 
   render() {
-    const person = this.props.person;
+    const { person, useApubName } = this.props;
     const local = person.local;
-    let apubName: string, link: string;
+    let link: string;
+    let serverStr: string | undefined = undefined;
+
+    const name = useApubName ? person.name : person.display_name ?? person.name;
 
     if (local) {
-      apubName = `@${person.name}`;
       link = `/u/${person.name}`;
     } else {
-      const domain = hostname(person.actor_id);
-      apubName = `@${person.name}@${domain}`;
+      serverStr = `@${hostname(person.actor_id)}`;
       link = !this.props.realLink
-        ? `/u/${person.name}@${domain}`
+        ? `/u/${person.name}${serverStr}`
         : person.actor_id;
     }
 
-    let displayName = this.props.useApubName
-      ? apubName
-      : person.display_name ?? apubName;
-
-    if (this.props.showApubName && !local && person.display_name) {
-      displayName = `${displayName} (${apubName})`;
-    }
-
+    const classes = classNames(
+      "person-listing d-inline-flex align-items-baseline",
+      {
+        "text-muted": this.props.muted,
+        "text-info": !this.props.muted,
+      },
+    );
     return (
       <>
         {!this.props.realLink ? (
-          <Link
-            title={apubName}
-            className={classNames(
-              "person-listing d-inline-flex align-items-baseline",
-              {
-                "text-muted": this.props.muted,
-                "text-info": !this.props.muted,
-              },
-            )}
-            to={link}
-          >
-            {this.avatarAndName(displayName)}
+          <Link title={name} className={classes} to={link}>
+            {this.avatarAndName(name, serverStr)}
           </Link>
         ) : (
-          <a
-            title={apubName}
-            className={`person-listing d-inline-flex align-items-baseline ${
-              this.props.muted ? "text-muted" : "text-info"
-            }`}
-            href={link}
-            rel={relTags}
-          >
-            {this.avatarAndName(displayName)}
+          <a title={name} className={classes} href={link} rel={relTags}>
+            {this.avatarAndName(name, serverStr)}
           </a>
         )}
 
-        {isCakeDay(person.published) && <CakeDay creatorName={apubName} />}
+        {isCakeDay(person.published) && <CakeDay creatorName={name} />}
       </>
     );
   }
 
-  avatarAndName(displayName: string) {
+  avatarAndName(name: string, serverStr?: string) {
     const avatar = this.props.person.avatar;
     return (
       <>
@@ -93,7 +76,10 @@ export class PersonListing extends Component<PersonListingProps, any> {
               icon
             />
           )}
-        <span>{displayName}</span>
+        <span>{name}</span>
+        {serverStr !== undefined && (
+          <small className="text-muted">{serverStr}</small>
+        )}
       </>
     );
   }

--- a/src/shared/components/person/person-listing.tsx
+++ b/src/shared/components/person/person-listing.tsx
@@ -77,9 +77,7 @@ export class PersonListing extends Component<PersonListingProps, any> {
             />
           )}
         <span>{name}</span>
-        {serverStr !== undefined && (
-          <small className="text-muted">{serverStr}</small>
-        )}
+        {serverStr && <small className="text-muted">{serverStr}</small>}
       </>
     );
   }


### PR DESCRIPTION
## Description

Everyone seems to like this one from jerboa anyway, so I'll add it here.

When its a non-local instance, always show the instance, but make it smaller and muted.

## Screenshots

### Before

Didn't show instance name if a display name was set

### After

Always shows it (for non-local)

(ignore the localhost string, that's just for testing)

![Screenshot_20240415_224838_Fulguris_1](https://github.com/LemmyNet/lemmy-ui/assets/930215/4c69c95d-de2b-432d-aded-3dd0a1d7d4d3)

