### PR TITLE
Enforce required validation on signup Answers 

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -4,6 +4,7 @@ import autosize from "autosize";
 import classNames from "classnames";
 import { NoOptionI18nKeys } from "i18next";
 import { Component, linkEvent } from "inferno";
+import { createElement } from "inferno-create-element";
 import { Prompt } from "inferno-router";
 import { Language } from "lemmy-js-client";
 import {
@@ -52,6 +53,7 @@ interface MarkdownTextAreaProps {
   onSubmit?(content: string, languageId?: number): Promise<boolean>;
   allLanguages: Language[]; // TODO should probably be nullable
   siteLanguages: number[]; // TODO same
+  renderAsDiv?: boolean;
 }
 
 interface ImageUploadStatus {
@@ -114,13 +116,16 @@ export class MarkdownTextArea extends Component<
 
   render() {
     const languageId = this.state.languageId;
-
-    return (
-      <form
-        className="markdown-textarea"
-        id={this.formId}
-        onSubmit={linkEvent(this, this.handleSubmit)}
-      >
+    return createElement(
+      this.props.renderAsDiv ? "div" : "form",
+      {
+        className: "markdown-textarea",
+        id: this.formId,
+        onSubmit: this.props.renderAsDiv
+          ? undefined
+          : linkEvent(this, this.handleSubmit),
+      },
+      <>
         <Prompt
           message={I18NextService.i18n.t("block_leaving")}
           when={
@@ -306,7 +311,7 @@ export class MarkdownTextArea extends Component<
             )}
           </div>
         </div>
-      </form>
+      </>,
     );
   }
 

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -303,6 +303,7 @@ export class Signup extends Component<SignupRouteProps, State> {
                   hideNavigationWarnings
                   allLanguages={[]}
                   siteLanguages={[]}
+                  renderAsDiv={true}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Description
Currently, users can click signup with empty Answer to get API error afterward. This PR enforces browser's required field validation to provide immediate feedback.

## Screenshots

### Before
<img width="1376" alt="ảnh" src="https://github.com/user-attachments/assets/1cb8a02c-7602-4b18-96b2-e08210de647c" />

### After
<img width="731" alt="ảnh" src="https://github.com/user-attachments/assets/79864ee8-aead-4269-adc1-05e6cd58463e" />
