### PR TITLE
Hide RSS button for Uploads view on profile page

### DIFF
--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -614,19 +614,20 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
             hideMostComments
           />
         </div>
-        {/* Don't show the rss feed for the Saved view, as that's not implemented.*/}
-        {view !== PersonDetailsView.Saved && (
-          <div className="col-auto">
-            <a href={profileRss} rel={relTags} title="RSS">
-              <Icon icon="rss" classes="text-muted small ps-0" />
-            </a>
-            <link
-              rel="alternate"
-              type="application/atom+xml"
-              href={profileRss}
-            />
-          </div>
-        )}
+        {/* Don't show the rss feed for the Saved and Uploads view, as that's not implemented.*/}
+        {view !== PersonDetailsView.Saved &&
+          view !== PersonDetailsView.Uploads && (
+            <div className="col-auto">
+              <a href={profileRss} rel={relTags} title="RSS">
+                <Icon icon="rss" classes="text-muted small ps-0" />
+              </a>
+              <link
+                rel="alternate"
+                type="application/atom+xml"
+                href={profileRss}
+              />
+            </div>
+          )}
       </div>
     );
   }


### PR DESCRIPTION
## Description

RSS feeds are not implemented for uploads, and it wouldn't make sense to, similarly to saved posts as discussed in #2438

## Screenshots

### Before

![rss_before](https://github.com/user-attachments/assets/244023b4-1968-43b3-a0ee-46c7bf906ad8)

### After

![rss_after](https://github.com/user-attachments/assets/c5537ed2-dec6-499f-9420-88921830fd94)