### PR TITLE
Fixing login password limits.

### DIFF
--- a/src/shared/components/common/password-input.tsx
+++ b/src/shared/components/common/password-input.tsx
@@ -103,8 +103,8 @@ class PasswordInput extends Component<PasswordInputProps, PasswordInputState> {
                 required={required !== false}
                 pattern=".+"
                 title={I18NextService.i18n.t("invalid_password")}
-                minLength={isNew ? 10 : undefined}
-                maxLength={isNew ? 60 : undefined}
+                minLength={10}
+                maxLength={60}
               />
               <button
                 className="btn btn-outline-dark"


### PR DESCRIPTION
- Fixes #2886

## Description

See linked issue.

@SleeplessOne1917 the only other case where `isNew` is used, is for autoComplete:

`autoComplete={isNew ? "new-password" : "current-password"}`