### PR TITLE
Hide NSFW field for create post form, for NSFW communities.

### DIFF
--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -86,6 +86,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
       blocked_instances: this.props.blockedInstances?.map(i => i.domain),
       blocked_urls: this.props.siteRes.blocked_urls.map(u => u.url),
       content_warning: this.props.siteRes.site_view.site.content_warning,
+      enable_nsfw: !!this.props.siteRes.site_view.site.content_warning,
     };
   }
 
@@ -908,6 +909,9 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
 
   handleSiteEnableNsfwChange(i: SiteForm, event: any) {
     i.state.siteForm.enable_nsfw = event.target.checked;
+    if (!event.target.checked) {
+      i.state.siteForm.content_warning = "";
+    }
     i.setState(i.state);
   }
 
@@ -1025,6 +1029,10 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
   }
 
   handleSiteContentWarningChange(val: string) {
-    this.setState(s => ((s.siteForm.content_warning = val), s));
+    this.state.siteForm.content_warning = val;
+    if (val) {
+      this.state.siteForm.enable_nsfw = true;
+    }
+    this.setState(this.state);
   }
 }

--- a/src/shared/components/post/create-post.tsx
+++ b/src/shared/components/post/create-post.tsx
@@ -89,6 +89,7 @@ interface CreatePostState {
   siteRes: GetSiteResponse;
   loading: boolean;
   selectedCommunityChoice?: Choice;
+  selectedCommunityIsNsfw: boolean;
   initialCommunitiesRes: RequestState<ListCommunitiesResponse>;
   isIsomorphic: boolean;
   resetCounter: number; // resets PostForm when changed
@@ -115,6 +116,7 @@ export class CreatePost extends Component<
     initialCommunitiesRes: EMPTY_REQUEST,
     isIsomorphic: false,
     resetCounter: 0,
+    selectedCommunityIsNsfw: false,
   };
 
   constructor(props: CreatePostRouteProps, context: any) {
@@ -165,6 +167,7 @@ export class CreatePost extends Component<
       if (res.state === "success") {
         this.setState({
           selectedCommunityChoice: communityToChoice(res.data.community_view),
+          selectedCommunityIsNsfw: res.data.community_view.community.nsfw,
           loading: false,
         });
       }
@@ -229,7 +232,12 @@ export class CreatePost extends Component<
   }
 
   render() {
-    const { selectedCommunityChoice, siteRes, loading } = this.state;
+    const {
+      selectedCommunityChoice,
+      selectedCommunityIsNsfw,
+      siteRes,
+      loading,
+    } = this.state;
     const {
       body,
       communityId,
@@ -286,6 +294,7 @@ export class CreatePost extends Component<
               onNsfwChange={this.handleNsfwChange}
               onAltTextBlur={this.handleAltTextBlur}
               onCopySuggestedTitle={this.handleCopySuggestedTitle}
+              isNsfwCommunity={selectedCommunityIsNsfw}
             />
           </div>
         </div>

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -69,6 +69,7 @@ interface PostFormProps {
   enableDownvotes?: boolean;
   voteDisplayMode: LocalUserVoteDisplayMode;
   selectedCommunityChoice?: Choice;
+  isNsfwCommunity: boolean;
   onSelectCommunity?: (choice: Choice) => void;
   initialCommunities?: CommunityView[];
   loading: boolean;
@@ -694,7 +695,7 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
             </div>
           </div>
         )}
-        {this.props.enableNsfw && (
+        {this.props.enableNsfw && !this.props.isNsfwCommunity && (
           <div className="form-check mb-3">
             <input
               className="form-check-input"

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -202,6 +202,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             allLanguages={this.props.allLanguages}
             siteLanguages={this.props.siteLanguages}
             loading={this.state.loading}
+            isNsfwCommunity={this.postView.community.nsfw}
           />
         )}
       </div>


### PR DESCRIPTION
- Fixes #2885

## Description

Hides the NSFW field on create post for NSFW communities.

A back-end PR will also handle making that a default.

## Screenshots

![Screenshot_20250107_165941_Kiwi Browser](https://github.com/user-attachments/assets/97eb79aa-37a7-49e1-aa7d-a89e61a93b64)
