### PR TITLE
Add support for using Lemmy UI with an external Lemmy instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ Based off of MrFoxPro's [inferno-isomorphic-template](https://github.com/MrFoxPr
 
 The following environment variables can be used to configure lemmy-ui:
 
-| `ENV_VAR`                      | type     | default          | description                                                                         |
-| ------------------------------ | -------- | ---------------- | ----------------------------------------------------------------------------------- |
-| `LEMMY_UI_HOST`                | `string` | `0.0.0.0:1234`   | The IP / port that the lemmy-ui isomorphic node server is hosted at.                |
-| `LEMMY_UI_LEMMY_INTERNAL_HOST` | `string` | `0.0.0.0:8536`   | The internal IP / port that lemmy is hosted at. Often `lemmy:8536` if using docker. |
-| `LEMMY_UI_LEMMY_EXTERNAL_HOST` | `string` | `0.0.0.0:8536`   | The external IP / port that lemmy is hosted at. Often `DOMAIN.TLD`.                 |
-| `LEMMY_UI_HTTPS`               | `bool`   | `false`          | Whether to use https.                                                               |
-| `LEMMY_UI_EXTRA_THEMES_FOLDER` | `string` | `./extra_themes` | A location for additional lemmy css themes.                                         |
-| `LEMMY_UI_DEBUG`               | `bool`   | `false`          | Loads the [Eruda](https://github.com/liriliri/eruda) debugging utility.             |
-| `LEMMY_UI_DISABLE_CSP`         | `bool`   | `false`          | Disables CSP security headers                                                       |
-| `LEMMY_UI_CUSTOM_HTML_HEADER`  | `string` |                  | Injects a custom script into `<head>`.                                              |
+| `ENV_VAR`                        | type     | default          | description                                                                         |
+|----------------------------------|----------|------------------|-------------------------------------------------------------------------------------|
+| `LEMMY_UI_HOST`                  | `string` | `0.0.0.0:1234`   | The IP / port that the lemmy-ui isomorphic node server is hosted at.                |
+| `LEMMY_UI_LEMMY_INTERNAL_HOST`   | `string` | `0.0.0.0:8536`   | The internal IP / port that lemmy is hosted at. Often `lemmy:8536` if using docker. |
+| `LEMMY_UI_LEMMY_EXTERNAL_HOST`   | `string` | `0.0.0.0:8536`   | The external IP / port that lemmy is hosted at. Often `DOMAIN.TLD`.                 |
+| `LEMMY_UI_LEMMY_EXTERNAL_DOMAIN` | `bool`   | `false`          | If the Lemmy server/backend is hosted on a different domain, this must be enabled.  |
+| `LEMMY_UI_HTTPS`                 | `bool`   | `false`          | Whether to use https.                                                               |
+| `LEMMY_UI_EXTRA_THEMES_FOLDER`   | `string` | `./extra_themes` | A location for additional lemmy css themes.                                         |
+| `LEMMY_UI_DEBUG`                 | `bool`   | `false`          | Loads the [Eruda](https://github.com/liriliri/eruda) debugging utility.             |
+| `LEMMY_UI_DISABLE_CSP`           | `bool`   | `false`          | Disables CSP security headers                                                       |
+| `LEMMY_UI_CUSTOM_HTML_HEADER`    | `string` |                  | Injects a custom script into `<head>`.                                              |

--- a/src/shared/utils/env/get-external-host.ts
+++ b/src/shared/utils/env/get-external-host.ts
@@ -2,19 +2,15 @@ import { isBrowser } from "@utils/browser";
 import { testHost } from "../../config";
 
 export default function getExternalHost() {
-  const externalDomains = process.env.LEMMY_UI_LEMMY_EXTERNAL_DOMAIN === "true";
-
-  if (externalDomains) {
-    return process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST;
-  } else {
-    return isBrowser()
-      ? `${window.location.hostname}${
+  return isBrowser()
+    ? process.env.LEMMY_UI_LEMMY_EXTERNAL_DOMAIN === "true"
+      ? process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST
+      : `${window.location.hostname}${
           ["1234", "1235"].includes(window.location.port)
             ? ":8536"
             : window.location.port === ""
               ? ""
               : `:${window.location.port}`
         }`
-      : process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST || testHost;
-  }
+    : process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST || testHost;
 }

--- a/src/shared/utils/env/get-external-host.ts
+++ b/src/shared/utils/env/get-external-host.ts
@@ -2,13 +2,19 @@ import { isBrowser } from "@utils/browser";
 import { testHost } from "../../config";
 
 export default function getExternalHost() {
-  return isBrowser()
-    ? `${window.location.hostname}${
-        ["1234", "1235"].includes(window.location.port)
-          ? ":8536"
-          : window.location.port === ""
-            ? ""
-            : `:${window.location.port}`
-      }`
-    : process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST || testHost;
+  const externalDomains = process.env.LEMMY_UI_LEMMY_EXTERNAL_DOMAIN === "true";
+
+  if (externalDomains) {
+    return process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST;
+  } else {
+    return isBrowser()
+      ? `${window.location.hostname}${
+          ["1234", "1235"].includes(window.location.port)
+            ? ":8536"
+            : window.location.port === ""
+              ? ""
+              : `:${window.location.port}`
+        }`
+      : process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST || testHost;
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,6 +86,12 @@ module.exports = (env, argv) => {
       new webpack.DefinePlugin({
         "process.env.COMMIT_HASH": `"${env.COMMIT_HASH}"`,
         "process.env.NODE_ENV": `"${mode}"`,
+        "process.env.LEMMY_UI_LEMMY_EXTERNAL_DOMAIN": JSON.stringify(
+          process.env.LEMMY_UI_LEMMY_EXTERNAL_DOMAIN,
+        ),
+        "process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST": JSON.stringify(
+          process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST,
+        ),
       }),
       new MiniCssExtractPlugin({
         filename: "styles/styles.css",


### PR DESCRIPTION
## Description

As discussed in the Lemmy docs PR (https://github.com/LemmyNet/lemmy-docs/pull/360), this adds support for using the Lemmy UI with an external Lemmy instance.

This PR, combined with the documentation PR, will fix:
- https://github.com/LemmyNet/lemmy/issues/2608
- https://github.com/LemmyNet/lemmy/issues/3400
- https://github.com/LemmyNet/lemmy/issues/3840

This adds `LEMMY_UI_LEMMY_EXTERNAL_DOMAIN` as a new environment variable that can be configured to either `true` or `false`.

## Testing
Lemmy UI was tested with the following consistent environment variables:
```sh
LEMMY_UI_LEMMY_INTERNAL_HOST=192.168.4.235:8536 LEMMY_UI_LEMMY_EXTERNAL_HOST=sol.mn LEMMY_UI_HTTPS=true pnpm dev
```
Additionally, the environment variable `LEMMY_UI_LEMMY_EXTERNAL_DOMAIN` was appended and the value was changed for testing.
| Environment variable | Can connect to external Lemmy server? |
|--------|--------|
| `LEMMY_UI_LEMMY_EXTERNAL_DOMAIN` was not set | false |
| `LEMMY_UI_LEMMY_EXTERNAL_DOMAIN=false` | false |
| `LEMMY_UI_LEMMY_EXTERNAL_DOMAIN=true` | true |  

Part of the testing process was to look at the browser's console and network activity. Everything works as expected, and there were no apparent issues found when testing manually.

<!-- Please describe exactly what this PR changes, including URLs and issue
numbers. If it fixes an issue, add "Fixes #XXXX" -->

## Screenshots
![image](https://github.com/user-attachments/assets/730c1f74-e125-487a-bf08-103bc811e986)

Users can login to a Lemmy server that is not running on the same domain, as shown in this image. Posts have been blurred.