### PR TITLE
Hiding RSS button for saved view on profile page. Fixes #2438

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
       "sortpack"
     ]
   },
-  "packageManager": "pnpm@9.0.5+sha256.61bd66913b52012107ec25a6ee4d6a161021ab99e04f6acee3aa50d0e34b4af9",
+  "packageManager": "pnpm@9.0.6+sha256.0624e30eff866cdeb363b15061bdb7fd9425b17bc1bb42c22f5f4efdea21f6b3",
   "engineStrict": true,
   "importSort": {
     ".js, .jsx, .ts, .tsx": {

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -506,7 +506,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
   }
 
   get selects() {
-    const { sort } = this.props;
+    const { sort, view } = this.props;
     const { username } = this.props.match.params;
 
     const profileRss = `/feeds/u/${username}.xml${getQueryString({ sort })}`;
@@ -522,12 +522,19 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
             hideMostComments
           />
         </div>
-        <div className="col-auto">
-          <a href={profileRss} rel={relTags} title="RSS">
-            <Icon icon="rss" classes="text-muted small ps-0" />
-          </a>
-          <link rel="alternate" type="application/atom+xml" href={profileRss} />
-        </div>
+        {/* Don't show the rss feed for the Saved view, as that's not implemented.*/}
+        {view !== PersonDetailsView.Saved && (
+          <div className="col-auto">
+            <a href={profileRss} rel={relTags} title="RSS">
+              <Icon icon="rss" classes="text-muted small ps-0" />
+            </a>
+            <link
+              rel="alternate"
+              type="application/atom+xml"
+              href={profileRss}
+            />
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Description

Hides the RSS button when viewing the `saved` view on profiles.