### PR TITLE
Prevent onBlur from appending URL scheme to URLs

### DIFF
--- a/src/shared/components/common/url-list-textarea.tsx
+++ b/src/shared/components/common/url-list-textarea.tsx
@@ -14,6 +14,12 @@ function handleTextChange(i: UrlListTextarea, event: any) {
   i.setState({ text: event.target.value });
 }
 
+const URL_SCHEME = "https://";
+
+function processUrl(str: string) {
+  return new URL(str).toString().replace(URL_SCHEME, "");
+}
+
 function handleTextBlur(i: UrlListTextarea, event: any) {
   const inputValue: string = event.currentTarget?.value ?? "";
 
@@ -24,10 +30,10 @@ function handleTextBlur(i: UrlListTextarea, event: any) {
     let url: string;
 
     try {
-      url = new URL(str).toString();
+      url = processUrl(str);
     } catch {
       try {
-        url = new URL("https://" + str).toString();
+        url = processUrl(URL_SCHEME + str);
       } catch {
         continue;
       }


### PR DESCRIPTION
Since the blocked URLs no longer include the scheme, I no longer stick the scheme on the front.