### PR TITLE
Fix getQueryString

### DIFF
--- a/src/shared/utils/helpers/get-query-string.ts
+++ b/src/shared/utils/helpers/get-query-string.ts
@@ -5,8 +5,9 @@ export default function getQueryString<
   Object.entries(obj)
     .filter(([, val]) => val !== undefined && val !== null)
     .forEach(([key, val]) => searchParams.set(key, val ?? ""));
-  if (searchParams.size) {
-    return "?" + searchParams.toString();
+  const params = searchParams.toString();
+  if (params) {
+    return "?" + params;
   }
   return "";
 }


### PR DESCRIPTION
Browsers without size property for URLSearchParams always returned an empty string.

This could fix the broken inputs on iPadOs https://github.com/LemmyNet/lemmy-ui/issues/2542, as the size property is only available for Safari >= 17.
