### PR TITLE
Disable blur for NSFW images by default if content_warning exists

### DIFF
--- a/src/shared/components/common/pictrs-image.tsx
+++ b/src/shared/components/common/pictrs-image.tsx
@@ -53,7 +53,7 @@ export class PictrsImage extends Component<PictrsImageProps, PictrsImageState> {
     const blurImage =
       nsfw &&
       (UserService.Instance.myUserInfo?.local_user_view.local_user.blur_nsfw ??
-        true);
+        !this.isoData.site_res.site_view.site.content_warning);
 
     return (
       !this.isoData.showAdultConsentModal && (


### PR DESCRIPTION
I'm trying to get rid of our own fork :) I can create same PR for 0.19 if it makes sense.