### PR TITLE
Only show View registration button to admins on profiles of local users

### DIFF
--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -763,7 +763,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
                       {capitalizeFirstLetter(I18NextService.i18n.t("unban"))}
                     </button>
                   ))}
-                {amAdmin() && (
+                {amAdmin() && pv.person.local && (
                   <>
                     <button
                       className={


### PR DESCRIPTION
## Description

fixes #3070

## Screenshots

![image](https://github.com/user-attachments/assets/eff4df63-1de8-4090-812b-befd76a4882a)

Screenshot is from 0.19 backport - I don't currently have a test instance for main.

### Before
See #3070

### After
See above