### PR TITLE
Prevent videos and embeds from showing if adult consent not accepted

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -204,6 +204,10 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const { post } = this.postView;
     const { url } = post;
 
+    if (this.isoData.showAdultConsentModal) {
+      return <></>;
+    }
+
     if (this.imageSrc) {
       return (
         <>


### PR DESCRIPTION
Forgot to prevent videos and embeds from showing when I did the original adult consent modal PR.