### PR TITLE
Hide images in private message reports

### DIFF
--- a/src/shared/components/private_message/private-message-report.tsx
+++ b/src/shared/components/private_message/private-message-report.tsx
@@ -4,7 +4,7 @@ import {
   PrivateMessageReportView,
   ResolvePrivateMessageReport,
 } from "lemmy-js-client";
-import { mdToHtml } from "../../markdown";
+import { mdToHtmlNoImages } from "../../markdown";
 import { I18NextService } from "../../services";
 import { Icon, Spinner } from "../common/icon";
 import { PersonListing } from "../person/person-listing";
@@ -54,8 +54,9 @@ export class PrivateMessageReport extends Component<Props, State> {
           {I18NextService.i18n.t("message")}:
           <div
             className="md-div"
-            dangerouslySetInnerHTML={mdToHtml(pmr.original_pm_text, () =>
-              this.forceUpdate(),
+            dangerouslySetInnerHTML={mdToHtmlNoImages(
+              pmr.original_pm_text,
+              () => this.forceUpdate(),
             )}
           />
         </div>


### PR DESCRIPTION
Looks like post-report and comment-report already hide images using [hideImages](https://github.com/LemmyNet/lemmy-ui/blob/main/src/shared/components/post/post-report.tsx#L87) param.

The disadvantage with this is that the images are not rendered at all, not even as plain link. So there is no way to view the image or even to know that it is there.