### PR TITLE
Add ability to fill magnet link title on post creation.

### DIFF
--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -45,6 +45,9 @@ import { MarkdownTextArea } from "../common/markdown-textarea";
 import { SearchableSelect } from "../common/searchable-select";
 import { PostListings } from "./post-listings";
 import { isBrowser } from "@utils/browser";
+import isMagnetLink, {
+  extractMagnetLinkDownloadName,
+} from "@utils/media/is-magnet-link";
 
 const MAX_POST_TITLE_LENGTH = 200;
 
@@ -806,10 +809,25 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
   async fetchPageTitle() {
     const url = this.state.form.url;
     if (url && validURL(url)) {
-      this.setState({ metadataRes: LOADING_REQUEST });
-      this.setState({
-        metadataRes: await HttpService.client.getSiteMetadata({ url }),
-      });
+      // If its a magnet link, fill in the download name
+      if (isMagnetLink(url)) {
+        const title = extractMagnetLinkDownloadName(url);
+        if (title) {
+          this.setState({
+            metadataRes: {
+              state: "success",
+              data: {
+                metadata: { title },
+              },
+            },
+          });
+        }
+      } else {
+        this.setState({ metadataRes: LOADING_REQUEST });
+        this.setState({
+          metadataRes: await HttpService.client.getSiteMetadata({ url }),
+        });
+      }
     }
   }
 

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -336,7 +336,8 @@ export function getEmojiMart(
 }
 
 export async function setupTribute() {
-  if (Tribute === null) {
+  // eslint-disable-next-line eqeqeq
+  if (Tribute == null) {
     console.debug("Tribute is null, importing...");
     Tribute = (await import("tributejs")).default;
   }


### PR DESCRIPTION
## Description

This adds the ability to copy the download name from a torrent magnet link on post creation.

## Screenshots

![Screenshot_20240807_131550_Via](https://github.com/user-attachments/assets/753c6068-cc72-42d4-9c0a-5d4fb130711d)
