### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
-FROM node:alpine as builder
+# syntax=docker/dockerfile:1
+
+FROM node:alpine AS builder
+
+ARG TARGETARCH
 
 # Added vips-dev and pkgconfig so that local vips is used instead of prebuilt
 # Done for two reasons:
 # - libvips binaries are not available for ARM32
 # - It can break depending on the CPU (https://github.com/LemmyNet/lemmy-ui/issues/1566)
-RUN apk update && apk upgrade && apk add --no-cache curl python3 build-base gcc wget git vips-dev pkgconfig
+RUN \
+    --mount=type=cache,target=/var/cache/apk,id=apk-${TARGETARCH},sharing=private \
+    set -x && apk update && apk upgrade && apk add curl python3 build-base gcc wget git vips-dev pkgconfig
 
 # Install node-gyp and corepack
-RUN npm install -g node-gyp corepack
+RUN \
+    --mount=type=cache,target=/root/.npm \
+    npm install -g node-gyp corepack
 
 # Enable corepack to use pnpm
 RUN corepack enable
@@ -19,7 +27,9 @@ ENV npm_config_target_libc=musl
 
 # Cache deps
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm i
+RUN \
+    --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm i
 # Build
 COPY generate_translations.js \
   tsconfig.json \
@@ -35,23 +45,34 @@ COPY .git .git
 RUN echo "export const VERSION = '$(git describe --tag)';" > "src/shared/version.ts"
 RUN echo "export const BUILD_DATE_ISO8601 = '$(date -u +"%Y-%m-%dT%H:%M:%SZ")';" > "src/shared/build-date.ts"
 
-RUN pnpm i
-RUN pnpm prebuild:prod
-RUN pnpm build:prod
+RUN \
+    --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm i
+RUN \
+    --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm prebuild:prod
+RUN \
+    --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm build:prod
 
 RUN rm -rf ./node_modules/import-sort-parser-typescript
 RUN rm -rf ./node_modules/typescript
 RUN rm -rf ./node_modules/npm
 
-FROM node:alpine as runner
+FROM node:alpine AS runner
+
+ARG TARGETARCH
+
 ENV NODE_ENV=production
 
