### PR TITLE
Show same cake day date independent of timezone

### DIFF
--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -24,7 +24,7 @@ import { canMod } from "@utils/roles";
 import type { QueryParams } from "@utils/types";
 import { RouteDataResponse } from "@utils/types";
 import classNames from "classnames";
-import { format, parseISO } from "date-fns";
+import { format } from "date-fns";
 import { NoOptionI18nKeys } from "i18next";
 import { Component, linkEvent } from "inferno";
 import { Link } from "inferno-router";
@@ -99,6 +99,7 @@ import { PersonListing } from "./person-listing";
 import { getHttpBaseInternal } from "../../utils/env";
 import { IRoutePropsWithFetch } from "../../routes";
 import { MediaUploads } from "../common/media-uploads";
+import { cakeDate } from "@utils/helpers";
 
 type ProfileData = RouteDataResponse<{
   personRes: GetPersonDetailsResponse;
@@ -695,7 +696,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
                 <Icon icon="cake" />
                 <span className="ms-2">
                   {I18NextService.i18n.t("cake_day_title")}{" "}
-                  {format(parseISO(pv.person.published), "PPP")}
+                  {format(cakeDate(pv.person.published), "PPP")}
                 </span>
               </div>
               {!UserService.Instance.myUserInfo && (

--- a/src/shared/utils/helpers/index.ts
+++ b/src/shared/utils/helpers/index.ts
@@ -13,7 +13,7 @@ import getUnixTime from "./get-unix-time";
 import { groupBy } from "./group-by";
 import hostname from "./hostname";
 import hsl from "./hsl";
-import isCakeDay from "./is-cake-day";
+import isCakeDay, { cakeDate } from "./is-cake-day";
 import numToSI from "./num-to-si";
 import poll from "./poll";
 import randomStr from "./random-str";
@@ -27,6 +27,7 @@ import dedupByProperty from "./dedup-by-property";
 import getApubName from "./apub-name";
 
 export {
+  cakeDate,
   capitalizeFirstLetter,
   debounce,
   editListImmutable,

--- a/src/shared/utils/helpers/is-cake-day.ts
+++ b/src/shared/utils/helpers/is-cake-day.ts
@@ -6,9 +6,9 @@ export function cakeDate(published: string): Date {
   return parse(published.substring(0, 10), "yyyy-MM-dd", new Date(0));
 }
 
-export default function isCakeDay(published: string, current?: Date): boolean {
+export default function isCakeDay(published: string): boolean {
   const createDate = cakeDate(published);
-  const currentDate = current ?? new Date();
+  const currentDate = new Date();
 
   // The day-overflow of Date makes leap days become 03-01 in non leap years.
   return (
@@ -16,63 +16,3 @@ export default function isCakeDay(published: string, current?: Date): boolean {
     !isSameYear(currentDate, createDate)
   );
 }
-
-/*
-import { format } from "date-fns";
-// Note: Systems with UTC+0 can pass these even when they shouldn't.
-console.assert(
-  isCakeDay("2023-05-11T00:00:00.000Z", new Date(2024, 4, 11)),
-  "basic, early",
-);
-console.assert(
-  isCakeDay("2023-05-11T23:59:00.000Z", new Date(2024, 4, 11)),
-  "basic, late",
-);
-
-console.assert(
-  !isCakeDay("2024-05-11T00:00:00.000Z", new Date(2024, 4, 11)),
-  "not today, early",
-);
-console.assert(
-  !isCakeDay("2024-05-11T23:59:00.000Z", new Date(2024, 4, 11)),
-  "not today, late",
-);
-
-console.assert(
-  isCakeDay("2020-02-29T00:00:00.000Z", new Date(2024, 1, 29)),
-  "leap day, leap year",
-);
-console.assert(
-  isCakeDay("2020-02-29T00:00:00.000Z", new Date(2025, 2, 1)),
-  "leap day, non leap year",
-);
-
-console.assert(
-  isCakeDay("2023-03-01T00:00:00.000Z", new Date(2024, 2, 1)),
-  "first of march, leap year",
-);
-console.assert(
-  isCakeDay("2023-03-01T00:00:00.000Z", new Date(2024, 2, 1)),
-  "first of march, non leap year",
-);
-
-console.assert(
-  isCakeDay("2020-03-01T00:00:00.000Z", new Date(2024, 2, 1)),
-  "first of march leap year, leap year",
-);
-console.assert(
-  isCakeDay("2020-03-01T00:00:00.000Z", new Date(2024, 2, 1)),
-  "first of march leap year, non leap year",
-);
-
-// This is how profile.tsx displays the date.
-console.assert(
-  format(cakeDate("2023-05-11T00:00:00.000Z"), "PPP") ===
-    format(cakeDate("2023-05-11T23:59:00.000Z"), "PPP"),
-);
-// This one depends on locales.
-// console.assert(
-//   format(cakeDate("2023-05-11T23:59:00.000Z"), "PPP") === "May 11th, 2023",
-//   format(cakeDate("2023-05-11T23:59:00.000Z"), "PPP"),
-// );
-*/

--- a/src/shared/utils/helpers/is-cake-day.ts
+++ b/src/shared/utils/helpers/is-cake-day.ts
@@ -1,34 +1,78 @@
-import { parseISO, getYear, getDayOfYear, isLeapYear } from "date-fns";
+import { getYear, isSameDay, isSameYear, parse, setYear } from "date-fns";
 
-const leapDay = getDayOfYear(new Date(2024, 1, 29));
+// Returns a date in local time with the same year, month and day. Ignores the
+// source timezone. The goal is to show the same date in all timezones.
+export function cakeDate(published: string): Date {
+  return parse(published.substring(0, 10), "yyyy-MM-dd", new Date(0));
+}
 
-export default function isCakeDay(published: string): boolean {
-  const createDate = parseISO(published);
-  const createDateDayOfYear = getDayOfYear(createDate);
-  const isCreateDateLeapYear = isLeapYear(createDate);
+export default function isCakeDay(published: string, current?: Date): boolean {
+  const createDate = cakeDate(published);
+  const currentDate = current ?? new Date();
 
-  const currentDate = new Date();
-  let currentDateDayOfYear = getDayOfYear(currentDate);
-  const isCurrentDateLeapYear = isLeapYear(currentDate);
-
-  if (
-    isCreateDateLeapYear &&
-    !isCurrentDateLeapYear &&
-    currentDateDayOfYear >= leapDay
-  ) {
-    ++currentDateDayOfYear;
-  }
-
-  if (
-    !isCreateDateLeapYear &&
-    isCurrentDateLeapYear &&
-    createDateDayOfYear >= leapDay
-  ) {
-    --currentDateDayOfYear;
-  }
-
+  // The day-overflow of Date makes leap days become 03-01 in non leap years.
   return (
-    createDateDayOfYear === currentDateDayOfYear &&
-    getYear(createDate) !== getYear(currentDate)
+    isSameDay(currentDate, setYear(createDate, getYear(currentDate))) &&
+    !isSameYear(currentDate, createDate)
   );
 }
+
+/*
+import { format } from "date-fns";
+// Note: Systems with UTC+0 can pass these even when they shouldn't.
+console.assert(
+  isCakeDay("2023-05-11T00:00:00.000Z", new Date(2024, 4, 11)),
+  "basic, early",
+);
+console.assert(
+  isCakeDay("2023-05-11T23:59:00.000Z", new Date(2024, 4, 11)),
+  "basic, late",
+);
+
+console.assert(
+  !isCakeDay("2024-05-11T00:00:00.000Z", new Date(2024, 4, 11)),
+  "not today, early",
+);
+console.assert(
+  !isCakeDay("2024-05-11T23:59:00.000Z", new Date(2024, 4, 11)),
+  "not today, late",
+);
+
+console.assert(
+  isCakeDay("2020-02-29T00:00:00.000Z", new Date(2024, 1, 29)),
+  "leap day, leap year",
+);
+console.assert(
+  isCakeDay("2020-02-29T00:00:00.000Z", new Date(2025, 2, 1)),
+  "leap day, non leap year",
+);
+
+console.assert(
+  isCakeDay("2023-03-01T00:00:00.000Z", new Date(2024, 2, 1)),
+  "first of march, leap year",
+);
+console.assert(
+  isCakeDay("2023-03-01T00:00:00.000Z", new Date(2024, 2, 1)),
+  "first of march, non leap year",
+);
+
+console.assert(
+  isCakeDay("2020-03-01T00:00:00.000Z", new Date(2024, 2, 1)),
+  "first of march leap year, leap year",
+);
+console.assert(
+  isCakeDay("2020-03-01T00:00:00.000Z", new Date(2024, 2, 1)),
+  "first of march leap year, non leap year",
+);
+
+// This is how profile.tsx displays the date.
+console.assert(
+  format(cakeDate("2023-05-11T00:00:00.000Z"), "PPP") ===
+    format(cakeDate("2023-05-11T23:59:00.000Z"), "PPP"),
+);
+// This one depends on locales.
+// console.assert(
+//   format(cakeDate("2023-05-11T23:59:00.000Z"), "PPP") === "May 11th, 2023",
+//   format(cakeDate("2023-05-11T23:59:00.000Z"), "PPP"),
+// );
+*/


### PR DESCRIPTION
## Description

Profile displays the UTC+0 date to all users. This alters the effective cake day for some users, but prevents users in different timezones from seeing different dates. It also keeps showing the same date after switching timezones.

The tooltip for "Joined X months ago" still shows the localized exact time and date, which can be a different day than displayed below as "Cake day:".
