### PR TITLE
Trigger toast error on community request failure

### DIFF
--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -9,6 +9,7 @@ import { HtmlTags } from "../common/html-tags";
 import { CommunityForm } from "./community-form";
 import { simpleScrollMixin } from "../mixins/scroll-mixin";
 import { RouteComponentProps } from "inferno-router/dist/Route";
+import { toast } from "../../toast";
 
 interface CreateCommunityState {
   siteRes: GetSiteResponse;
@@ -75,6 +76,9 @@ export class CreateCommunity extends Component<
       });
       const name = res.data.community_view.community.name;
       this.props.history.replace(`/c/${name}`);
+    } else if (res.state === "failed") {
+      toast(I18NextService.i18n.t(res.err.message), "danger");
+      this.setState({ loading: false });
     } else {
       this.setState({ loading: false });
     }


### PR DESCRIPTION
## Description
I tried to create a community and used a duplicate name. I found it a little confusing that I didn't get any error feedback. I tried to keep the error flow consistent with other code in the repo
-Fixes https://github.com/LemmyNet/lemmy-ui/issues/2348
-Fixes https://github.com/LemmyNet/lemmy-ui/issues/1374 (This looks like a duplicate)

## Screenshots

![image](https://github.com/user-attachments/assets/f82ec9ce-9c81-4362-b7a9-bc38ad6ca3ff)
