### PR TITLE
Using video tag for embed video urls that are videos.

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -245,7 +245,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const url = post.url;
 
     // if direct video link or embedded video link
-    if (url && isVideo(url)) {
+    if (url && isVideo(post.embed_video_url ?? url)) {
       return (
         <div className="ratio ratio-16x9 mt-3">
           <video

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -245,7 +245,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     const url = post.url;
 
     // if direct video link or embedded video link
-    if (url && isVideo(post.embed_video_url ?? url)) {
+    if ((url && isVideo(url)) || isVideo(post.embed_video_url ?? "")) {
       return (
         <div className="ratio ratio-16x9 mt-3">
           <video


### PR DESCRIPTION
- Fixes #2826

## Description

If the embed_video is an actual video url, then prefer using the html `<video` over an `<iframe`
