### PR TITLE
Remove instance cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
       "sortpack"
     ]
   },
-  "packageManager": "pnpm@10.2.1+sha512.398035c7bd696d0ba0b10a688ed558285329d27ea994804a52bad9167d8e3a72bcb993f9699585d3ca25779ac64949ef422757a6c31102c12ab932e5cbe5cc92",
+  "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",
   "engineStrict": true,
   "importSort": {
     ".js, .jsx, .ts, .tsx": {

--- a/src/shared/services/UserService.ts
+++ b/src/shared/services/UserService.ts
@@ -55,6 +55,9 @@ export class UserService {
 
     HttpService.client.logout();
 
+    // TODO: Remove this in a few releases when this cache has been deleted from most users' browsers
+    window.caches.delete("instance-cache");
+
     if (isAuthPath(location.pathname)) {
       location.replace("/");
     } else {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,6 +148,7 @@ module.exports = (env, argv) => {
               handler: "NetworkFirst",
               options: {
                 cacheName: "instance-cache",
+                maxAgeSeconds: 600,
               },
             },
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,7 +148,9 @@ module.exports = (env, argv) => {
               handler: "NetworkFirst",
               options: {
                 cacheName: "instance-cache",
-                maxAgeSeconds: 600,
+                expiration: {
+                  maxAgeSeconds: 600,
+                },
               },
             },
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,25 +132,6 @@ module.exports = (env, argv) => {
           inlineWorkboxRuntime: true,
           runtimeCaching: [
             {
-              urlPattern: ({
-                sameOrigin,
-                url: { pathname, host },
-                request: { method },
-              }) =>
-                (sameOrigin || host.includes("localhost")) &&
-                (!(
-                  pathname.includes("pictrs") || pathname.includes("static")
-                ) ||
-                  method === "POST"),
-              handler: "NetworkFirst",
-              options: {
-                cacheName: "instance-cache",
-                expiration: {
-                  maxAgeSeconds: 600,
-                },
-              },
-            },
-            {
               urlPattern: ({ url: { pathname, host }, sameOrigin }) =>
                 (sameOrigin || host.includes("localhost")) &&
                 pathname.includes("static"),


### PR DESCRIPTION
Fixes #2792

It turns out that the problem was just that a max age wasn't specified for the `instance-cache`. This PR makes it so everything in that cache expires in 10 minutes.