### PR TITLE
UX - Swap "Select Language" and "Cancel/Preview/Reply" button locations around in commentsReverse order of buttons in Reply TextArea

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -255,7 +255,6 @@ export class MarkdownTextArea extends Component<
               </label>
             </div>
           </div>
-        </div>
 
           <div className="col-12 d-flex align-items-center flex-wrap mt-2">
             {this.state.previewMode && this.state.content && (

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -257,38 +257,6 @@ export class MarkdownTextArea extends Component<
           </div>
 
           <div className="col-12 d-flex align-items-center flex-wrap mt-2">
-            {this.state.previewMode && this.state.content && (
-                  <div
-                    className="card border-secondary card-body md-div"
-                    dangerouslySetInnerHTML={mdToHtml(this.state.content, () =>
-                      this.forceUpdate(),
-                    )}
-                  />
-                )}
-                {this.state.imageUploadStatus &&
-                  this.state.imageUploadStatus.total > 1 && (
-                    <ProgressBar
-                      className="mt-2"
-                      striped
-                      animated
-                      value={this.state.imageUploadStatus.uploaded}
-                      max={this.state.imageUploadStatus.total}
-                      text={
-                        I18NextService.i18n.t("pictures_uploaded_progess", {
-                          uploaded: this.state.imageUploadStatus.uploaded,
-                          total: this.state.imageUploadStatus.total,
-                        }) ?? undefined
-                      }
-                    />
-                  )}
-              </div>
-              <label className="visually-hidden" htmlFor={this.id}>
-                {I18NextService.i18n.t("body")}
-              </label>
-            </div>
-          </div>
-
-          <div className="col-12 d-flex align-items-center flex-wrap mt-2">
             {this.props.buttonTitle && (
               <button
                 type="submit"

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -281,6 +281,7 @@ export class MarkdownTextArea extends Component<
                       }
                     />
                   )}
+              </div>
               <label className="visually-hidden" htmlFor={this.id}>
                 {I18NextService.i18n.t("body")}
               </label>

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -257,29 +257,46 @@ export class MarkdownTextArea extends Component<
           </div>
 
           <div className="col-12 d-flex align-items-center flex-wrap mt-2">
-            {this.props.showLanguage && (
-              <LanguageSelect
-                iconVersion
-                allLanguages={this.props.allLanguages}
-                selectedLanguageIds={
-                  languageId ? Array.of(languageId) : undefined
-                }
-                siteLanguages={this.props.siteLanguages}
-                onChange={this.handleLanguageChange}
-                disabled={this.isDisabled}
-              />
-            )}
+            {this.state.previewMode && this.state.content && (
+                  <div
+                    className="card border-secondary card-body md-div"
+                    dangerouslySetInnerHTML={mdToHtml(this.state.content, () =>
+                      this.forceUpdate(),
+                    )}
+                  />
+                )}
+                {this.state.imageUploadStatus &&
+                  this.state.imageUploadStatus.total > 1 && (
+                    <ProgressBar
+                      className="mt-2"
+                      striped
+                      animated
+                      value={this.state.imageUploadStatus.uploaded}
+                      max={this.state.imageUploadStatus.total}
+                      text={
+                        I18NextService.i18n.t("pictures_uploaded_progess", {
+                          uploaded: this.state.imageUploadStatus.uploaded,
+                          total: this.state.imageUploadStatus.total,
+                        }) ?? undefined
+                      }
+                    />
+                  )}
+              </div>
+              <label className="visually-hidden" htmlFor={this.id}>
+                {I18NextService.i18n.t("body")}
+              </label>
+            </div>
+          </div>
 
-            {/* A flex expander */}
-            <div className="flex-grow-1"></div>
-
-            {this.props.replyType && (
+          <div className="col-12 d-flex align-items-center flex-wrap mt-2">
+            {this.props.buttonTitle && (
               <button
-                type="button"
+                type="submit"
                 className="btn btn-sm btn-secondary ms-2"
-                onClick={linkEvent(this, this.handleReplyCancel)}
+                disabled={this.isDisabled || !this.state.content}
               >
-                {I18NextService.i18n.t("cancel")}
+                {this.state.loading && <Spinner className="me-1" />}
+                {this.props.buttonTitle}
               </button>
             )}
             <button
@@ -294,15 +311,30 @@ export class MarkdownTextArea extends Component<
                 ? I18NextService.i18n.t("edit")
                 : I18NextService.i18n.t("preview")}
             </button>
-            {this.props.buttonTitle && (
+            {this.props.replyType && (
               <button
-                type="submit"
+                type="button"
                 className="btn btn-sm btn-secondary ms-2"
-                disabled={this.isDisabled || !this.state.content}
+                onClick={linkEvent(this, this.handleReplyCancel)}
               >
-                {this.state.loading && <Spinner className="me-1" />}
-                {this.props.buttonTitle}
+                {I18NextService.i18n.t("cancel")}
               </button>
+            )}
+
+            {/* A flex expander */}
+            <div className="flex-grow-1"></div>
+
+            {this.props.showLanguage && (
+              <LanguageSelect
+                iconVersion
+                allLanguages={this.props.allLanguages}
+                selectedLanguageIds={
+                  languageId ? Array.of(languageId) : undefined
+                }
+                siteLanguages={this.props.siteLanguages}
+                onChange={this.handleLanguageChange}
+                disabled={this.isDisabled}
+              />
             )}
           </div>
         </div>

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -255,6 +255,7 @@ export class MarkdownTextArea extends Component<
               </label>
             </div>
           </div>
+        </div>
 
           <div className="col-12 d-flex align-items-center flex-wrap mt-2">
             {this.state.previewMode && this.state.content && (

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -281,7 +281,6 @@ export class MarkdownTextArea extends Component<
                       }
                     />
                   )}
-              </div>
               <label className="visually-hidden" htmlFor={this.id}>
                 {I18NextService.i18n.t("body")}
               </label>


### PR DESCRIPTION
Fixes #1924

## Description

Title. This solution simply changes the order of the elements in the code. A shorter way would be to make `flex-direction: row-reverse;` but seems a bit overkill...

New to the contribution world, please let me know of any errors ^^

## Screenshots

### Before
![Before](https://github.com/user-attachments/assets/7f98b999-6cbc-4062-8cb2-170a279b8258)


### After
![After](https://github.com/user-attachments/assets/7b728a65-c34d-439e-acf7-3b6622904268)
