### PR TITLE
Renovate should only apply security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,15 @@
   "extends": ["config:recommended"],
   "schedule": ["every weekend"],
   "automerge": true,
-  "ignoreDeps": ["lemmy-js-client"]
+  "ignoreDeps": ["lemmy-js-client"],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": ["*"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
This can avoid accidental breakage from updates like in https://github.com/LemmyNet/joinlemmy-site/issues/431.