### PR TITLE
Fixing modlog filtering to allow admins and mods to filter by mod.

### DIFF
--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -907,8 +907,9 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
             options={userSearchOptions}
             loading={loadingUserSearch}
           />
-          {!this.isoData.site_res.site_view.local_site
-            .hide_modlog_mod_names && (
+          {(this.amAdminOrMod ||
+            !this.isoData.site_res.site_view.local_site
+              .hide_modlog_mod_names) && (
             <Filter
               filterType="mod"
               onChange={this.handleModChange}


### PR DESCRIPTION
- Fixes #2590

## Description

Fixes modlog filtering to allow filtering by mods or admins.

## Screenshots

![Screenshot_20240723_141114_Via](https://github.com/user-attachments/assets/008feebc-f01e-4432-aad0-f9ab9dbbf66a)
