### PR TITLE
Fixing peertube and ordinary video embeds.

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -187,6 +187,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             {this.showBody && post.url && post.embed_title && (
               <MetadataCard post={post} />
             )}
+            {this.showBody && this.videoBlock}
             {this.showBody && this.body()}
           </>
         ) : (
@@ -238,29 +239,44 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       </div>
     );
   }
-  get img() {
-    const { post } = this.postView;
-    const { url } = post;
 
-    if (this.isoData.showAdultConsentModal) {
-      return <></>;
-    }
+  get videoBlock() {
+    const post = this.postView.post;
+    const url = post.url;
 
     // if direct video link or embedded video link
-    if (url && (isVideo(url) || post.embed_video_url)) {
+    if (url && isVideo(url)) {
       return (
-        <div className="embed-responsive ratio ratio-16x9 mt-3">
+        <div className="ratio ratio-16x9 mt-3">
           <video
             onLoadStart={linkEvent(this, this.handleVideoLoadStart)}
             onPlay={linkEvent(this, this.handleVideoLoadStart)}
             onVolumeChange={linkEvent(this, this.handleVideoVolumeChange)}
             controls
-            className="embed-responsive-item col-12"
           >
             <source src={post.embed_video_url ?? url} type="video/mp4" />
           </video>
         </div>
       );
+    } else if (post.embed_video_url) {
+      return (
+        <div className="ratio ratio-16x9 mt-3">
+          <iframe
+            title="video embed"
+            src={post.embed_video_url}
+            sandbox="allow-same-origin allow-scripts"
+            allowFullScreen={true}
+          ></iframe>
+        </div>
+      );
+    }
+  }
+
+  get img() {
+    const { post } = this.postView;
+
+    if (this.isoData.showAdultConsentModal) {
+      return <></>;
     }
 
     if (this.imageSrc) {


### PR DESCRIPTION
- Fixes #709

Video embeds were broken before, with this they show in the post:

![Screenshot_20240827_151016_Firefox Nightly](https://github.com/user-attachments/assets/6003c4c8-33a8-4cdc-b81c-9b1660ed3103)
