### PR TITLE
Modify the logic for appending the URL after uploading an image

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -460,12 +460,29 @@ export class MarkdownTextArea extends Component<
     if (res.state === "success") {
       if (res.data.msg === "ok") {
         const imageMarkdown = `![](${res.data.url})`;
-        i.setState(({ content }) => ({
-          content: content ? `${content}\n${imageMarkdown}` : imageMarkdown,
-        }));
+        const textarea: HTMLTextAreaElement = document.getElementById(
+          i.id,
+        ) as HTMLTextAreaElement;
+        const cursorPosition = textarea.selectionStart;
+
+        i.setState(({ content }) => {
+          const currentContent = content || "";
+          return {
+            content:
+              currentContent.slice(0, cursorPosition) +
+              imageMarkdown +
+              currentContent.slice(cursorPosition),
+          };
+        });
+
         i.contentChange();
-        const textarea: any = document.getElementById(i.id);
-        autosize.update(textarea);
+        // Update cursor position to after the inserted image link
+        setTimeout(() => {
+          textarea.selectionStart = cursorPosition + imageMarkdown.length;
+          textarea.selectionEnd = cursorPosition + imageMarkdown.length;
+          autosize.update(textarea);
+        }, 10);
+
         pictrsDeleteToast(image.name, res.data.delete_url as string);
       } else if (res.data.msg === "too_large") {
         toast(I18NextService.i18n.t("upload_too_large"), "danger");


### PR DESCRIPTION
Modify the logic for appending the URL after uploading an image, placing the image URL after the cursor.

## Description

- Use textarea.selectionStart to get the cursor position.
- Use string slicing (slice) to split the content at the cursor position.
- Insert the new content at the cursor position, instead of simply appending it to the end.
- Fixes #765 

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/6d097006-a357-4a44-8f48-8499d402465b)

### After
![image](https://github.com/user-attachments/assets/74e51a38-6197-4e2b-9780-0a113140ccf7)
