### PR TITLE
Render more while reloading only some resources

### DIFF
--- a/src/shared/components/app/app.tsx
+++ b/src/shared/components/app/app.tsx
@@ -32,6 +32,54 @@ export default class App extends Component<any, any> {
     destroyTippy();
   }
 
+  routes = routes.map(
+    ({ path, component: RouteComponent, fetchInitialData, getQueryParams }) => (
+      <Route
+        key={path}
+        path={path}
+        exact
+        component={routeProps => {
+          if (!fetchInitialData) {
+            FirstLoadService.falsify();
+          }
+
+          let queryProps = routeProps;
+          if (getQueryParams && this.isoData.site_res) {
+            // ErrorGuard will not render its children when
+            // site_res is missing, this guarantees that props
+            // will always contain the query params.
+            queryProps = {
+              ...routeProps,
+              ...getQueryParams(
+                routeProps.location.search,
+                this.isoData.site_res,
+              ),
+            };
+          }
+
+          return (
+            <ErrorGuard>
+              <div tabIndex={-1}>
+                {RouteComponent &&
+                  (isAuthPath(path ?? "") ? (
+                    <AuthGuard {...routeProps}>
+                      <RouteComponent {...queryProps} />
+                    </AuthGuard>
+                  ) : isAnonymousPath(path ?? "") ? (
+                    <AnonymousGuard>
+                      <RouteComponent {...queryProps} />
+                    </AnonymousGuard>
+                  ) : (
+                    <RouteComponent {...queryProps} />
+                  ))}
+              </div>
+            </ErrorGuard>
+          );
+        }}
+      />
+    ),
+  );
+
   render() {
     const siteRes = this.isoData.site_res;
     const siteView = siteRes?.site_view;
@@ -64,58 +112,7 @@ export default class App extends Component<any, any> {
             <Navbar siteRes={siteRes} />
             <div className="mt-4 p-0 fl-1">
               <Switch>
-                {routes.map(
-                  ({
-                    path,
-                    component: RouteComponent,
-                    fetchInitialData,
-                    getQueryParams,
-                  }) => (
-                    <Route
-                      key={path}
-                      path={path}
-                      exact
-                      component={routeProps => {
-                        if (!fetchInitialData) {
-                          FirstLoadService.falsify();
-                        }
-
-                        let queryProps = routeProps;
-                        if (getQueryParams && this.isoData.site_res) {
-                          // ErrorGuard will not render its children when
-                          // site_res is missing, this guarantees that props
-                          // will always contain the query params.
-                          queryProps = {
-                            ...routeProps,
-                            ...getQueryParams(
-                              routeProps.location.search,
-                              this.isoData.site_res,
-                            ),
-                          };
-                        }
-
-                        return (
-                          <ErrorGuard>
-                            <div tabIndex={-1}>
-                              {RouteComponent &&
-                                (isAuthPath(path ?? "") ? (
-                                  <AuthGuard {...routeProps}>
-                                    <RouteComponent {...queryProps} />
-                                  </AuthGuard>
-                                ) : isAnonymousPath(path ?? "") ? (
-                                  <AnonymousGuard>
-                                    <RouteComponent {...queryProps} />
-                                  </AnonymousGuard>
-                                ) : (
-                                  <RouteComponent {...queryProps} />
-                                ))}
-                            </div>
-                          </ErrorGuard>
-                        );
-                      }}
-                    />
-                  ),
-                )}
+                {this.routes}
                 <Route component={ErrorPage} />
               </Switch>
             </div>

--- a/src/shared/components/app/app.tsx
+++ b/src/shared/components/app/app.tsx
@@ -33,7 +33,13 @@ export default class App extends Component<any, any> {
   }
 
   routes = routes.map(
-    ({ path, component: RouteComponent, fetchInitialData, getQueryParams }) => (
+    ({
+      path,
+      component: RouteComponent,
+      fetchInitialData,
+      getQueryParams,
+      mountedSameRouteNavKey,
+    }) => (
       <Route
         key={path}
         path={path}
@@ -57,20 +63,24 @@ export default class App extends Component<any, any> {
             };
           }
 
+          // When key is location.key the component will be recreated when
+          // navigating to itself. This is usesful to e.g. reset forms.
+          const key = mountedSameRouteNavKey ?? routeProps.location.key;
+
           return (
             <ErrorGuard>
               <div tabIndex={-1}>
                 {RouteComponent &&
                   (isAuthPath(path ?? "") ? (
                     <AuthGuard {...routeProps}>
-                      <RouteComponent {...queryProps} />
+                      <RouteComponent key={key} {...queryProps} />
                     </AuthGuard>
                   ) : isAnonymousPath(path ?? "") ? (
                     <AnonymousGuard>
-                      <RouteComponent {...queryProps} />
+                      <RouteComponent key={key} {...queryProps} />
                     </AnonymousGuard>
                   ) : (
-                    <RouteComponent {...queryProps} />
+                    <RouteComponent key={key} {...queryProps} />
                   ))}
               </div>
             </ErrorGuard>

--- a/src/shared/components/app/navbar.tsx
+++ b/src/shared/components/app/navbar.tsx
@@ -63,7 +63,7 @@ export class Navbar extends Component<NavbarProps, NavbarState> {
     this.handleOutsideMenuClick = this.handleOutsideMenuClick.bind(this);
   }
 
-  async componentDidMount() {
+  async componentWillMount() {
     // Subscribe to jwt changes
     if (isBrowser()) {
       // On the first load, check the unreads

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -502,7 +502,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
       <>
         <Link
           className={classnames}
-          to={`/comment/${
+          to={`/post/${cv.post.id}/${
             (this.props.showContext && getCommentParentId(cv.comment)) ||
             cv.comment.id
           }`}

--- a/src/shared/components/common/anonymous-guard.tsx
+++ b/src/shared/components/common/anonymous-guard.tsx
@@ -1,6 +1,7 @@
 import { Component } from "inferno";
 import { UserService } from "../../services";
 import { Spinner } from "./icon";
+import { isBrowser } from "@utils/browser";
 
 class AnonymousGuard extends Component<any, any> {
   constructor(props: any, context: any) {
@@ -11,8 +12,8 @@ class AnonymousGuard extends Component<any, any> {
     return UserService.Instance.myUserInfo;
   }
 
-  componentDidMount() {
-    if (this.hasAuth()) {
+  componentWillMount() {
+    if (this.hasAuth() && isBrowser()) {
       this.context.router.history.replace(`/`);
     }
   }

--- a/src/shared/components/common/anonymous-guard.tsx
+++ b/src/shared/components/common/anonymous-guard.tsx
@@ -2,29 +2,23 @@ import { Component } from "inferno";
 import { UserService } from "../../services";
 import { Spinner } from "./icon";
 
-interface AnonymousGuardState {
-  hasRedirected: boolean;
-}
-
-class AnonymousGuard extends Component<any, AnonymousGuardState> {
-  state = {
-    hasRedirected: false,
-  } as AnonymousGuardState;
-
+class AnonymousGuard extends Component<any, any> {
   constructor(props: any, context: any) {
     super(props, context);
   }
 
+  hasAuth() {
+    return UserService.Instance.myUserInfo;
+  }
+
   componentDidMount() {
-    if (UserService.Instance.myUserInfo) {
+    if (this.hasAuth()) {
       this.context.router.history.replace(`/`);
-    } else {
-      this.setState({ hasRedirected: true });
     }
   }
 
   render() {
-    return this.state.hasRedirected ? this.props.children : <Spinner />;
+    return !this.hasAuth() ? this.props.children : <Spinner />;
   }
 }
 

--- a/src/shared/components/common/auth-guard.tsx
+++ b/src/shared/components/common/auth-guard.tsx
@@ -4,18 +4,10 @@ import { UserService } from "../../services";
 import { Spinner } from "./icon";
 import { getQueryString } from "@utils/helpers";
 
-interface AuthGuardState {
-  hasRedirected: boolean;
-}
-
 class AuthGuard extends Component<
   RouteComponentProps<Record<string, string>>,
-  AuthGuardState
+  any
 > {
-  state = {
-    hasRedirected: false,
-  } as AuthGuardState;
-
   constructor(
     props: RouteComponentProps<Record<string, string>>,
     context: any,
@@ -23,19 +15,21 @@ class AuthGuard extends Component<
     super(props, context);
   }
 
+  hasAuth() {
+    return UserService.Instance.myUserInfo;
+  }
+
   componentDidMount() {
-    if (!UserService.Instance.myUserInfo) {
+    if (!this.hasAuth()) {
       const { pathname, search } = this.props.location;
       this.context.router.history.replace(
         `/login${getQueryString({ prev: pathname + search })}`,
       );
-    } else {
-      this.setState({ hasRedirected: true });
     }
   }
 
   render() {
-    return this.state.hasRedirected ? this.props.children : <Spinner />;
+    return this.hasAuth() ? this.props.children : <Spinner />;
   }
 }
 

--- a/src/shared/components/common/auth-guard.tsx
+++ b/src/shared/components/common/auth-guard.tsx
@@ -3,6 +3,7 @@ import { RouteComponentProps } from "inferno-router/dist/Route";
 import { UserService } from "../../services";
 import { Spinner } from "./icon";
 import { getQueryString } from "@utils/helpers";
+import { isBrowser } from "@utils/browser";
 
 class AuthGuard extends Component<
   RouteComponentProps<Record<string, string>>,
@@ -19,8 +20,8 @@ class AuthGuard extends Component<
     return UserService.Instance.myUserInfo;
   }
 
-  componentDidMount() {
-    if (!this.hasAuth()) {
+  componentWillMount() {
+    if (!this.hasAuth() && isBrowser()) {
       const { pathname, search } = this.props.location;
       this.context.router.history.replace(
         `/login${getQueryString({ prev: pathname + search })}`,

--- a/src/shared/components/common/content-actions/content-action-dropdown.tsx
+++ b/src/shared/components/common/content-actions/content-action-dropdown.tsx
@@ -643,7 +643,6 @@ export default class ContentActionDropdown extends Component<
       type,
     } = this.props;
 
-    // Wait until componentDidMount runs (which only happens on the browser) to prevent sending over a gratuitous amount of markup
     return (
       <>
         {renderRemoveDialog && (

--- a/src/shared/components/common/loading-ellipses.tsx
+++ b/src/shared/components/common/loading-ellipses.tsx
@@ -15,11 +15,7 @@ export class LoadingEllipses extends Component<any, LoadingEllipsesState> {
   }
 
   render() {
-    return (
-      this.state.ellipses || (
-        <span dangerouslySetInnerHTML={{ __html: "&nbsp;" }} />
-      )
-    );
+    return this.state.ellipses;
   }
 
   componentDidMount() {

--- a/src/shared/components/common/loading-ellipses.tsx
+++ b/src/shared/components/common/loading-ellipses.tsx
@@ -15,7 +15,11 @@ export class LoadingEllipses extends Component<any, LoadingEllipsesState> {
   }
 
   render() {
-    return this.state.ellipses;
+    return (
+      this.state.ellipses || (
+        <span dangerouslySetInnerHTML={{ __html: "&nbsp;" }} />
+      )
+    );
   }
 
   componentDidMount() {

--- a/src/shared/components/common/searchable-select.tsx
+++ b/src/shared/components/common/searchable-select.tsx
@@ -39,7 +39,7 @@ function handleSearch(i: SearchableSelect, e: ChangeEvent<HTMLInputElement>) {
 }
 
 function focusSearch(i: SearchableSelect) {
-  if (i.toggleButtonRef.current?.ariaExpanded !== "true") {
+  if (i.toggleButtonRef.current?.ariaExpanded === "true") {
     i.searchInputRef.current?.focus();
 
     if (i.props.onSearch) {

--- a/src/shared/components/common/subscribe-button.tsx
+++ b/src/shared/components/common/subscribe-button.tsx
@@ -1,12 +1,13 @@
 import { getQueryString, validInstanceTLD } from "@utils/helpers";
 import classNames from "classnames";
 import { NoOptionI18nKeys } from "i18next";
-import { Component, MouseEventHandler, linkEvent } from "inferno";
+import { Component, MouseEventHandler, createRef, linkEvent } from "inferno";
 import { CommunityView } from "lemmy-js-client";
 import { I18NextService, UserService } from "../../services";
 import { VERSION } from "../../version";
 import { Icon, Spinner } from "./icon";
 import { toast } from "../../toast";
+import { modalMixin } from "../mixins/modal-mixin";
 
 interface SubscribeButtonProps {
   communityView: CommunityView;
@@ -64,7 +65,7 @@ export function SubscribeButton({
         >
           {I18NextService.i18n.t("subscribe")}
         </button>
-        <RemoteFetchModal communityActorId={actor_id} />
+        <RemoteFetchModal show={false} communityActorId={actor_id} />
       </>
     );
   }
@@ -93,6 +94,7 @@ export function SubscribeButton({
 
 interface RemoteFetchModalProps {
   communityActorId: string;
+  show: boolean;
 }
 
 interface RemoteFetchModalState {
@@ -101,10 +103,6 @@ interface RemoteFetchModalState {
 
 function handleInput(i: RemoteFetchModal, event: any) {
   i.setState({ instanceText: event.target.value });
-}
-
-function focusInput() {
-  document.getElementById("remoteFetchInstance")?.focus();
 }
 
 function submitRemoteFollow(
@@ -139,6 +137,7 @@ function submitRemoteFollow(
   )}`;
 }
 
+@modalMixin
 class RemoteFetchModal extends Component<
   RemoteFetchModalProps,
   RemoteFetchModalState
@@ -147,20 +146,15 @@ class RemoteFetchModal extends Component<
     instanceText: "",
   };
 
+  modalDivRef = createRef<HTMLDivElement>();
+  inputRef = createRef<HTMLInputElement>();
+
   constructor(props: any, context: any) {
     super(props, context);
   }
 
-  componentDidMount() {
-    document
-      .getElementById("remoteFetchModal")
-      ?.addEventListener("shown.bs.modal", focusInput);
-  }
-
-  componentWillUnmount(): void {
-    document
-      .getElementById("remoteFetchModal")
-      ?.removeEventListener("shown.bs.modal", focusInput);
+  handleShow() {
+    this.inputRef.current?.focus();
   }
 
   render() {
@@ -171,6 +165,7 @@ class RemoteFetchModal extends Component<
         tabIndex={-1}
         aria-hidden
         aria-labelledby="#remoteFetchModalTitle"
+        ref={this.modalDivRef}
       >
         <div className="modal-dialog modal-dialog-centered modal-fullscreen-sm-down">
           <div className="modal-content">
@@ -203,6 +198,7 @@ class RemoteFetchModal extends Component<
                 required
                 enterKeyHint="go"
                 inputMode="url"
+                ref={this.inputRef}
               />
             </form>
             <footer className="modal-footer">

--- a/src/shared/components/common/subscribe-button.tsx
+++ b/src/shared/components/common/subscribe-button.tsx
@@ -65,7 +65,7 @@ export function SubscribeButton({
         >
           {I18NextService.i18n.t("subscribe")}
         </button>
-        <RemoteFetchModal show={false} communityActorId={actor_id} />
+        <RemoteFetchModal communityActorId={actor_id} />
       </>
     );
   }
@@ -94,7 +94,7 @@ export function SubscribeButton({
 
 interface RemoteFetchModalProps {
   communityActorId: string;
-  show: boolean;
+  show?: boolean;
 }
 
 interface RemoteFetchModalState {

--- a/src/shared/components/common/view-votes-modal.tsx
+++ b/src/shared/components/common/view-votes-modal.tsx
@@ -24,6 +24,7 @@ import { fetchLimit } from "../../config";
 import { PersonListing } from "../person/person-listing";
 import { modalMixin } from "../mixins/modal-mixin";
 import { UserBadges } from "./user-badges";
+import { isBrowser } from "@utils/browser";
 
 interface ViewVotesModalProps {
   children?: InfernoNode;
@@ -96,8 +97,8 @@ export default class ViewVotesModal extends Component<
     this.handlePageChange = this.handlePageChange.bind(this);
   }
 
-  async componentDidMount() {
-    if (this.props.show) {
+  async componentWillMount() {
+    if (this.props.show && isBrowser()) {
       await this.refetch();
     }
   }

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -40,6 +40,7 @@ import { getHttpBaseInternal } from "../../utils/env";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../../routes";
 import { scrollMixin } from "../mixins/scroll-mixin";
+import { isBrowser } from "@utils/browser";
 
 type CommunitiesData = RouteDataResponse<{
   listCommunitiesResponse: ListCommunitiesResponse;
@@ -121,8 +122,8 @@ export class Communities extends Component<
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       await this.refetch();
     }
   }

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -124,8 +124,12 @@ export class Communities extends Component<
 
   async componentWillMount() {
     if (!this.state.isIsomorphic && isBrowser()) {
-      await this.refetch();
+      await this.refetch(this.props);
     }
+  }
+
+  componentWillReceiveProps(nextProps: CommunitiesRouteProps) {
+    this.refetch(nextProps);
   }
 
   get documentTitle(): string {
@@ -288,22 +292,16 @@ export class Communities extends Component<
     );
   }
 
-  async updateUrl({ listingType, sort, page }: Partial<CommunitiesProps>) {
-    const {
-      listingType: urlListingType,
-      sort: urlSort,
-      page: urlPage,
-    } = this.props;
+  async updateUrl(props: Partial<CommunitiesProps>) {
+    const { listingType, sort, page } = { ...this.props, ...props };
 
     const queryParams: QueryParams<CommunitiesProps> = {
-      listingType: listingType ?? urlListingType,
-      sort: sort ?? urlSort,
-      page: (page ?? urlPage)?.toString(),
+      listingType: listingType,
+      sort: sort,
+      page: page?.toString(),
     };
 
     this.props.history.push(`/communities${getQueryString(queryParams)}`);
-
-    await this.refetch();
   }
 
   handlePageChange(page: number) {
@@ -369,10 +367,8 @@ export class Communities extends Component<
     data.i.findAndUpdateCommunity(res);
   }
 
-  async refetch() {
+  async refetch({ listingType, sort, page }: CommunitiesProps) {
     this.setState({ listCommunitiesResponse: LOADING_REQUEST });
-
-    const { listingType, sort, page } = this.props;
 
     this.setState({
       listCommunitiesResponse: await HttpService.client.listCommunities({

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -138,7 +138,7 @@ export class Communities extends Component<
     }`;
   }
 
-  renderListings() {
+  renderListingsTable() {
     switch (this.state.listCommunitiesResponse.state) {
       case "loading":
         return (
@@ -147,28 +147,7 @@ export class Communities extends Component<
           </h5>
         );
       case "success": {
-        const { listingType, sort, page } = this.props;
         return (
-          <div>
-            <h1 className="h4 mb-4">
-              {I18NextService.i18n.t("list_of_communities")}
-            </h1>
-            <div className="row g-3 align-items-center mb-2">
-              <div className="col-auto">
-                <ListingTypeSelect
-                  type_={listingType}
-                  showLocal={showLocal(this.isoData)}
-                  showSubscribed
-                  onChange={this.handleListingTypeChange}
-                />
-              </div>
-              <div className="col-auto me-auto">
-                <SortSelect sort={sort} onChange={this.handleSortChange} />
-              </div>
-              <div className="col-auto">{this.searchForm()}</div>
-            </div>
-
-            <div className="table-responsive">
               <table
                 id="community_table"
                 className="table table-sm table-hover"
@@ -238,29 +217,49 @@ export class Communities extends Component<
                   )}
                 </tbody>
               </table>
-            </div>
-            <Paginator
-              page={page}
-              onChange={this.handlePageChange}
-              nextDisabled={
-                communityLimit >
-                this.state.listCommunitiesResponse.data.communities.length
-              }
-            />
-          </div>
         );
       }
     }
   }
 
   render() {
+    const { listingType, sort, page } = this.props;
     return (
       <div className="communities container-lg">
         <HtmlTags
           title={this.documentTitle}
           path={this.context.router.route.match.url}
         />
-        {this.renderListings()}
+        <div>
+          <h1 className="h4 mb-4">
+            {I18NextService.i18n.t("list_of_communities")}
+          </h1>
+          <div className="row g-3 align-items-center mb-2">
+            <div className="col-auto">
+              <ListingTypeSelect
+                type_={listingType}
+                showLocal={showLocal(this.isoData)}
+                showSubscribed
+                onChange={this.handleListingTypeChange}
+              />
+            </div>
+            <div className="col-auto me-auto">
+              <SortSelect sort={sort} onChange={this.handleSortChange} />
+            </div>
+            <div className="col-auto">{this.searchForm()}</div>
+          </div>
+
+          <div className="table-responsive">{this.renderListingsTable()}</div>
+          <Paginator
+            page={page}
+            onChange={this.handlePageChange}
+            nextDisabled={
+              this.state.listCommunitiesResponse.state !== "success" ||
+              communityLimit >
+                this.state.listCommunitiesResponse.data.communities.length
+            }
+          />
+        </div>
       </div>
     );
   }

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -148,75 +148,70 @@ export class Communities extends Component<
         );
       case "success": {
         return (
-              <table
-                id="community_table"
-                className="table table-sm table-hover"
-              >
-                <thead className="pointer">
-                  <tr>
-                    <th>{I18NextService.i18n.t("name")}</th>
-                    <th className="text-right">
-                      {I18NextService.i18n.t("subscribers")}
-                    </th>
-                    <th className="text-right">
-                      {I18NextService.i18n.t("users")} /{" "}
-                      {I18NextService.i18n.t("month")}
-                    </th>
-                    <th className="text-right d-none d-lg-table-cell">
-                      {I18NextService.i18n.t("posts")}
-                    </th>
-                    <th className="text-right d-none d-lg-table-cell">
-                      {I18NextService.i18n.t("comments")}
-                    </th>
-                    <th></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {this.state.listCommunitiesResponse.data.communities.map(
-                    cv => (
-                      <tr key={cv.community.id}>
-                        <td>
-                          <CommunityLink community={cv.community} />
-                        </td>
-                        <td className="text-right">
-                          {numToSI(cv.counts.subscribers)}
-                        </td>
-                        <td className="text-right">
-                          {numToSI(cv.counts.users_active_month)}
-                        </td>
-                        <td className="text-right d-none d-lg-table-cell">
-                          {numToSI(cv.counts.posts)}
-                        </td>
-                        <td className="text-right d-none d-lg-table-cell">
-                          {numToSI(cv.counts.comments)}
-                        </td>
-                        <td className="text-right">
-                          <SubscribeButton
-                            communityView={cv}
-                            onFollow={linkEvent(
-                              {
-                                i: this,
-                                communityId: cv.community.id,
-                                follow: true,
-                              },
-                              this.handleFollow,
-                            )}
-                            onUnFollow={linkEvent(
-                              {
-                                i: this,
-                                communityId: cv.community.id,
-                                follow: false,
-                              },
-                              this.handleFollow,
-                            )}
-                            isLink
-                          />
-                        </td>
-                      </tr>
-                    ),
-                  )}
-                </tbody>
-              </table>
+          <table id="community_table" className="table table-sm table-hover">
+            <thead className="pointer">
+              <tr>
+                <th>{I18NextService.i18n.t("name")}</th>
+                <th className="text-right">
+                  {I18NextService.i18n.t("subscribers")}
+                </th>
+                <th className="text-right">
+                  {I18NextService.i18n.t("users")} /{" "}
+                  {I18NextService.i18n.t("month")}
+                </th>
+                <th className="text-right d-none d-lg-table-cell">
+                  {I18NextService.i18n.t("posts")}
+                </th>
+                <th className="text-right d-none d-lg-table-cell">
+                  {I18NextService.i18n.t("comments")}
+                </th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {this.state.listCommunitiesResponse.data.communities.map(cv => (
+                <tr key={cv.community.id}>
+                  <td>
+                    <CommunityLink community={cv.community} />
+                  </td>
+                  <td className="text-right">
+                    {numToSI(cv.counts.subscribers)}
+                  </td>
+                  <td className="text-right">
+                    {numToSI(cv.counts.users_active_month)}
+                  </td>
+                  <td className="text-right d-none d-lg-table-cell">
+                    {numToSI(cv.counts.posts)}
+                  </td>
+                  <td className="text-right d-none d-lg-table-cell">
+                    {numToSI(cv.counts.comments)}
+                  </td>
+                  <td className="text-right">
+                    <SubscribeButton
+                      communityView={cv}
+                      onFollow={linkEvent(
+                        {
+                          i: this,
+                          communityId: cv.community.id,
+                          follow: true,
+                        },
+                        this.handleFollow,
+                      )}
+                      onUnFollow={linkEvent(
+                        {
+                          i: this,
+                          communityId: cv.community.id,
+                          follow: false,
+                        },
+                        this.handleFollow,
+                      )}
+                      isLink
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         );
       }
     }

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -361,17 +361,19 @@ export class Communities extends Component<
     data.i.findAndUpdateCommunity(res);
   }
 
+  fetchToken?: symbol;
   async refetch({ listingType, sort, page }: CommunitiesProps) {
+    const token = (this.fetchToken = Symbol());
     this.setState({ listCommunitiesResponse: LOADING_REQUEST });
-
-    this.setState({
-      listCommunitiesResponse: await HttpService.client.listCommunities({
-        type_: listingType,
-        sort: sort,
-        limit: communityLimit,
-        page,
-      }),
+    const listCommunitiesResponse = await HttpService.client.listCommunities({
+      type_: listingType,
+      sort: sort,
+      limit: communityLimit,
+      page,
     });
+    if (token === this.fetchToken) {
+      this.setState({ listCommunitiesResponse });
+    }
   }
 
   findAndUpdateCommunity(res: RequestState<CommunityResponse>) {

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -274,13 +274,16 @@ export class Community extends Component<CommunityRouteProps, State> {
     }
   }
 
+  fetchCommunityToken?: symbol;
   async fetchCommunity(props: CommunityRouteProps) {
+    const token = (this.fetchCommunityToken = Symbol());
     this.setState({ communityRes: LOADING_REQUEST });
-    this.setState({
-      communityRes: await HttpService.client.getCommunity({
-        name: props.match.params.name,
-      }),
+    const communityRes = await HttpService.client.getCommunity({
+      name: props.match.params.name,
     });
+    if (token === this.fetchCommunityToken) {
+      this.setState({ communityRes });
+    }
   }
 
   async componentWillMount() {
@@ -702,34 +705,38 @@ export class Community extends Component<CommunityRouteProps, State> {
     this.props.history.push(`/c/${name}${getQueryString(queryParams)}`);
   }
 
+  fetchDataToken?: symbol;
   async fetchData(props: CommunityRouteProps) {
+    const token = (this.fetchDataToken = Symbol());
     const { dataType, pageCursor, sort, showHidden } = props;
     const { name } = props.match.params;
 
     if (dataType === DataType.Post) {
       this.setState({ postsRes: LOADING_REQUEST, commentsRes: EMPTY_REQUEST });
-      this.setState({
-        postsRes: await HttpService.client.getPosts({
-          page_cursor: pageCursor,
-          limit: fetchLimit,
-          sort,
-          type_: "All",
-          community_name: name,
-          saved_only: false,
-          show_hidden: showHidden === "true",
-        }),
+      const postsRes = await HttpService.client.getPosts({
+        page_cursor: pageCursor,
+        limit: fetchLimit,
+        sort,
+        type_: "All",
+        community_name: name,
+        saved_only: false,
+        show_hidden: showHidden === "true",
       });
+      if (token === this.fetchDataToken) {
+        this.setState({ postsRes });
+      }
     } else {
       this.setState({ commentsRes: LOADING_REQUEST, postsRes: EMPTY_REQUEST });
-      this.setState({
-        commentsRes: await HttpService.client.getComments({
-          limit: fetchLimit,
-          sort: postToCommentSortType(sort),
-          type_: "All",
-          community_name: name,
-          saved_only: false,
-        }),
+      const commentsRes = await HttpService.client.getComments({
+        limit: fetchLimit,
+        sort: postToCommentSortType(sort),
+        type_: "All",
+        community_name: name,
+        saved_only: false,
       });
+      if (token === this.fetchDataToken) {
+        this.setState({ commentsRes });
+      }
     }
   }
 

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -385,34 +385,32 @@ export class Community extends Component<CommunityRouteProps, State> {
       this.state.communityRes.data;
     return (
       <>
-          {res && (
-            <HtmlTags
-              title={this.documentTitle}
-              path={this.context.router.route.match.url}
-              canonicalPath={res.community_view.community.actor_id}
-              description={res.community_view.community.description}
-              image={res.community_view.community.icon}
-            />
-          )}
+        {res && (
+          <HtmlTags
+            title={this.documentTitle}
+            path={this.context.router.route.match.url}
+            canonicalPath={res.community_view.community.actor_id}
+            description={res.community_view.community.description}
+            image={res.community_view.community.icon}
+          />
+        )}
 
-                {this.communityInfo()}
-                <div className="d-block d-md-none">
-                  <button
-                    className="btn btn-secondary d-inline-block mb-2 me-3"
-                    onClick={linkEvent(this, this.handleShowSidebarMobile)}
-                  >
-                    {I18NextService.i18n.t("sidebar")}{" "}
-                    <Icon
-                      icon={
-                        this.state.showSidebarMobile
-                          ? `minus-square`
-                          : `plus-square`
-                      }
-                      classes="icon-inline"
-                    />
-                  </button>
-                  {this.state.showSidebarMobile && this.sidebar()}
-                </div>
+        {this.communityInfo()}
+        <div className="d-block d-md-none">
+          <button
+            className="btn btn-secondary d-inline-block mb-2 me-3"
+            onClick={linkEvent(this, this.handleShowSidebarMobile)}
+          >
+            {I18NextService.i18n.t("sidebar")}{" "}
+            <Icon
+              icon={
+                this.state.showSidebarMobile ? `minus-square` : `plus-square`
+              }
+              classes="icon-inline"
+            />
+          </button>
+          {this.state.showSidebarMobile && this.sidebar()}
+        </div>
       </>
     );
   }
@@ -569,41 +567,41 @@ export class Community extends Component<CommunityRouteProps, State> {
     const urlCommunityName = this.props.match.params.name;
 
     return (
-        <div className="mb-2">
-          {community && (
-            <BannerIconHeader banner={community.banner} icon={community.icon} />
-          )}
-          <div>
-            <h1
-              className="h4 mb-0 overflow-wrap-anywhere d-inline"
-              data-tippy-content={
-                community?.posting_restricted_to_mods
-                  ? I18NextService.i18n.t("community_locked")
-                  : ""
-              }
-            >
-              {community?.title ?? (
-                <>
-                  {urlCommunityName}
-                  <LoadingEllipses />
-                </>
-              )}
-            </h1>
-            {community?.posting_restricted_to_mods && (
-              <Icon icon="lock" inline classes="text-danger fs-4 ms-2" />
+      <div className="mb-2">
+        {community && (
+          <BannerIconHeader banner={community.banner} icon={community.icon} />
+        )}
+        <div>
+          <h1
+            className="h4 mb-0 overflow-wrap-anywhere d-inline"
+            data-tippy-content={
+              community?.posting_restricted_to_mods
+                ? I18NextService.i18n.t("community_locked")
+                : ""
+            }
+          >
+            {community?.title ?? (
+              <>
+                {urlCommunityName}
+                <LoadingEllipses />
+              </>
             )}
-          </div>
-          {(community && (
-            <CommunityLink
-              community={community}
-              realLink
-              useApubName
-              muted
-              hideAvatar
-            />
-          )) ??
-            urlCommunityName}
+          </h1>
+          {community?.posting_restricted_to_mods && (
+            <Icon icon="lock" inline classes="text-danger fs-4 ms-2" />
+          )}
         </div>
+        {(community && (
+          <CommunityLink
+            community={community}
+            realLink
+            useApubName
+            muted
+            hideAvatar
+          />
+        )) ??
+          urlCommunityName}
+      </div>
     );
   }
 

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -114,6 +114,7 @@ import {
 import { Sidebar } from "./sidebar";
 import { IRoutePropsWithFetch } from "../../routes";
 import PostHiddenSelect from "../common/post-hidden-select";
+import { isBrowser } from "@utils/browser";
 
 type CommunityData = RouteDataResponse<{
   communityRes: GetCommunityResponse;
@@ -274,8 +275,8 @@ export class Community extends Component<CommunityRouteProps, State> {
     });
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       await Promise.all([this.fetchCommunity(), this.fetchData()]);
     }
   }

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -80,6 +80,21 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
     this.handleEditCancel = this.handleEditCancel.bind(this);
   }
 
+  unlisten = () => {};
+
+  componentWillMount() {
+    // Leave edit mode on navigation
+    this.unlisten = this.context.router.history.listen(() => {
+      if (this.state.showEdit) {
+        this.setState({ showEdit: false });
+      }
+    });
+  }
+
+  componentWillUnmount(): void {
+    this.unlisten();
+  }
+
   componentWillReceiveProps(
     nextProps: Readonly<{ children?: InfernoNode } & SidebarProps>,
   ): void {

--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -51,7 +51,6 @@ type AdminSettingsData = RouteDataResponse<{
 interface AdminSettingsState {
   siteRes: GetSiteResponse;
   banned: PersonView[];
-  currentTab: string;
   instancesRes: RequestState<GetFederatedInstancesResponse>;
   bannedRes: RequestState<BannedPersonsResponse>;
   leaveAdminTeamRes: RequestState<GetSiteResponse>;
@@ -79,7 +78,6 @@ export class AdminSettings extends Component<
   state: AdminSettingsState = {
     siteRes: this.isoData.site_res,
     banned: [],
-    currentTab: "site",
     bannedRes: EMPTY_REQUEST,
     instancesRes: EMPTY_REQUEST,
     leaveAdminTeamRes: EMPTY_REQUEST,
@@ -429,10 +427,6 @@ export class AdminSettings extends Component<
     this.setState({ loading: false });
 
     return editRes;
-  }
-
-  handleSwitchTab(i: { ctx: AdminSettings; tab: string }) {
-    i.ctx.setState({ currentTab: i.tab });
   }
 
   async handleLeaveAdminTeam(i: AdminSettings) {

--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -41,6 +41,7 @@ import { IRoutePropsWithFetch } from "../../routes";
 import { MediaUploads } from "../common/media-uploads";
 import { Paginator } from "../common/paginator";
 import { snapToTop } from "@utils/browser";
+import { isBrowser } from "@utils/browser";
 
 type AdminSettingsData = RouteDataResponse<{
   bannedRes: BannedPersonsResponse;
@@ -132,12 +133,14 @@ export class AdminSettings extends Component<
     };
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
-      await this.fetchData();
-    } else {
-      const themeList = await fetchThemeList();
-      this.setState({ themeList });
+  async componentWillMount() {
+    if (isBrowser()) {
+      if (!this.state.isIsomorphic) {
+        await this.fetchData();
+      } else {
+        const themeList = await fetchThemeList();
+        this.setState({ themeList });
+      }
     }
   }
 

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -112,7 +112,7 @@ import {
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../../routes";
 import PostHiddenSelect from "../common/post-hidden-select";
-import { snapToTop } from "@utils/browser";
+import { isBrowser, snapToTop } from "@utils/browser";
 
 interface HomeState {
   postsRes: RequestState<GetPostsResponse>;
@@ -344,12 +344,13 @@ export class Home extends Component<HomeRouteProps, HomeState> {
     )?.content;
   }
 
-  async componentDidMount() {
+  async componentWillMount() {
     if (
-      !this.state.isIsomorphic ||
-      !Object.values(this.isoData.routeData).some(
-        res => res.state === "success" || res.state === "failed",
-      )
+      (!this.state.isIsomorphic ||
+        !Object.values(this.isoData.routeData).some(
+          res => res.state === "success" || res.state === "failed",
+        )) &&
+      isBrowser()
     ) {
       await Promise.all([this.fetchTrendingCommunities(), this.fetchData()]);
     }

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -19,13 +19,14 @@ import {
   getQueryString,
   getRandomFromList,
   resourcesSettled,
+  bareRoutePush,
 } from "@utils/helpers";
 import { scrollMixin } from "../mixins/scroll-mixin";
 import { canCreateCommunity } from "@utils/roles";
 import type { QueryParams, StringBoolean } from "@utils/types";
 import { RouteDataResponse } from "@utils/types";
 import { NoOptionI18nKeys } from "i18next";
-import { Component, MouseEventHandler, linkEvent } from "inferno";
+import { Component, InfernoNode, MouseEventHandler, linkEvent } from "inferno";
 import { T } from "inferno-i18next-dess";
 import { Link } from "inferno-router";
 import {
@@ -352,7 +353,20 @@ export class Home extends Component<HomeRouteProps, HomeState> {
         )) &&
       isBrowser()
     ) {
-      await Promise.all([this.fetchTrendingCommunities(), this.fetchData()]);
+      await Promise.all([
+        this.fetchTrendingCommunities(),
+        this.fetchData(this.props),
+      ]);
+    }
+  }
+
+  componentWillReceiveProps(
+    nextProps: HomeRouteProps & { children?: InfernoNode },
+  ) {
+    this.fetchData(nextProps);
+
+    if (bareRoutePush(this.props, nextProps)) {
+      this.fetchTrendingCommunities();
     }
   }
 
@@ -662,34 +676,23 @@ export class Home extends Component<HomeRouteProps, HomeState> {
     );
   }
 
-  async updateUrl({
-    dataType,
-    listingType,
-    pageCursor,
-    sort,
-    showHidden,
-  }: Partial<HomeProps>) {
-    const {
-      dataType: urlDataType,
-      listingType: urlListingType,
-      sort: urlSort,
-      showHidden: urlShowHidden,
-    } = this.props;
-
+  async updateUrl(props: Partial<HomeProps>) {
+    const { dataType, listingType, pageCursor, sort, showHidden } = {
+      ...this.props,
+      ...props,
+    };
     const queryParams: QueryParams<HomeProps> = {
-      dataType: getDataTypeString(dataType ?? urlDataType),
-      listingType: listingType ?? urlListingType,
+      dataType: getDataTypeString(dataType ?? DataType.Post),
+      listingType: listingType,
       pageCursor: pageCursor,
-      sort: sort ?? urlSort,
-      showHidden: showHidden ?? urlShowHidden,
+      sort: sort,
+      showHidden: showHidden,
     };
 
     this.props.history.push({
       pathname: "/",
       search: getQueryString(queryParams),
     });
-
-    await this.fetchData();
   }
 
   get posts() {
@@ -855,11 +858,15 @@ export class Home extends Component<HomeRouteProps, HomeState> {
     });
   }
 
-  async fetchData() {
-    const { dataType, pageCursor, listingType, sort, showHidden } = this.props;
-
+  async fetchData({
+    dataType,
+    pageCursor,
+    listingType,
+    sort,
+    showHidden,
+  }: HomeProps) {
     if (dataType === DataType.Post) {
-      this.setState({ postsRes: LOADING_REQUEST });
+      this.setState({ postsRes: LOADING_REQUEST, commentsRes: EMPTY_REQUEST });
       this.setState({
         postsRes: await HttpService.client.getPosts({
           page_cursor: pageCursor,
@@ -871,7 +878,7 @@ export class Home extends Component<HomeRouteProps, HomeState> {
         }),
       });
     } else {
-      this.setState({ commentsRes: LOADING_REQUEST });
+      this.setState({ commentsRes: LOADING_REQUEST, postsRes: EMPTY_REQUEST });
       this.setState({
         commentsRes: await HttpService.client.getComments({
           limit: fetchLimit,

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -858,6 +858,7 @@ export class Home extends Component<HomeRouteProps, HomeState> {
     });
   }
 
+  fetchDataToken?: symbol;
   async fetchData({
     dataType,
     pageCursor,
@@ -865,28 +866,31 @@ export class Home extends Component<HomeRouteProps, HomeState> {
     sort,
     showHidden,
   }: HomeProps) {
+    const token = (this.fetchDataToken = Symbol());
     if (dataType === DataType.Post) {
       this.setState({ postsRes: LOADING_REQUEST, commentsRes: EMPTY_REQUEST });
-      this.setState({
-        postsRes: await HttpService.client.getPosts({
-          page_cursor: pageCursor,
-          limit: fetchLimit,
-          sort,
-          saved_only: false,
-          type_: listingType,
-          show_hidden: showHidden === "true",
-        }),
+      const postsRes = await HttpService.client.getPosts({
+        page_cursor: pageCursor,
+        limit: fetchLimit,
+        sort,
+        saved_only: false,
+        type_: listingType,
+        show_hidden: showHidden === "true",
       });
+      if (token === this.fetchDataToken) {
+        this.setState({ postsRes });
+      }
     } else {
       this.setState({ commentsRes: LOADING_REQUEST, postsRes: EMPTY_REQUEST });
-      this.setState({
-        commentsRes: await HttpService.client.getComments({
-          limit: fetchLimit,
-          sort: postToCommentSortType(sort),
-          saved_only: false,
-          type_: listingType,
-        }),
+      const commentsRes = await HttpService.client.getComments({
+        limit: fetchLimit,
+        sort: postToCommentSortType(sort),
+        saved_only: false,
+        type_: listingType,
       });
+      if (token === this.fetchDataToken) {
+        this.setState({ commentsRes });
+      }
     }
   }
 

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -26,6 +26,7 @@ import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../../routes";
 import { resourcesSettled } from "@utils/helpers";
 import { scrollMixin } from "../mixins/scroll-mixin";
+import { isBrowser } from "@utils/browser";
 
 type InstancesData = RouteDataResponse<{
   federatedInstancesResponse: GetFederatedInstancesResponse;
@@ -71,8 +72,8 @@ export class Instances extends Component<InstancesRouteProps, InstancesState> {
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       await this.fetchInstances();
     }
   }

--- a/src/shared/components/home/setup.tsx
+++ b/src/shared/components/home/setup.tsx
@@ -19,6 +19,7 @@ import PasswordInput from "../common/password-input";
 import { SiteForm } from "./site-form";
 import { simpleScrollMixin } from "../mixins/scroll-mixin";
 import { RouteComponentProps } from "inferno-router/dist/Route";
+import { isBrowser } from "@utils/browser";
 
 interface State {
   form: {
@@ -61,8 +62,10 @@ export class Setup extends Component<
     this.handleCreateSite = this.handleCreateSite.bind(this);
   }
 
-  async componentDidMount() {
-    this.setState({ themeList: await fetchThemeList() });
+  async componentWillMount() {
+    if (isBrowser()) {
+      this.setState({ themeList: await fetchThemeList() });
+    }
   }
 
   get documentTitle(): string {

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -76,8 +76,11 @@ export class Signup extends Component<
     this.handleAnswerChange = this.handleAnswerChange.bind(this);
   }
 
-  async componentDidMount() {
-    if (this.state.siteRes.site_view.local_site.captcha_enabled) {
+  async componentWillMount() {
+    if (
+      this.state.siteRes.site_view.local_site.captcha_enabled &&
+      isBrowser()
+    ) {
       await this.fetchCaptcha();
     }
   }

--- a/src/shared/components/mixins/modal-mixin.ts
+++ b/src/shared/components/mixins/modal-mixin.ts
@@ -2,7 +2,7 @@ import { Modal } from "bootstrap";
 import { Component, InfernoNode, RefObject } from "inferno";
 
 export function modalMixin<
-  P extends { show: boolean },
+  P extends { show?: boolean },
   S,
   Base extends new (...args: any[]) => Component<P, S> & {
     readonly modalDivRef: RefObject<HTMLDivElement>;

--- a/src/shared/components/mixins/scroll-mixin.ts
+++ b/src/shared/components/mixins/scroll-mixin.ts
@@ -68,7 +68,6 @@ export function scrollMixin<
       nextProps: Readonly<{ children?: InfernoNode } & P>,
       nextContext: any,
     ) {
-      // Currently this is hypothetical. Components unmount before route changes.
       if (this.props.location.key !== nextProps.location.key) {
         this.saveFinalPosition();
         this.reset();

--- a/src/shared/components/mixins/scroll-mixin.ts
+++ b/src/shared/components/mixins/scroll-mixin.ts
@@ -1,6 +1,6 @@
 import { isBrowser, nextUserAction, snapToTop } from "../../utils/browser";
 import { Component, InfernoNode } from "inferno";
-import { Location } from "history";
+import { Location, History, Action } from "history";
 
 function restoreScrollPosition(props: { location: Location }) {
   const key: string = props.location.key;
@@ -25,7 +25,7 @@ function dropScrollPosition(props: { location: Location }) {
 }
 
 export function scrollMixin<
-  P extends { location: Location },
+  P extends { location: Location; history: History },
   S,
   Base extends new (
     ...args: any
@@ -69,8 +69,10 @@ export function scrollMixin<
       nextContext: any,
     ) {
       if (this.props.location.key !== nextProps.location.key) {
-        this.saveFinalPosition();
-        this.reset();
+        if (nextProps.history.action !== Action.Replace) {
+          this.saveFinalPosition();
+          this.reset();
+        }
       }
       return super.componentWillReceiveProps?.(nextProps, nextContext);
     }
@@ -130,7 +132,7 @@ export function scrollMixin<
 }
 
 export function simpleScrollMixin<
-  P extends { location: Location },
+  P extends { location: Location; history: History },
   S,
   Base extends new (...args: any) => Component<P, S>,
 >(base: Base, _context?: ClassDecoratorContext<Base>) {

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -847,13 +847,13 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
           <h5>
             {communityResp ? (
               <>
-            <Link
-              className="text-body"
-              to={`/c/${communityResp.community_view.community.name}`}
-            >
-              /c/{communityResp.community_view.community.name}
-            </Link>{" "}
-            <span>{I18NextService.i18n.t("modlog")}</span>
+                <Link
+                  className="text-body"
+                  to={`/c/${communityResp.community_view.community.name}`}
+                >
+                  /c/{communityResp.community_view.community.name}
+                </Link>{" "}
+                <span>{I18NextService.i18n.t("modlog")}</span>
               </>
             ) : (
               communityState === "loading" && <LoadingEllipses />

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -1,9 +1,4 @@
-import {
-  fetchUsers,
-  getUpdatedSearchId,
-  personToChoice,
-  setIsoData,
-} from "@utils/app";
+import { fetchUsers, personToChoice, setIsoData } from "@utils/app";
 import {
   debounce,
   formatPastDate,
@@ -12,6 +7,7 @@ import {
   getQueryParams,
   getQueryString,
   resourcesSettled,
+  bareRoutePush,
 } from "@utils/helpers";
 import { scrollMixin } from "./mixins/scroll-mixin";
 import { amAdmin, amMod } from "@utils/roles";
@@ -706,38 +702,62 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
 
   async componentWillMount() {
     if (!this.state.isIsomorphic && isBrowser()) {
-      const { modId, userId } = this.props;
-      const promises = [this.refetch()];
+      await Promise.all([
+        this.fetchModlog(this.props),
+        this.fetchCommunity(this.props),
+        this.fetchUser(this.props),
+        this.fetchMod(this.props),
+      ]);
+    }
+  }
 
-      if (userId) {
-        promises.push(
-          HttpService.client
-            .getPersonDetails({ person_id: userId })
-            .then(res => {
-              if (res.state === "success") {
-                this.setState({
-                  userSearchOptions: [personToChoice(res.data.person_view)],
-                });
-              }
-            }),
-        );
+  componentWillReceiveProps(nextProps: ModlogRouteProps) {
+    this.fetchModlog(nextProps);
+
+    const reload = bareRoutePush(this.props, nextProps);
+
+    if (nextProps.modId !== this.props.modId || reload) {
+      this.fetchMod(nextProps);
+    }
+    if (nextProps.userId !== this.props.userId || reload) {
+      this.fetchUser(nextProps);
+    }
+    if (
+      nextProps.match.params.communityId !==
+        this.props.match.params.communityId ||
+      reload
+    ) {
+      this.fetchCommunity(nextProps);
+    }
+  }
+
+  async fetchUser(props: ModlogRouteProps) {
+    const { userId } = props;
+
+    if (userId) {
+      const res = await HttpService.client.getPersonDetails({
+        person_id: userId,
+      });
+      if (res.state === "success") {
+        this.setState({
+          userSearchOptions: [personToChoice(res.data.person_view)],
+        });
       }
+    }
+  }
 
-      if (modId) {
-        promises.push(
-          HttpService.client
-            .getPersonDetails({ person_id: modId })
-            .then(res => {
-              if (res.state === "success") {
-                this.setState({
-                  modSearchOptions: [personToChoice(res.data.person_view)],
-                });
-              }
-            }),
-        );
+  async fetchMod(props: ModlogRouteProps) {
+    const { modId } = props;
+
+    if (modId) {
+      const res = await HttpService.client.getPersonDetails({
+        person_id: modId,
+      });
+      if (res.state === "success") {
+        this.setState({
+          modSearchOptions: [personToChoice(res.data.person_view)],
+        });
       }
-
-      await Promise.all(promises);
     }
   }
 
@@ -969,35 +989,34 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
     });
   });
 
-  async updateUrl({ actionType, modId, page, userId }: Partial<ModlogProps>) {
+  async updateUrl(props: Partial<ModlogProps>) {
     const {
-      page: urlPage,
-      actionType: urlActionType,
-      modId: urlModId,
-      userId: urlUserId,
-    } = this.props;
+      actionType,
+      modId,
+      page,
+      userId,
+      match: {
+        params: { communityId },
+      },
+    } = { ...this.props, ...props };
 
     const queryParams: QueryParams<ModlogProps> = {
-      page: (page ?? urlPage).toString(),
-      actionType: actionType ?? urlActionType,
-      modId: getUpdatedSearchId(modId, urlModId),
-      userId: getUpdatedSearchId(userId, urlUserId),
+      page: page.toString(),
+      actionType: actionType,
+      modId: modId?.toString(),
+      userId: userId?.toString(),
     };
-
-    const communityId = this.props.match.params.communityId;
 
     this.props.history.push(
       `/modlog${communityId ? `/${communityId}` : ""}${getQueryString(
         queryParams,
       )}`,
     );
-
-    await this.refetch();
   }
 
-  async refetch() {
-    const { actionType, page, modId, userId, postId, commentId } = this.props;
-    const { communityId: urlCommunityId } = this.props.match.params;
+  async fetchModlog(props: ModlogRouteProps) {
+    const { actionType, page, modId, userId, postId, commentId } = props;
+    const { communityId: urlCommunityId } = props.match.params;
     const communityId = getIdFromString(urlCommunityId);
 
     this.setState({ res: LOADING_REQUEST });
@@ -1016,6 +1035,11 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
         post_id: postId,
       }),
     });
+  }
+
+  async fetchCommunity(props: ModlogRouteProps) {
+    const { communityId: urlCommunityId } = props.match.params;
+    const communityId = getIdFromString(urlCommunityId);
 
     if (communityId) {
       this.setState({ communityRes: LOADING_REQUEST });
@@ -1024,6 +1048,8 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
           id: communityId,
         }),
       });
+    } else {
+      this.setState({ communityRes: EMPTY_REQUEST });
     }
   }
 

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -63,6 +63,7 @@ import { PersonListing } from "./person/person-listing";
 import { getHttpBaseInternal } from "../utils/env";
 import { IRoutePropsWithFetch } from "../routes";
 import { isBrowser } from "@utils/browser";
+import { LoadingEllipses } from "./common/loading-ellipses";
 
 type FilterType = "mod" | "user";
 
@@ -814,6 +815,11 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
       modSearchOptions,
     } = this.state;
     const { actionType, modId, userId } = this.props;
+    const { communityId } = this.props.match.params;
+
+    const communityState = this.state.communityRes.state;
+    const communityResp =
+      communityState === "success" && this.state.communityRes.data;
 
     return (
       <div className="modlog container-lg">
@@ -837,15 +843,21 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
             #<strong>#</strong>#
           </T>
         </div>
-        {this.state.communityRes.state === "success" && (
+        {communityId && (
           <h5>
+            {communityResp ? (
+              <>
             <Link
               className="text-body"
-              to={`/c/${this.state.communityRes.data.community_view.community.name}`}
+              to={`/c/${communityResp.community_view.community.name}`}
             >
-              /c/{this.state.communityRes.data.community_view.community.name}{" "}
-            </Link>
+              /c/{communityResp.community_view.community.name}
+            </Link>{" "}
             <span>{I18NextService.i18n.t("modlog")}</span>
+              </>
+            ) : (
+              communityState === "loading" && <LoadingEllipses />
+            )}
           </h5>
         )}
         <div className="row mb-2">
@@ -956,6 +968,10 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
   }
 
   handleSearchUsers = debounce(async (text: string) => {
+    if (!text.length) {
+      return;
+    }
+
     const { userId } = this.props;
     const { userSearchOptions } = this.state;
     this.setState({ loadingUserSearch: true });
@@ -973,6 +989,10 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
   });
 
   handleSearchMods = debounce(async (text: string) => {
+    if (!text.length) {
+      return;
+    }
+
     const { modId } = this.props;
     const { modSearchOptions } = this.state;
     this.setState({ loadingModSearch: true });

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -66,6 +66,7 @@ import { CommunityLink } from "./community/community-link";
 import { PersonListing } from "./person/person-listing";
 import { getHttpBaseInternal } from "../utils/env";
 import { IRoutePropsWithFetch } from "../routes";
+import { isBrowser } from "@utils/browser";
 
 type FilterType = "mod" | "user";
 
@@ -703,8 +704,8 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       const { modId, userId } = this.props;
       const promises = [this.refetch()];
 

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -732,14 +732,16 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
     }
   }
 
+  fetchUserToken?: symbol;
   async fetchUser(props: ModlogRouteProps) {
+    const token = (this.fetchUserToken = Symbol());
     const { userId } = props;
 
     if (userId) {
       const res = await HttpService.client.getPersonDetails({
         person_id: userId,
       });
-      if (res.state === "success") {
+      if (res.state === "success" && token === this.fetchUserToken) {
         this.setState({
           userSearchOptions: [personToChoice(res.data.person_view)],
         });
@@ -747,14 +749,16 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
     }
   }
 
+  fetchModToken?: symbol;
   async fetchMod(props: ModlogRouteProps) {
+    const token = (this.fetchModToken = Symbol());
     const { modId } = props;
 
     if (modId) {
       const res = await HttpService.client.getPersonDetails({
         person_id: modId,
       });
-      if (res.state === "success") {
+      if (res.state === "success" && token === this.fetchModToken) {
         this.setState({
           modSearchOptions: [personToChoice(res.data.person_view)],
         });
@@ -1034,40 +1038,46 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
     );
   }
 
+  fetchModlogToken?: symbol;
   async fetchModlog(props: ModlogRouteProps) {
+    const token = (this.fetchModlogToken = Symbol());
     const { actionType, page, modId, userId, postId, commentId } = props;
     const { communityId: urlCommunityId } = props.match.params;
     const communityId = getIdFromString(urlCommunityId);
 
     this.setState({ res: LOADING_REQUEST });
-    this.setState({
-      res: await HttpService.client.getModlog({
-        community_id: communityId,
-        page,
-        limit: fetchLimit,
-        type_: actionType,
-        other_person_id: userId,
-        mod_person_id: !this.isoData.site_res.site_view.local_site
-          .hide_modlog_mod_names
-          ? modId
-          : undefined,
-        comment_id: commentId,
-        post_id: postId,
-      }),
+    const res = await HttpService.client.getModlog({
+      community_id: communityId,
+      page,
+      limit: fetchLimit,
+      type_: actionType,
+      other_person_id: userId,
+      mod_person_id: !this.isoData.site_res.site_view.local_site
+        .hide_modlog_mod_names
+        ? modId
+        : undefined,
+      comment_id: commentId,
+      post_id: postId,
     });
+    if (token === this.fetchModlogToken) {
+      this.setState({ res });
+    }
   }
 
+  fetchCommunityToken?: symbol;
   async fetchCommunity(props: ModlogRouteProps) {
+    const token = (this.fetchCommunityToken = Symbol());
     const { communityId: urlCommunityId } = props.match.params;
     const communityId = getIdFromString(urlCommunityId);
 
     if (communityId) {
       this.setState({ communityRes: LOADING_REQUEST });
-      this.setState({
-        communityRes: await HttpService.client.getCommunity({
-          id: communityId,
-        }),
+      const communityRes = await HttpService.client.getCommunity({
+        id: communityId,
       });
+      if (token === this.fetchCommunityToken) {
+        this.setState({ communityRes });
+      }
     } else {
       this.setState({ communityRes: EMPTY_REQUEST });
     }

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -860,7 +860,12 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
                 <span>{I18NextService.i18n.t("modlog")}</span>
               </>
             ) : (
-              communityState === "loading" && <LoadingEllipses />
+              communityState === "loading" && (
+                <>
+                  <LoadingEllipses />
+                  &nbsp;
+                </>
+              )
             )}
           </h5>
         )}

--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -89,6 +89,7 @@ import { getHttpBaseInternal } from "../../utils/env";
 import { CommentsLoadingSkeleton } from "../common/loading-skeleton";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../../routes";
+import { isBrowser } from "@utils/browser";
 
 enum UnreadOrAll {
   Unread,
@@ -213,8 +214,8 @@ export class Inbox extends Component<InboxRouteProps, InboxState> {
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       await this.refetch();
     }
   }

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -303,7 +303,9 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
     }
   }
 
+  fetchUploadsToken?: symbol;
   async fetchUploads(props: ProfileRouteProps) {
+    const token = (this.fetchUploadsToken = Symbol());
     const { page } = props;
     this.setState({ uploadsRes: LOADING_REQUEST });
     const form: ListMedia = {
@@ -312,10 +314,14 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
       limit: fetchLimit,
     };
     const uploadsRes = await HttpService.client.listMedia(form);
-    this.setState({ uploadsRes });
+    if (token === this.fetchUploadsToken) {
+      this.setState({ uploadsRes });
+    }
   }
 
+  fetchUserDataToken?: symbol;
   async fetchUserData(props: ProfileRouteProps, showBothLoading = false) {
+    const token = (this.fetchUploadsToken = this.fetchUserDataToken = Symbol());
     const { page, sort, view } = props;
 
     if (view === PersonDetailsView.Uploads) {
@@ -350,11 +356,13 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
       limit: fetchLimit,
     });
 
-    this.setState({
-      personRes,
-      personDetailsRes: personRes,
-      personBlocked: isPersonBlocked(personRes),
-    });
+    if (token === this.fetchUserDataToken) {
+      this.setState({
+        personRes,
+        personDetailsRes: personRes,
+        personBlocked: isPersonBlocked(personRes),
+      });
+    }
   }
 
   get amCurrentUser() {
@@ -470,7 +478,8 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
 
               {this.renderUploadsRes()}
 
-              {personDetailsState === "loading" ? (
+              {personDetailsState === "loading" &&
+              this.props.view !== PersonDetailsView.Uploads ? (
                 <h5>
                   <Spinner large />
                 </h5>

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -100,6 +100,7 @@ import { getHttpBaseInternal } from "../../utils/env";
 import { IRoutePropsWithFetch } from "../../routes";
 import { MediaUploads } from "../common/media-uploads";
 import { cakeDate } from "@utils/helpers";
+import { isBrowser } from "@utils/browser";
 
 type ProfileData = RouteDataResponse<{
   personRes: GetPersonDetailsResponse;
@@ -260,8 +261,8 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       await this.fetchUserData();
     }
   }

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -471,52 +471,56 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
               {this.renderUploadsRes()}
 
               {personDetailsState === "loading" ? (
-                <h5><Spinner large /></h5>
-              ) : personDetailsRes && (
-              <PersonDetails
-                personRes={personDetailsRes}
-                admins={siteRes.admins}
-                sort={sort}
-                page={page}
-                limit={fetchLimit}
-                finished={this.state.finished}
-                enableDownvotes={enableDownvotes(siteRes)}
-                voteDisplayMode={voteDisplayMode(siteRes)}
-                enableNsfw={enableNsfw(siteRes)}
-                view={view}
-                onPageChange={this.handlePageChange}
-                allLanguages={siteRes.all_languages}
-                siteLanguages={siteRes.discussion_languages}
-                // TODO all the forms here
-                onSaveComment={this.handleSaveComment}
-                onBlockPerson={this.handleBlockPersonAlt}
-                onDeleteComment={this.handleDeleteComment}
-                onRemoveComment={this.handleRemoveComment}
-                onCommentVote={this.handleCommentVote}
-                onCommentReport={this.handleCommentReport}
-                onDistinguishComment={this.handleDistinguishComment}
-                onAddModToCommunity={this.handleAddModToCommunity}
-                onAddAdmin={this.handleAddAdmin}
-                onTransferCommunity={this.handleTransferCommunity}
-                onPurgeComment={this.handlePurgeComment}
-                onPurgePerson={this.handlePurgePerson}
-                onCommentReplyRead={this.handleCommentReplyRead}
-                onPersonMentionRead={this.handlePersonMentionRead}
-                onBanPersonFromCommunity={this.handleBanFromCommunity}
-                onBanPerson={this.handleBanPerson}
-                onCreateComment={this.handleCreateComment}
-                onEditComment={this.handleEditComment}
-                onPostEdit={this.handlePostEdit}
-                onPostVote={this.handlePostVote}
-                onPostReport={this.handlePostReport}
-                onLockPost={this.handleLockPost}
-                onDeletePost={this.handleDeletePost}
-                onRemovePost={this.handleRemovePost}
-                onSavePost={this.handleSavePost}
-                onPurgePost={this.handlePurgePost}
-                onFeaturePost={this.handleFeaturePost}
-                onMarkPostAsRead={() => {}}
-              />
+                <h5>
+                  <Spinner large />
+                </h5>
+              ) : (
+                personDetailsRes && (
+                  <PersonDetails
+                    personRes={personDetailsRes}
+                    admins={siteRes.admins}
+                    sort={sort}
+                    page={page}
+                    limit={fetchLimit}
+                    finished={this.state.finished}
+                    enableDownvotes={enableDownvotes(siteRes)}
+                    voteDisplayMode={voteDisplayMode(siteRes)}
+                    enableNsfw={enableNsfw(siteRes)}
+                    view={view}
+                    onPageChange={this.handlePageChange}
+                    allLanguages={siteRes.all_languages}
+                    siteLanguages={siteRes.discussion_languages}
+                    // TODO all the forms here
+                    onSaveComment={this.handleSaveComment}
+                    onBlockPerson={this.handleBlockPersonAlt}
+                    onDeleteComment={this.handleDeleteComment}
+                    onRemoveComment={this.handleRemoveComment}
+                    onCommentVote={this.handleCommentVote}
+                    onCommentReport={this.handleCommentReport}
+                    onDistinguishComment={this.handleDistinguishComment}
+                    onAddModToCommunity={this.handleAddModToCommunity}
+                    onAddAdmin={this.handleAddAdmin}
+                    onTransferCommunity={this.handleTransferCommunity}
+                    onPurgeComment={this.handlePurgeComment}
+                    onPurgePerson={this.handlePurgePerson}
+                    onCommentReplyRead={this.handleCommentReplyRead}
+                    onPersonMentionRead={this.handlePersonMentionRead}
+                    onBanPersonFromCommunity={this.handleBanFromCommunity}
+                    onBanPerson={this.handleBanPerson}
+                    onCreateComment={this.handleCreateComment}
+                    onEditComment={this.handleEditComment}
+                    onPostEdit={this.handlePostEdit}
+                    onPostVote={this.handlePostVote}
+                    onPostReport={this.handlePostReport}
+                    onLockPost={this.handleLockPost}
+                    onDeletePost={this.handleDeletePost}
+                    onRemovePost={this.handleRemovePost}
+                    onSavePost={this.handleSavePost}
+                    onPurgePost={this.handlePurgePost}
+                    onFeaturePost={this.handleFeaturePost}
+                    onMarkPostAsRead={() => {}}
+                  />
+                )
               )}
             </div>
 

--- a/src/shared/components/person/registration-applications.tsx
+++ b/src/shared/components/person/registration-applications.tsx
@@ -109,16 +109,12 @@ export class RegistrationApplications extends Component<
   }
 
   renderApps() {
-    switch (this.state.appsRes.state) {
-      case "loading":
-        return (
-          <h5>
-            <Spinner large />
-          </h5>
-        );
-      case "success": {
-        const apps = this.state.appsRes.data.registration_applications;
-        return (
+    const appsState = this.state.appsRes.state;
+    const apps =
+      appsState === "success" &&
+      this.state.appsRes.data.registration_applications;
+
+    return (
           <div className="row">
             <div className="col-12">
               <HtmlTags
@@ -129,17 +125,25 @@ export class RegistrationApplications extends Component<
                 {I18NextService.i18n.t("registration_applications")}
               </h1>
               {this.selects()}
+              {apps ? (
+            <>
               {this.applicationList(apps)}
               <Paginator
                 page={this.state.page}
                 onChange={this.handlePageChange}
                 nextDisabled={fetchLimit > apps.length}
               />
+            </>
+              ) : (
+                appsState === "loading" && (
+                  <div className="text-center">
+                    <Spinner large />
+                  </div>
+                )
+              )}
             </div>
           </div>
-        );
-      }
-    }
+    );
   }
 
   render() {

--- a/src/shared/components/person/registration-applications.tsx
+++ b/src/shared/components/person/registration-applications.tsx
@@ -29,6 +29,7 @@ import { UnreadCounterService } from "../../services";
 import { getHttpBaseInternal } from "../../utils/env";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../../routes";
+import { isBrowser } from "@utils/browser";
 
 enum RegistrationState {
   Unread,
@@ -92,8 +93,8 @@ export class RegistrationApplications extends Component<
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       await this.refetch();
     }
   }

--- a/src/shared/components/person/registration-applications.tsx
+++ b/src/shared/components/person/registration-applications.tsx
@@ -115,17 +115,17 @@ export class RegistrationApplications extends Component<
       this.state.appsRes.data.registration_applications;
 
     return (
-          <div className="row">
-            <div className="col-12">
-              <HtmlTags
-                title={this.documentTitle}
-                path={this.context.router.route.match.url}
-              />
-              <h1 className="h4 mb-4">
-                {I18NextService.i18n.t("registration_applications")}
-              </h1>
-              {this.selects()}
-              {apps ? (
+      <div className="row">
+        <div className="col-12">
+          <HtmlTags
+            title={this.documentTitle}
+            path={this.context.router.route.match.url}
+          />
+          <h1 className="h4 mb-4">
+            {I18NextService.i18n.t("registration_applications")}
+          </h1>
+          {this.selects()}
+          {apps ? (
             <>
               {this.applicationList(apps)}
               <Paginator
@@ -134,15 +134,15 @@ export class RegistrationApplications extends Component<
                 nextDisabled={fetchLimit > apps.length}
               />
             </>
-              ) : (
-                appsState === "loading" && (
-                  <div className="text-center">
-                    <Spinner large />
-                  </div>
-                )
-              )}
-            </div>
-          </div>
+          ) : (
+            appsState === "loading" && (
+              <div className="text-center">
+                <Spinner large />
+              </div>
+            )
+          )}
+        </div>
+      </div>
     );
   }
 

--- a/src/shared/components/person/registration-applications.tsx
+++ b/src/shared/components/person/registration-applications.tsx
@@ -268,19 +268,22 @@ export class RegistrationApplications extends Component<
     };
   }
 
+  refetchToken?: symbol;
   async refetch() {
+    const token = (this.refetchToken = Symbol());
     const unread_only =
       this.state.registrationState === RegistrationState.Unread;
     this.setState({
       appsRes: LOADING_REQUEST,
     });
-    this.setState({
-      appsRes: await HttpService.client.listRegistrationApplications({
-        unread_only: unread_only,
-        page: this.state.page,
-        limit: fetchLimit,
-      }),
+    const appsRes = await HttpService.client.listRegistrationApplications({
+      unread_only: unread_only,
+      page: this.state.page,
+      limit: fetchLimit,
     });
+    if (token === this.refetchToken) {
+      this.setState({ appsRes });
+    }
   }
 
   async handleApproveApplication(form: ApproveRegistrationApplication) {

--- a/src/shared/components/person/reports.tsx
+++ b/src/shared/components/person/reports.tsx
@@ -575,6 +575,7 @@ export class Reports extends Component<ReportsRouteProps, ReportsState> {
 
   static async fetchInitialData({
     headers,
+    site,
   }: InitialFetchRequest): Promise<ReportsData> {
     const client = wrapClient(
       new LemmyHttp(getHttpBaseInternal(), { headers }),
@@ -601,7 +602,7 @@ export class Reports extends Component<ReportsRouteProps, ReportsState> {
       messageReportsRes: EMPTY_REQUEST,
     };
 
-    if (amAdmin()) {
+    if (amAdmin(site.my_user)) {
       const privateMessageReportsForm: ListPrivateMessageReports = {
         unresolved_only,
         page,

--- a/src/shared/components/person/reports.tsx
+++ b/src/shared/components/person/reports.tsx
@@ -56,6 +56,7 @@ import { UnreadCounterService } from "../../services";
 import { getHttpBaseInternal } from "../../utils/env";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../../routes";
+import { isBrowser } from "@utils/browser";
 
 enum UnreadOrAll {
   Unread,
@@ -160,8 +161,8 @@ export class Reports extends Component<ReportsRouteProps, ReportsState> {
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       await this.refetch();
     }
   }

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -348,7 +348,7 @@ export class Settings extends Component<SettingsRouteProps, SettingsState> {
     }
   }
 
-  async componentDidMount() {
+  async componentWillMount() {
     this.setState({ themeList: await fetchThemeList() });
 
     if (!this.state.isIsomorphic) {

--- a/src/shared/components/person/verify-email.tsx
+++ b/src/shared/components/person/verify-email.tsx
@@ -13,6 +13,7 @@ import { HtmlTags } from "../common/html-tags";
 import { Spinner } from "../common/icon";
 import { simpleScrollMixin } from "../mixins/scroll-mixin";
 import { RouteComponentProps } from "inferno-router/dist/Route";
+import { isBrowser } from "@utils/browser";
 
 interface State {
   verifyRes: RequestState<SuccessResponse>;
@@ -52,8 +53,10 @@ export class VerifyEmail extends Component<
     }
   }
 
-  async componentDidMount() {
-    await this.verify();
+  async componentWillMount() {
+    if (isBrowser()) {
+      await this.verify();
+    }
   }
 
   get documentTitle(): string {

--- a/src/shared/components/post/create-post.tsx
+++ b/src/shared/components/post/create-post.tsx
@@ -33,6 +33,7 @@ import { getHttpBaseInternal } from "../../utils/env";
 import { IRoutePropsWithFetch } from "../../routes";
 import { simpleScrollMixin } from "../mixins/scroll-mixin";
 import { toast } from "../../toast";
+import { isBrowser } from "@utils/browser";
 
 export interface CreatePostProps {
   communityId?: number;
@@ -132,9 +133,9 @@ export class CreatePost extends Component<
     }
   }
 
-  async componentDidMount() {
+  async componentWillMount() {
     // TODO test this
-    if (!this.state.isIsomorphic) {
+    if (!this.state.isIsomorphic && isBrowser()) {
       const { communityId } = this.props;
 
       const initialCommunitiesRes = await fetchCommunitiesForOptions(

--- a/src/shared/components/post/create-post.tsx
+++ b/src/shared/components/post/create-post.tsx
@@ -81,7 +81,7 @@ export class CreatePost extends Component<
   private isoData = setIsoData<CreatePostData>(this.context);
   state: CreatePostState = {
     siteRes: this.isoData.site_res,
-    loading: true,
+    loading: false,
     initialCommunitiesRes: EMPTY_REQUEST,
     isIsomorphic: false,
   };

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -10,7 +10,7 @@ import {
 import { isImage } from "@utils/media";
 import { Choice } from "@utils/types";
 import autosize from "autosize";
-import { Component, InfernoNode, linkEvent } from "inferno";
+import { Component, InfernoNode, createRef, linkEvent } from "inferno";
 import { Prompt } from "inferno-router";
 import {
   CommunityView,
@@ -132,8 +132,9 @@ function copySuggestedTitle(d: { i: PostForm; suggestedTitle?: string }) {
     );
     d.i.setState({ suggestedPostsRes: EMPTY_REQUEST });
     setTimeout(() => {
-      const textarea: any = document.getElementById("post-title");
-      autosize.update(textarea);
+      if (d.i.postTitleRef.current) {
+        autosize.update(d.i.postTitleRef.current);
+      }
     }, 10);
   }
 }
@@ -248,6 +249,8 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
     submitted: false,
   };
 
+  postTitleRef = createRef<HTMLTextAreaElement>();
+
   constructor(props: PostFormProps, context: any) {
     super(props, context);
     this.fetchSimilarPosts = debounce(this.fetchSimilarPosts.bind(this));
@@ -306,10 +309,8 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
   }
 
   componentDidMount() {
-    const textarea: any = document.getElementById("post-title");
-
-    if (textarea) {
-      autosize(textarea);
+    if (this.postTitleRef.current) {
+      autosize(this.postTitleRef.current);
     }
   }
 
@@ -382,6 +383,7 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
               rows={1}
               minLength={3}
               maxLength={MAX_POST_TITLE_LENGTH}
+              ref={this.postTitleRef}
             />
             {!validTitle(this.state.form.name) && (
               <div className="invalid-feedback">

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -316,7 +316,11 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
   componentWillReceiveProps(
     nextProps: Readonly<{ children?: InfernoNode } & PostFormProps>,
   ): void {
-    if (this.props !== nextProps) {
+    if (
+      this.props.selectedCommunityChoice?.value !==
+        nextProps.selectedCommunityChoice?.value &&
+      nextProps.selectedCommunityChoice
+    ) {
       this.setState(
         s => (
           (s.form.community_id = getIdFromString(
@@ -325,6 +329,22 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
           s
         ),
       );
+      this.setState({
+        communitySearchOptions: [nextProps.selectedCommunityChoice].concat(
+          (nextProps.initialCommunities?.map(communityToChoice) ?? []).filter(
+            option => option.value !== nextProps.selectedCommunityChoice?.value,
+          ),
+        ),
+      });
+    }
+    if (
+      !this.props.initialCommunities?.length &&
+      nextProps.initialCommunities?.length
+    ) {
+      this.setState({
+        communitySearchOptions:
+          nextProps.initialCommunities?.map(communityToChoice) ?? [],
+      });
     }
   }
 

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -137,7 +137,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     this.handleHidePost = this.handleHidePost.bind(this);
   }
 
-  componentDidMount(): void {
+  componentWillMount(): void {
     if (
       UserService.Instance.myUserInfo &&
       !this.isoData.showAdultConsentModal

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -137,6 +137,8 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     this.handleHidePost = this.handleHidePost.bind(this);
   }
 
+  unlisten = () => {};
+
   componentWillMount(): void {
     if (
       UserService.Instance.myUserInfo &&
@@ -148,6 +150,17 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         imageExpanded: auto_expand && !(blur_nsfw && this.postView.post.nsfw),
       });
     }
+
+    // Leave edit mode on navigation
+    this.unlisten = this.context.router.history.listen(() => {
+      if (this.state.showEdit) {
+        this.setState({ showEdit: false });
+      }
+    });
+  }
+
+  componentWillUnmount(): void {
+    this.unlisten();
   }
 
   get postView(): PostView {

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -588,6 +588,10 @@ export class Post extends Component<PostRouteProps, PostState> {
                 res.post_view.banned_from_community
               ) && (
                 <CommentForm
+                  key={
+                    this.context.router.history.location.key
+                    // reset on new location, otherwise <Prompt /> stops working
+                  }
                   node={res.post_view.post.id}
                   disabled={res.post_view.post.locked}
                   allLanguages={siteRes.all_languages}

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -280,27 +280,24 @@ export class Post extends Component<PostRouteProps, PostState> {
     }
   }
 
+  fetchPostToken?: symbol;
   async fetchPost(props: PostRouteProps) {
-    this.setState({
-      postRes: LOADING_REQUEST,
-    });
-
+    const token = (this.fetchPostToken = Symbol());
+    this.setState({ postRes: LOADING_REQUEST });
     const postRes = await HttpService.client.getPost({
       id: getIdFromProps(props),
       comment_id: getCommentIdFromProps(props),
     });
-
-    this.setState({
-      postRes,
-    });
+    if (token === this.fetchPostToken) {
+      this.setState({ postRes });
+    }
   }
 
+  fetchCommentsToken?: symbol;
   async fetchComments(props: PostRouteProps) {
+    const token = (this.fetchCommentsToken = Symbol());
     const { sort } = props;
-    this.setState({
-      commentsRes: LOADING_REQUEST,
-    });
-
+    this.setState({ commentsRes: LOADING_REQUEST });
     const commentsRes = await HttpService.client.getComments({
       post_id: getIdFromProps(props),
       parent_id: getCommentIdFromProps(props),
@@ -309,10 +306,9 @@ export class Post extends Component<PostRouteProps, PostState> {
       type_: "All",
       saved_only: false,
     });
-
-    this.setState({
-      commentsRes,
-    });
+    if (token === this.fetchCommentsToken) {
+      this.setState({ commentsRes });
+    }
   }
 
   updateUrl(props: PartialPostRouteProps, replace = false) {

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -24,7 +24,6 @@ import {
 import { scrollMixin } from "../mixins/scroll-mixin";
 import { isImage } from "@utils/media";
 import { RouteDataResponse } from "@utils/types";
-import autosize from "autosize";
 import classNames from "classnames";
 import { Component, RefObject, createRef, linkEvent } from "inferno";
 import {
@@ -293,13 +292,15 @@ export class Post extends Component<PostRouteProps, PostState> {
     document.removeEventListener("scroll", this.commentScrollDebounced);
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
-      await this.fetchPost();
+  async componentWillMount() {
+    if (isBrowser()) {
+      if (!this.state.isIsomorphic) {
+        await this.fetchPost();
+      }
     }
+  }
 
-    autosize(document.querySelectorAll("textarea"));
-
+  componentDidMount() {
     this.commentScrollDebounced = debounce(this.trackCommentsBoxScrolling, 100);
     document.addEventListener("scroll", this.commentScrollDebounced);
   }

--- a/src/shared/components/private_message/create-private-message.tsx
+++ b/src/shared/components/private_message/create-private-message.tsx
@@ -26,6 +26,7 @@ import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../../routes";
 import { resourcesSettled } from "@utils/helpers";
 import { scrollMixin } from "../mixins/scroll-mixin";
+import { isBrowser } from "@utils/browser";
 
 type CreatePrivateMessageData = RouteDataResponse<{
   recipientDetailsResponse: GetPersonDetailsResponse;
@@ -79,8 +80,8 @@ export class CreatePrivateMessage extends Component<
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       await this.fetchPersonDetails();
     }
   }

--- a/src/shared/components/remote-fetch.tsx
+++ b/src/shared/components/remote-fetch.tsx
@@ -25,6 +25,7 @@ import { CommunityLink } from "./community/community-link";
 import { getHttpBaseInternal } from "../utils/env";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../routes";
+import { isBrowser } from "@utils/browser";
 
 interface RemoteFetchProps {
   uri?: string;
@@ -128,8 +129,8 @@ export class RemoteFetch extends Component<
     }
   }
 
-  async componentDidMount() {
-    if (!this.state.isIsomorphic) {
+  async componentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       const { uri } = this.props;
 
       if (uri) {

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -71,6 +71,7 @@ import { PostListing } from "./post/post-listing";
 import { getHttpBaseInternal } from "../utils/env";
 import { RouteComponentProps } from "inferno-router/dist/Route";
 import { IRoutePropsWithFetch } from "../routes";
+import { isBrowser } from "@utils/browser";
 
 interface SearchProps {
   q?: string;
@@ -329,12 +330,8 @@ export class Search extends Component<SearchRouteProps, SearchState> {
     }
   }
 
-  async componentDidMount() {
-    if (this.props.history.action !== "POP") {
-      this.searchInput.current?.select();
-    }
-
-    if (!this.state.isIsomorphic) {
+  async compoentWillMount() {
+    if (!this.state.isIsomorphic && isBrowser()) {
       this.setState({
         searchCommunitiesLoading: true,
         searchCreatorLoading: true,
@@ -403,6 +400,12 @@ export class Search extends Component<SearchRouteProps, SearchState> {
         searchCommunitiesLoading: false,
         searchCreatorLoading: false,
       });
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.history.action !== "POP") {
+      this.searchInput.current?.select();
     }
   }
 

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -87,6 +87,7 @@ export interface IRoutePropsWithFetch<
   component: Inferno.ComponentClass<
     RouteComponentProps<PathPropsT> & QueryPropsT
   >;
+  mountedSameRouteNavKey?: string;
 }
 
 export const routes: IRoutePropsWithFetch<RouteData, any, any>[] = [

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -97,6 +97,7 @@ export const routes: IRoutePropsWithFetch<RouteData, any, any>[] = [
     fetchInitialData: Home.fetchInitialData,
     exact: true,
     getQueryParams: getHomeQueryParams,
+    mountedSameRouteNavKey: "home",
   } as HomeFetchConfig,
   {
     path: `/login`,
@@ -131,6 +132,7 @@ export const routes: IRoutePropsWithFetch<RouteData, any, any>[] = [
     component: Communities,
     fetchInitialData: Communities.fetchInitialData,
     getQueryParams: getCommunitiesQueryParams,
+    mountedSameRouteNavKey: "communities",
   } as CommunitiesFetchConfig,
   {
     path: `/post/:post_id`,
@@ -147,12 +149,14 @@ export const routes: IRoutePropsWithFetch<RouteData, any, any>[] = [
     component: Community,
     fetchInitialData: Community.fetchInitialData,
     getQueryParams: getCommunityQueryParams,
+    mountedSameRouteNavKey: "community",
   } as CommunityFetchConfig,
   {
     path: `/u/:username`,
     component: Profile,
     fetchInitialData: Profile.fetchInitialData,
     getQueryParams: getProfileQueryParams,
+    mountedSameRouteNavKey: "profile",
   } as ProfileFetchConfig,
   {
     path: `/inbox`,
@@ -165,16 +169,11 @@ export const routes: IRoutePropsWithFetch<RouteData, any, any>[] = [
     fetchInitialData: Settings.fetchInitialData,
   } as SettingsFetchConfig,
   {
-    path: `/modlog/:communityId`,
+    path: `/modlog/:communityId?`,
     component: Modlog,
     fetchInitialData: Modlog.fetchInitialData,
     getQueryParams: getModlogQueryParams,
-  } as ModlogFetchConfig,
-  {
-    path: `/modlog`,
-    component: Modlog,
-    fetchInitialData: Modlog.fetchInitialData,
-    getQueryParams: getModlogQueryParams,
+    mountedSameRouteNavKey: "modlog",
   } as ModlogFetchConfig,
   { path: `/setup`, component: Setup },
   {
@@ -197,6 +196,7 @@ export const routes: IRoutePropsWithFetch<RouteData, any, any>[] = [
     component: Search,
     fetchInitialData: Search.fetchInitialData,
     getQueryParams: getSearchQueryParams,
+    mountedSameRouteNavKey: "search",
   } as SearchFetchConfig,
   {
     path: `/password_change/:token`,

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -53,7 +53,11 @@ import {
   CreatePost,
   getCreatePostQueryParams,
 } from "./components/post/create-post";
-import { Post, PostFetchConfig } from "./components/post/post";
+import {
+  Post,
+  PostFetchConfig,
+  getPostQueryParams,
+} from "./components/post/post";
 import {
   CreatePrivateMessage,
   CreatePrivateMessageFetchConfig,
@@ -135,14 +139,21 @@ export const routes: IRoutePropsWithFetch<RouteData, any, any>[] = [
     mountedSameRouteNavKey: "communities",
   } as CommunitiesFetchConfig,
   {
-    path: `/post/:post_id`,
+    // "/comment/:post_id?/:comment_id" would be preferable as direct comment
+    // link, but it looks like a Route can't match multiple paths and a
+    // component can't stay mounted across routes.
+    path: `/post/:post_id/:comment_id?`,
     component: Post,
     fetchInitialData: Post.fetchInitialData,
+    getQueryParams: getPostQueryParams,
+    mountedSameRouteNavKey: "post",
   } as PostFetchConfig,
   {
     path: `/comment/:comment_id`,
     component: Post,
     fetchInitialData: Post.fetchInitialData,
+    getQueryParams: getPostQueryParams,
+    mountedSameRouteNavKey: "post",
   } as PostFetchConfig,
   {
     path: `/c/:name`,

--- a/src/shared/utils/app/get-updated-search-id.ts
+++ b/src/shared/utils/app/get-updated-search-id.ts
@@ -1,8 +1,0 @@
-export default function getUpdatedSearchId(
-  id?: number | null,
-  urlId?: number | null,
-) {
-  return id === null
-    ? undefined
-    : ((id ?? urlId) === 0 ? undefined : id ?? urlId)?.toString();
-}

--- a/src/shared/utils/app/index.ts
+++ b/src/shared/utils/app/index.ts
@@ -31,7 +31,6 @@ import getDataTypeString from "./get-data-type-string";
 import getDepthFromComment from "./get-depth-from-comment";
 import getIdFromProps from "./get-id-from-props";
 import getRecipientIdFromProps from "./get-recipient-id-from-props";
-import getUpdatedSearchId from "./get-updated-search-id";
 import initializeSite from "./initialize-site";
 import insertCommentIntoTree from "./insert-comment-into-tree";
 import isAuthPath from "./is-auth-path";
@@ -89,7 +88,6 @@ export {
   getDepthFromComment,
   getIdFromProps,
   getRecipientIdFromProps,
-  getUpdatedSearchId,
   initializeSite,
   insertCommentIntoTree,
   isAuthPath,

--- a/src/shared/utils/helpers/bare-route-push.ts
+++ b/src/shared/utils/helpers/bare-route-push.ts
@@ -1,0 +1,14 @@
+import { RouteComponentProps } from "inferno-router/dist/Route";
+
+// Intended to allow reloading all the data of the current page by clicking the
+// navigation link of the current page.
+export default function bareRoutePush<P extends RouteComponentProps<any>>(
+  prevProps: P,
+  nextProps: P,
+) {
+  return (
+    prevProps.location.pathname === nextProps.location.pathname &&
+    !nextProps.location.search &&
+    nextProps.history.action === "PUSH"
+  );
+}

--- a/src/shared/utils/helpers/index.ts
+++ b/src/shared/utils/helpers/index.ts
@@ -1,3 +1,4 @@
+import bareRoutePush from "./bare-route-push";
 import capitalizeFirstLetter from "./capitalize-first-letter";
 import debounce from "./debounce";
 import editListImmutable from "./edit-list-immutable";
@@ -27,6 +28,7 @@ import dedupByProperty from "./dedup-by-property";
 import getApubName from "./apub-name";
 
 export {
+  bareRoutePush,
   cakeDate,
   capitalizeFirstLetter,
   debounce,


### PR DESCRIPTION
This change can keep components mounted when the next URL matches the current
route. This allows components to keep rendering some resources while reloading
others.

Commit https://github.com/LemmyNet/lemmy-ui/commit/ff5a391fa372b3fbb682e274289a4f85a0f9e0ad contains most of the markup changes without running prettier, the follow up commit is only running prettier.

## Changes
### Home, Community
  - Sidebar stays loaded while reloading posts/comments
  - Community name stays visible while reloading posts/comments
  - Community initially displays community name from URL
 - [HomeCommunity.webm](https://github.com/LemmyNet/lemmy-ui/assets/161147791/1d54c18c-7f44-41ce-9530-4450056dd909) (Side by side, left old, right new)

### Post
  - Post stays loaded while reloading comments.
  - Comment listing type is reflected in URL
  - Comment link changed to `/post/:post_id/:comment_id?` (`/comment/:comment_id` still works)
  - Comment link doesn't change listing type, doesn't reload post
  - Same for "Show context" and "View all comments" buttons
  - Flat comments view works with New and Old, sorted by published
  - [Post.webm](https://github.com/LemmyNet/lemmy-ui/assets/161147791/3dbae774-a801-42c5-be4e-fd8c932a2085)

### Search
  - Doesn't reload Community/User filter while updating search results
  - [Search.webm](https://github.com/LemmyNet/lemmy-ui/assets/161147791/783de97d-f440-4e08-986e-ac034896c2ac)

### Modlog
  - Doesn't reload community name when changing filters
  - [Modlog.webm](https://github.com/LemmyNet/lemmy-ui/assets/161147791/e44069c6-d16b-4680-82a9-cd97013a41a8)

### Profile
  - Keeps showing user info while reloading data
  - Overview, Comments and Posts (are the same request) don't reload data when switching between them
  - [Profile.webm](https://github.com/LemmyNet/lemmy-ui/assets/161147791/9671ba90-c9b9-4fdb-99e4-96b9d6036560)


### Spinners
  - Communities shows spinner below buttons
  - Registration Applications shows spinner below buttons
  - Create Post no longer shows spinner
  - [spinner.webm](https://github.com/LemmyNet/lemmy-ui/assets/161147791/1c9d9bfc-63be-4790-8a35-e9e480af7ebf)

### Prompt
  - <Prompt /> warns before reloading posts/comments when editing post/comment
  - [prompts.webm](https://github.com/LemmyNet/lemmy-ui/assets/161147791/92918a94-9b1f-4777-aa6a-35635964df7b)


### Inbox
  - Fixed issue with high latency responses (this is the only instance where this already was kind of an issue)
  - [highLatency.webm](https://github.com/LemmyNet/lemmy-ui/assets/161147791/1f7c2224-5cb3-4bf3-9e41-4675d4f67f7b) (dev tools set to 3s latency)


### Other changes
  - Move most of componentDidMount to componentWillMount, this avoids updating component states immediately after the first render
  - Include children of auth and anonymous guard in first render.
  - Fix amAdmin check in reports fetchInitialData
  - AdminSettings remove unused currentTab state
