### PR TITLE
Remove LEMMY_UI_LEMMY_EXTERNAL_HOST from webpack.DefinePlugin

### DIFF
--- a/src/server/handlers/catch-all-handler.tsx
+++ b/src/server/handlers/catch-all-handler.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../shared/services/";
 import { parsePath } from "history";
 import { getQueryString } from "@utils/helpers";
-import { adultConsentCookieKey } from "../../shared/config";
+import { adultConsentCookieKey, testHost } from "../../shared/config";
 
 export default async (req: Request, res: Response) => {
   try {
@@ -150,6 +150,7 @@ export default async (req: Request, res: Response) => {
       showAdultConsentModal:
         !!site?.site_view.site.content_warning &&
         !(site.my_user || req.cookies[adultConsentCookieKey]),
+      lemmy_external_host: process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST ?? testHost,
     };
 
     const wrapper = (

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -17,6 +17,7 @@ export interface IsoData<T extends RouteData = any> {
   site_res: GetSiteResponse;
   errorPageData?: ErrorPageData;
   showAdultConsentModal: boolean;
+  lemmy_external_host: string;
 }
 
 export type IsoDataOptionalSite<T extends RouteData = any> = Partial<

--- a/src/shared/utils/env/get-external-host.ts
+++ b/src/shared/utils/env/get-external-host.ts
@@ -1,5 +1,8 @@
 import { testHost } from "../../config";
+import { isBrowser } from "@utils/browser";
 
 export default function getExternalHost() {
-  return process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST ?? testHost;
+  return isBrowser()
+    ? window.isoData.lemmy_external_host
+    : (process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST ?? testHost);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,9 +86,6 @@ module.exports = (env, argv) => {
       new webpack.DefinePlugin({
         "process.env.COMMIT_HASH": `"${env.COMMIT_HASH}"`,
         "process.env.NODE_ENV": `"${mode}"`,
-        "process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST": JSON.stringify(
-          process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST,
-        ),
       }),
       new MiniCssExtractPlugin({
         filename: "styles/styles.css",


### PR DESCRIPTION
## Description

[webpack.DefinePlugin](https://webpack.js.org/plugins/define-plugin/) overrides expressions at compile time, but this env var must be evaluated at runtime

This was already raised in the discussion here but not actually resolved before the PR got merged: https://github.com/LemmyNet/lemmy-ui/pull/3041#discussion_r2028679878

### Before

`LEMMY_UI_LEMMY_EXTERNAL_HOST` env var is always evaluated as `undefined` if it's not defined at build time.

### After

`LEMMY_UI_LEMMY_EXTERNAL_HOST` is evaluated at runtime.