### PR TITLE
Remove trending communities card from home.

### DIFF
--- a/src/shared/components/common/loading-skeleton.tsx
+++ b/src/shared/components/common/loading-skeleton.tsx
@@ -58,40 +58,6 @@ class PostsLoadingSkeletonItem extends Component<any, any> {
   }
 }
 
-export class TrendingCommunitiesLoadingSkeleton extends Component<
-  LoadingSkeletonProps,
-  any
-> {
-  render() {
-    return (
-      <div className="mb-2">
-        {Array.from({ length: this.props.itemCount ?? 10 }, (_, index) => (
-          <TrendingCommunitiesLoadingSkeletonItem key={index} />
-        ))}
-      </div>
-    );
-  }
-}
-
-class TrendingCommunitiesLoadingSkeletonItem extends Component<any, any> {
-  render() {
-    return (
-      <div className="col flex-grow-1 mt-2 ps-2 pe-4">
-        <div className="row">
-          <div className="col flex-grow-0 pe-0">
-            <div className="d-flex placeholder-glow img-icon">
-              <span className="placeholder placeholder-lg w-100 h-100 rounded-circle" />
-            </div>
-          </div>
-          <div className="col flex-grow-1 pe-0">
-            <LoadingSkeletonLine size={12} />
-          </div>
-        </div>
-      </div>
-    );
-  }
-}
-
 export class CommentsLoadingSkeleton extends Component<any, any> {
   render() {
     return Array.from({ length: this.props.itemCount ?? 10 }, (_, index) => (

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -27,7 +27,7 @@ import {
   ghostArchiveUrl,
   postMarkdownFieldCharacterLimit,
   relTags,
-  trendingFetchLimit,
+  similarPostFetchLimit,
   webArchiveUrl,
 } from "../../config";
 import { PostFormParams } from "../../interfaces";
@@ -825,7 +825,7 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
           listing_type: "All",
           community_id: this.state.form.community_id,
           page: 1,
-          limit: trendingFetchLimit,
+          limit: similarPostFetchLimit,
         }),
       });
     }

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -16,7 +16,6 @@ export const webArchiveUrl = "https://web.archive.org";
 export const elementUrl = "https://element.io";
 
 export const postRefetchSeconds: number = 60 * 1000;
-export const trendingFetchLimit = 6;
 export const mentionDropdownFetchLimit = 10;
 export const commentTreeMaxDepth = 8;
 export const postMarkdownFieldCharacterLimit = 50000;
@@ -25,6 +24,7 @@ export const maxUploadImages = 20;
 export const concurrentImageUpload = 4;
 export const updateUnreadCountsInterval = 30000;
 export const fetchLimit = 20;
+export const similarPostFetchLimit = 6;
 export const relTags = "noopener nofollow";
 export const emDash = "\u2014";
 export const authCookieName = "jwt";


### PR DESCRIPTION
- This proved after time to be pointless. I thought about keeping the create and explore communities buttons, but these are already in the navbar, and so just take up more pointless space.
- Fixes #2027
- Fixes #2007

## Description

Removes the trending communities card block from home.

## Screenshots

### Before

![Screenshot_20240729_105943_Via](https://github.com/user-attachments/assets/b8e1e5eb-d34b-4348-a6a0-7d2ffdbcb0e8)


### After

![Screenshot_20240729_105658_Via](https://github.com/user-attachments/assets/b38f903b-c4e8-4fd5-8ba6-dd6d6e502290)
