### PR TITLE
Add linkify user @ mentions

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -43,9 +43,10 @@ const queryPairRegex = "[a-zA-Zd_-]+=[a-zA-Zd+-_]+";
  * /c/community@server.com
  * /m/community@server.com
  * /u/username@server.com
+ * @username@server.com
  */
 export const instanceLinkRegex = new RegExp(
-  `(/[cmu]/|!)[a-zA-Z\\d._%+-]+@[a-zA-Z\\d.-]+\\.[a-zA-Z]{2,}(?:/?\\?${queryPairRegex}(?:&${queryPairRegex})*)?`,
+  `(/[cmu]/|!|@)[a-zA-Z\\d._%+-]+@[a-zA-Z\\d.-]+\\.[a-zA-Z]{2,}(?:/?\\?${queryPairRegex}(?:&${queryPairRegex})*)?`,
   "g",
 );
 

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -120,6 +120,9 @@ function localInstanceLinkParser(md: MarkdownIt) {
             let href: string;
             if (match[0].startsWith("!")) {
               href = "/c/" + match[0].substring(1);
+            } else if (match[0].startsWith("@")) {
+              href = "/u/" + match[0].substring(1);
+              linkClass = "user-link";
             } else if (match[0].startsWith("/m/")) {
               href = "/c/" + match[0].substring(3);
             } else {


### PR DESCRIPTION
## Description

The UI will now linkify @ user mentions of the format `@username@server.com` to point to the user's page, e.g. `https://example.com/u/user@server.com`

Fixes #2019

Fixes #2579 

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/29ca62b6-e373-4d40-b087-d0aa2faf8e03)

### After

![image](https://github.com/user-attachments/assets/fd02c3e9-ad11-4748-80f2-7b6dcf29ec2d)