-RUN apk update && apk add --no-cache curl vips-cpp && rm -rf /var/cache/apk/*
+RUN \
+    --mount=type=cache,target=/var/cache/apk,id=apk-${TARGETARCH},sharing=private \
+    apk update && apk add curl vips-cpp
 
-COPY --from=builder /usr/src/app/dist /app/dist
-COPY --from=builder /usr/src/app/node_modules /app/node_modules
+COPY --from=builder --chown=node:node /usr/src/app/dist /app/dist
+COPY --from=builder --chown=node:node /usr/src/app/node_modules /app/node_modules
 
-RUN chown -R node:node /app
+RUN chown node:node /app
 
 LABEL org.opencontainers.image.authors="The Lemmy Authors"
 LABEL org.opencontainers.image.source="https://github.com/LemmyNet/lemmy-ui"


### PR DESCRIPTION
## Description

- use cache mounts for package managers to allow reuse
- chown in COPY to final stage to avoid updating files again
- fix inconsistent capitalization in FROM/AS

This also almost halves the image size, as a separate chown after a COPY results in an additional layer, which duplicates all chowned files with updated ownerships.
It also reduces build time, especially in environments with slower storage, as the separate chown step also has to iterate over the entire directory tree.

References:

- https://docs.docker.com/reference/dockerfile/#syntax
- https://docs.docker.com/build/cache/optimize/#use-cache-mounts
- https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
- https://docs.docker.com/reference/build-checks/from-as-casing/

### Before

`docker image ls lemmy-ui:main`
```
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
lemmy-ui     main      9371cf45e389   2 minutes ago   1.64GB
```
`docker image history lemmy-ui:main`
```
IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
9371cf45e389   48 seconds ago       CMD ["node" "dist/js/server.js"]                0B        buildkit.dockerfile.v0
<missing>      48 seconds ago       WORKDIR /app                                    4.1kB     buildkit.dockerfile.v0
<missing>      49 seconds ago       EXPOSE map[1234/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      49 seconds ago       USER node                                       0B        buildkit.dockerfile.v0
<missing>      49 seconds ago       HEALTHCHECK &{["CMD-SHELL" "curl -ILfSs http…   0B        buildkit.dockerfile.v0
<missing>      49 seconds ago       LABEL org.opencontainers.image.description=T…   0B        buildkit.dockerfile.v0
<missing>      49 seconds ago       LABEL org.opencontainers.image.licenses=AGPL…   0B        buildkit.dockerfile.v0
<missing>      49 seconds ago       LABEL org.opencontainers.image.source=https:…   0B        buildkit.dockerfile.v0
<missing>      49 seconds ago       LABEL org.opencontainers.image.authors=The L…   0B        buildkit.dockerfile.v0
<missing>      49 seconds ago       RUN /bin/sh -c chown -R node:node /app # bui…   600MB     buildkit.dockerfile.v0
<missing>      About a minute ago   COPY /usr/src/app/node_modules /app/node_mod…   521MB     buildkit.dockerfile.v0
<missing>      2 minutes ago        COPY /usr/src/app/dist /app/dist # buildkit     16.2MB    buildkit.dockerfile.v0
<missing>      8 days ago           RUN /bin/sh -c apk update && apk add --no-ca…   53.7MB    buildkit.dockerfile.v0
<missing>      8 days ago           ENV NODE_ENV=production                         0B        buildkit.dockerfile.v0
<missing>      2 weeks ago          CMD ["node"]                                    0B        buildkit.dockerfile.v0
<missing>      2 weeks ago          ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      2 weeks ago          COPY docker-entrypoint.sh /usr/local/bin/ # …   20.5kB    buildkit.dockerfile.v0
<missing>      2 weeks ago          RUN /bin/sh -c apk add --no-cache --virtual …   5.48MB    buildkit.dockerfile.v0
<missing>      2 weeks ago          ENV YARN_VERSION=1.22.22                        0B        buildkit.dockerfile.v0
<missing>      2 weeks ago          RUN /bin/sh -c addgroup -g 1000 node     && …   157MB     buildkit.dockerfile.v0
<missing>      2 weeks ago          ENV NODE_VERSION=23.11.0                        0B        buildkit.dockerfile.v0
<missing>      2 months ago         CMD ["/bin/sh"]                                 0B        buildkit.dockerfile.v0
<missing>      2 months ago         ADD alpine-minirootfs-3.21.3-aarch64.tar.gz …   8.84MB    buildkit.dockerfile.v0
```

### After
`docker image ls lemmy-ui:optimize-dockerfile`
```
REPOSITORY   TAG                   IMAGE ID       CREATED          SIZE
lemmy-ui     optimize-dockerfile   04fce5a5a51f   36 seconds ago   1GB
```
`docker image history lemmy-ui:optimize-dockerfile`
```
IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
04fce5a5a51f   47 seconds ago       CMD ["node" "dist/js/server.js"]                0B        buildkit.dockerfile.v0
<missing>      47 seconds ago       WORKDIR /app                                    4.1kB     buildkit.dockerfile.v0
<missing>      47 seconds ago       EXPOSE map[1234/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      47 seconds ago       USER node                                       0B        buildkit.dockerfile.v0
<missing>      47 seconds ago       HEALTHCHECK &{["CMD-SHELL" "curl -ILfSs http…   0B        buildkit.dockerfile.v0
<missing>      47 seconds ago       LABEL org.opencontainers.image.description=T…   0B        buildkit.dockerfile.v0
<missing>      47 seconds ago       LABEL org.opencontainers.image.licenses=AGPL…   0B        buildkit.dockerfile.v0
<missing>      47 seconds ago       LABEL org.opencontainers.image.source=https:…   0B        buildkit.dockerfile.v0
<missing>      47 seconds ago       LABEL org.opencontainers.image.authors=The L…   0B        buildkit.dockerfile.v0
<missing>      47 seconds ago       RUN |1 TARGETARCH=arm64 /bin/sh -c chown nod…   4.1kB     buildkit.dockerfile.v0
<missing>      48 seconds ago       COPY --chown=node:node /usr/src/app/node_mod…   583MB     buildkit.dockerfile.v0
<missing>      About a minute ago   COPY --chown=node:node /usr/src/app/dist /ap…   16.2MB    buildkit.dockerfile.v0
<missing>      28 minutes ago       RUN |1 TARGETARCH=arm64 /bin/sh -c apk updat…   53.7MB    buildkit.dockerfile.v0
<missing>      28 minutes ago       ENV NODE_ENV=production                         0B        buildkit.dockerfile.v0
<missing>      28 minutes ago       ARG TARGETARCH=arm64                            0B        buildkit.dockerfile.v0
<missing>      2 weeks ago          CMD ["node"]                                    0B        buildkit.dockerfile.v0
<missing>      2 weeks ago          ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      2 weeks ago          COPY docker-entrypoint.sh /usr/local/bin/ # …   20.5kB    buildkit.dockerfile.v0
<missing>      2 weeks ago          RUN /bin/sh -c apk add --no-cache --virtual …   5.48MB    buildkit.dockerfile.v0
<missing>      2 weeks ago          ENV YARN_VERSION=1.22.22                        0B        buildkit.dockerfile.v0
<missing>      2 weeks ago          RUN /bin/sh -c addgroup -g 1000 node     && …   157MB     buildkit.dockerfile.v0
<missing>      2 weeks ago          ENV NODE_VERSION=23.11.0                        0B        buildkit.dockerfile.v0
<missing>      2 months ago         CMD ["/bin/sh"]                                 0B        buildkit.dockerfile.v0
<missing>      2 months ago         ADD alpine-minirootfs-3.21.3-aarch64.tar.gz …   8.84MB    buildkit.dockerfile.v0
```