### PR TITLE
Adding a bottom-margin to spoiler details tag.

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -84,6 +84,10 @@ body {
   overflow-x: auto;
 }
 
+.md-div details {
+  margin-bottom: 1rem;
+}
+
 .vote-bar {
   min-width: 5ch;
   margin-top: -6.5px;


### PR DESCRIPTION
- Fixes #2878

## Description

Adds a bottom margin for details.

## Screenshots

![Screenshot_20250105_121728_Kiwi Browser](https://github.com/user-attachments/assets/7851b8ec-178a-4eef-8d61-e4b29224a4e0)
