### PR TITLE
fixed wildcard path matching syntax

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -54,7 +54,7 @@ server.get("/manifest.webmanifest", ManifestHandler);
 server.get("/css/themes/:name", ThemeHandler);
 server.get("/css/code-themes/:name", CodeThemeHandler);
 server.get("/css/themelist", ThemesListHandler);
-server.get("/*", CatchAllHandler);
+server.get("/{*splat}", CatchAllHandler);
 
 const listener = server.listen(Number(port), hostname, () => {
   verifyDynamicImports(true);


### PR DESCRIPTION
Bug report: https://github.com/LemmyNet/lemmy-ui/issues/3106

Putting this for reference: https://expressjs.com/en/guide/migrating-5.html#path-syntax