### PR TITLE
Fix memory leak around emojis on server render

### DIFF
--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -252,6 +252,7 @@ export function setupEmojiDataModel(custom_emoji_views: CustomEmojiView[]) {
     custom_emoji_views,
     x => x.custom_emoji.category,
   );
+  customEmojis.length = 0;
   for (const [category, emojis] of Object.entries(groupedEmojis)) {
     customEmojis.push({
       id: category,


### PR DESCRIPTION
## Description

On serverside render, this customEmojis array gets appended to on every request. This eventually leads to Node.js killing the process for using too much memory.

