### PR TITLE
Show upvoted posts, comments in user's profile

### DIFF
--- a/src/shared/components/person/person-details.tsx
+++ b/src/shared/components/person/person-details.tsx
@@ -342,22 +342,24 @@ export class PersonDetails extends Component<PersonDetailsProps, any> {
 
   upvoted() {
     let id = 0;
-    const comments: ItemType[] = this.props.likedCommentsRes.comments.map(
-      r => ({
-        id: id++,
-        type_: ItemEnum.Comment,
-        view: r,
-        published: r.comment.published,
-        score: r.counts.score,
-      }),
-    );
-    const posts: ItemType[] = this.props.likedPostsRes.posts.map(r => ({
-      id: id++,
-      type_: ItemEnum.Post,
-      view: r,
-      published: r.post.published,
-      score: r.counts.score,
-    }));
+    const comments: ItemType[] = this.props.likedCommentsRes
+      ? this.props.likedCommentsRes.comments.map(r => ({
+          id: id++,
+          type_: ItemEnum.Comment,
+          view: r,
+          published: r.comment.published,
+          score: r.counts.score,
+        }))
+      : [];
+    const posts: ItemType[] = this.props.likedPostsRes
+      ? this.props.likedPostsRes.posts.map(r => ({
+          id: id++,
+          type_: ItemEnum.Post,
+          view: r,
+          published: r.post.published,
+          score: r.counts.score,
+        }))
+      : [];
 
     const combined = [...comments, ...posts];
 

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -75,10 +75,6 @@ export enum PersonDetailsView {
   Posts = "Posts",
   Saved = "Saved",
   Uploads = "Uploads",
-}
-
-export enum PersonDetailsFilter {
-  Own = "Own",
   Upvoted = "Upvoted",
 }
 

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -77,6 +77,11 @@ export enum PersonDetailsView {
   Uploads = "Uploads",
 }
 
+export enum PersonDetailsFilter {
+  Own = "Own",
+  Upvoted = "Upvoted",
+}
+
 export enum PurgeType {
   Person,
   Community,


### PR DESCRIPTION
## Description

Adds an option to view upvoted posts/comments in the Overview, Posts, and Comments views in the user's own profile.

The option is implemented as a separate row of buttons containing `Own` and `Upvoted` to show the user's own posts/comments or show the posts/comments the user upvoted, respectively.

The buttons are only shown in the user's own profile, and not in the `Saved` and `Uploads` views either.

The value of the buttons is stored in the URL as `&filter=`, similarly to `&view=`.

-Fixes #1673
-Fixes #2443

## Questions & notes
 1. In spite of what #2443 claims, `disliked_only` to fetch downvoted posts/comments is not implemented AFAIK. (A separate issue for `Downvoted` should be opened?)
 1. I think it's better like this, with separate buttons rather than new views (such as `Upvoted Posts` and `Upvoted Comments`), especially if `Downvoted` gets implemented in the future. But I can reimplement it as views, if requested.
 1. `Own` should be called something else... `My own`... `My posts/comments`... `By me` ... `???` (I can open a lemmy-translations PR when decided)
 1. Perhaps RSS shouldn't be displayed if the filter is set to `Upvoted`?

## Screenshots

<details>
  <summary>Before/After Overview</summary>

### Before
![before_overview](https://github.com/user-attachments/assets/334561d9-a70d-493a-abfb-9bec01cfc4ac)

### After
![after_overview_1](https://github.com/user-attachments/assets/c2118ea6-5693-423c-bbdd-3ba3cfd6e69d)
![after_overview_2](https://github.com/user-attachments/assets/6255418c-7da3-4494-9611-b031a6565313)

</details>


<details>
  <summary>Before/After Comments</summary>

### Before
![before_comments](https://github.com/user-attachments/assets/0642cd47-8f70-42ed-b94c-efc24efb989f)

### After
![after_comments_1](https://github.com/user-attachments/assets/388f1ddd-6918-4987-aba1-0cdf21a2bfce)

![after_comments_2](https://github.com/user-attachments/assets/8bbdac1b-4538-4405-9335-8e4efba5f967)

</details>


<details>
  <summary>Before/After Posts</summary>

### Before
![before_posts](https://github.com/user-attachments/assets/38ad5bd7-7e83-421a-8ce7-bc5276ce874f)

### After
![after_posts_1](https://github.com/user-attachments/assets/cd9f1aba-dc57-4a17-b718-7fc613192ac2)
![after_posts_2](https://github.com/user-attachments/assets/f9a9a278-635e-45c7-8875-f3acde96574a)

</details>