### PR TITLE
Fix 502 error on initial settings page load.

### DIFF
--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -67,7 +67,12 @@ import { PersonListing } from "./person-listing";
 import { InitialFetchRequest } from "../../interfaces";
 import TotpModal from "../common/totp-modal";
 import { LoadingEllipses } from "../common/loading-ellipses";
-import { refreshTheme, setThemeOverride, snapToTop } from "../../utils/browser";
+import {
+  isBrowser,
+  refreshTheme,
+  setThemeOverride,
+  snapToTop,
+} from "../../utils/browser";
 import { getHttpBaseInternal } from "../../utils/env";
 import { IRoutePropsWithFetch } from "../../routes";
 import { RouteComponentProps } from "inferno-router/dist/Route";
@@ -349,16 +354,18 @@ export class Settings extends Component<SettingsRouteProps, SettingsState> {
   }
 
   async componentWillMount() {
-    this.setState({ themeList: await fetchThemeList() });
+    if (isBrowser()) {
+      this.setState({ themeList: await fetchThemeList() });
 
-    if (!this.state.isIsomorphic) {
-      this.setState({
-        instancesRes: LOADING_REQUEST,
-      });
+      if (!this.state.isIsomorphic) {
+        this.setState({
+          instancesRes: LOADING_REQUEST,
+        });
 
-      this.setState({
-        instancesRes: await HttpService.client.getFederatedInstances(),
-      });
+        this.setState({
+          instancesRes: await HttpService.client.getFederatedInstances(),
+        });
+      }
     }
   }
 


### PR DESCRIPTION
- Needed to wrap the fetchThemeList in an isBrowser check.
- Fixes #2497

This was crashing the UI server by trying to fetch the themelist locally, when it doesn't need to.