### PR TITLE
Remove min and max length from password input when using login form

### DIFF
--- a/src/shared/components/common/password-input.tsx
+++ b/src/shared/components/common/password-input.tsx
@@ -99,8 +99,10 @@ class PasswordInput extends Component<PasswordInputProps, PasswordInputState> {
                 onInput={onInput}
                 value={value}
                 required
-                pattern=".{10,60}"
+                pattern=".+"
                 title={I18NextService.i18n.t("invalid_password")}
+                minLength={isNew ? 10 : undefined}
+                maxLength={isNew ? 60 : undefined}
               />
               <button
                 className="btn btn-outline-dark"


### PR DESCRIPTION
Fixes #2381 using @richardARPANET 's suggestion.

Something I noticed working on this is that whitespace is allowed in passwords. This doesn't seem a problem in and of itself, but it's possible to make a password entirely from whitespace. Should this be allowed?