### PR TITLE
Add banned badges to post and comment listings

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -224,6 +224,8 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 isMod={creator_is_moderator}
                 isAdmin={creator_is_admin}
                 isBot={cv.creator.bot_account}
+                isBanned={cv.creator.banned}
+                isBannedFromCommunity={cv.creator_banned_from_community}
               />
 
               {this.props.showCommunity && (

--- a/src/shared/components/common/modal/view-votes-modal.tsx
+++ b/src/shared/components/common/modal/view-votes-modal.tsx
@@ -53,7 +53,8 @@ function voteViewTable(votes: VoteView[]) {
                   classNames="ms-1"
                   isBot={v.creator.bot_account}
                   isDeleted={v.creator.deleted}
-                  isBanned={v.creator.banned || v.creator_banned_from_community}
+                  isBanned={v.creator.banned}
+                  isBannedFromCommunity={v.creator_banned_from_community}
                 />
               </td>
               <td className="text-end">{scoreToIcon(v.score)}</td>

--- a/src/shared/components/common/user-badges.tsx
+++ b/src/shared/components/common/user-badges.tsx
@@ -5,6 +5,7 @@ import { tippyMixin } from "../mixins/tippy-mixin";
 
 interface UserBadgesProps {
   isBanned?: boolean;
+  isBannedFromCommunity?: boolean;
   isDeleted?: boolean;
   isPostCreator?: boolean;
   isMod?: boolean;
@@ -40,6 +41,7 @@ export class UserBadges extends Component<UserBadgesProps> {
   render() {
     return (
       (this.props.isBanned ||
+        this.props.isBannedFromCommunity ||
         this.props.isPostCreator ||
         this.props.isMod ||
         this.props.isAdmin ||
@@ -55,6 +57,16 @@ export class UserBadges extends Component<UserBadgesProps> {
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("banned"),
                 tooltip: I18NextService.i18n.t("banned"),
+                classes: "text-danger border border-danger",
+                shrink: false,
+              })}
+            </span>
+          )}
+          {this.props.isBannedFromCommunity && (
+            <span className="col">
+              {getRoleLabelPill({
+                label: I18NextService.i18n.t("banned_from_community_badge"),
+                tooltip: I18NextService.i18n.t("banned_from_community_badge"),
                 classes: "text-danger border border-danger",
                 shrink: false,
               })}

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -426,6 +426,8 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           isMod={pv.creator_is_moderator}
           isAdmin={pv.creator_is_admin}
           isBot={pv.creator.bot_account}
+          isBanned={pv.creator.banned}
+          isBannedFromCommunity={pv.creator_banned_from_community}
         />
         {this.props.showCommunity && (
           <>


### PR DESCRIPTION
## Description

Adds a new badge for "Banned from community", and adds the two banned badges to post listings and comment listings

- Fixes #2743
- Fixes #2095

- Requires https://github.com/LemmyNet/lemmy-translations/pull/158

## Screenshots

<details>
  <summary>Before/After Main Page</summary>

### Before

![before](https://github.com/user-attachments/assets/101c4543-eca8-473a-83eb-9108abd161f3)

### After
![after](https://github.com/user-attachments/assets/9c1f47cc-7b0a-4b01-810c-4f629385d324)
</details>

<details>
  <summary>Before/After Banned User Profile</summary>

### Before
![before_banned_profile](https://github.com/user-attachments/assets/62dadd37-8bfc-46dc-9103-6a19b52bb4e7)

### After
![after_banned_profile](https://github.com/user-attachments/assets/bd9709be-8afd-4571-a879-16b0e6e7d50e)
</details>

<details>
  <summary>Before/After Banned User Comment</summary>

### Before
![before_banned_comment](https://github.com/user-attachments/assets/dbd6a609-574e-4cfd-9512-ab2d98c2d32d)

### After
![after_comment_banned](https://github.com/user-attachments/assets/703eb191-0a60-49d6-9091-5c0ee1094a9b)
</details>

<details>
  <summary>Before/After Moderator Vote View</summary>

### Before
![before_vote_view](https://github.com/user-attachments/assets/bd5f547e-6f31-45ed-be32-fbf80a924e12)

### After
![after_vote_view](https://github.com/user-attachments/assets/316ba50f-f6f3-4854-96e6-2483f3159f28)
</details>