### PR TITLE
Separating login and register links for must login alert.

### DIFF
--- a/src/shared/components/comment/comment-form.tsx
+++ b/src/shared/components/comment/comment-form.tsx
@@ -74,6 +74,9 @@ export class CommentForm extends Component<CommentFormProps, any> {
               <Link className="alert-link" to="/login">
                 #
               </Link>
+              <Link className="alert-link" to="/signup">
+                #
+              </Link>
             </T>
           </div>
         )}


### PR DESCRIPTION
- Fixes #2624

Now the login and register links are separate. Before the entire block just went to the login page, now there are two links, one for login, the other for register.

## Screenshots

### After

![Screenshot_20240828_151907_Firefox Nightly](https://github.com/user-attachments/assets/d76167f3-a44e-4470-9a7a-0f475cf04ea1)
