### PR TITLE
Fix modlog mod_id filtering not working.

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -78,12 +78,6 @@ commit_parsers = [
 ]
 # filter out the commits that are not matched by commit parsers
 filter_commits = false
-# regex for matching git tags
-tag_pattern = "v[0-9].*"
-# regex for skipping tags
-skip_tags = "beta|alpha"
-# regex for ignoring tags
-ignore_tags = "rc"
 # sort the tags topologically
 topo_order = false
 # sort the commits inside sections by oldest/newest order

--- a/cliff.toml
+++ b/cliff.toml
@@ -78,6 +78,12 @@ commit_parsers = [
 ]
 # filter out the commits that are not matched by commit parsers
 filter_commits = false
+# regex for matching git tags
+tag_pattern = "v[0-9].*"
+# regex for skipping tags
+skip_tags = "beta|alpha"
+# regex for ignoring tags
+ignore_tags = "rc"
 # sort the tags topologically
 topo_order = false
 # sort the commits inside sections by oldest/newest order

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -1058,10 +1058,11 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
       limit: fetchLimit,
       type_: actionType,
       other_person_id: userId,
-      mod_person_id: !this.isoData.site_res.site_view.local_site
-        .hide_modlog_mod_names
-        ? modId
-        : undefined,
+      mod_person_id:
+        this.amAdminOrMod ||
+        !this.isoData.site_res.site_view.local_site.hide_modlog_mod_names
+          ? modId
+          : undefined,
       comment_id: commentId,
       post_id: postId,
     });

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -1058,11 +1058,7 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
       limit: fetchLimit,
       type_: actionType,
       other_person_id: userId,
-      mod_person_id:
-        this.amAdminOrMod ||
-        !this.isoData.site_res.site_view.local_site.hide_modlog_mod_names
-          ? modId
-          : undefined,
+      mod_person_id: modId,
       comment_id: commentId,
       post_id: postId,
     });
@@ -1092,19 +1088,15 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
 
   static async fetchInitialData({
     headers,
-    query: { page, userId, modId: modId_, actionType, commentId, postId },
+    query: { page, userId, modId, actionType, commentId, postId },
     match: {
       params: { communityId: urlCommunityId },
     },
-    site,
   }: InitialFetchRequest<ModlogPathProps, ModlogProps>): Promise<ModlogData> {
     const client = wrapClient(
       new LemmyHttp(getHttpBaseInternal(), { headers }),
     );
     const communityId = getIdFromString(urlCommunityId);
-    const modId = !site.site_view.local_site.hide_modlog_mod_names
-      ? modId_
-      : undefined;
 
     const modlogForm: GetModlog = {
       page,


### PR DESCRIPTION
- Fixes #2794

Okay I've tested this now, and it works.

## Description

Mod ID filtering seemsto be broken, because its relying only on the hide_modlog_names setting.

Example: https://lemmy.ml/modlog?page=1&actionType=All&modId=1438729

The backend results seem to be fine, so this is a UI issue.

https://lemmy.ml/api/v3/modlog?page=1&mod_person_id=1438729

Edit: After this is merged, it needs to be cherry-picked to `release/v0.19`