### PR TITLE
Add crawl-delay to robots.txt

### DIFF
--- a/src/server/handlers/robots-handler.ts
+++ b/src/server/handlers/robots-handler.ts
@@ -16,7 +16,5 @@ export default async ({ res }: { res: Response }) => {
   Disallow: /password_change
   Disallow: /search/
   Disallow: /modlog
-  
-  User-Agent: *
   Crawl-delay: 60`);
 };

--- a/src/server/handlers/robots-handler.ts
+++ b/src/server/handlers/robots-handler.ts
@@ -16,5 +16,7 @@ export default async ({ res }: { res: Response }) => {
   Disallow: /password_change
   Disallow: /search/
   Disallow: /modlog
-  `);
+  
+  User-Agent: *
+  Crawl-delay: 60`);
 };


### PR DESCRIPTION
This should prevent the various crawlers from overloading Lemmy instances. It is not officially part of robots.txt spec but many crawlers support it.

https://stackoverflow.com/a/9130248
https://imagesift.com/about