### PR TITLE
[0.19] Fix missing user badge for deleted users

### DIFF
--- a/src/shared/components/common/user-badges.tsx
+++ b/src/shared/components/common/user-badges.tsx
@@ -42,6 +42,7 @@ export class UserBadges extends Component<UserBadgesProps> {
     return (
       (this.props.isBanned ||
         this.props.isBannedFromCommunity ||
+        this.props.isDeleted ||
         this.props.isPostCreator ||
         this.props.isMod ||
         this.props.isAdmin ||
@@ -77,7 +78,7 @@ export class UserBadges extends Component<UserBadgesProps> {
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("deleted"),
                 tooltip: I18NextService.i18n.t("deleted"),
-                classes: "text-danger border border-danger",
+                classes: "text-info border border-info",
                 shrink: false,
               })}
             </span>


### PR DESCRIPTION
## Description

Fix displaying the deleted badge for users even if they don't have any other badge being displayed. Also changes the deleted badge for users from danger to info to make it more distinct from banned users.

Backport of #3161

## Screenshots

![image](https://github.com/user-attachments/assets/0aa35e87-b49f-4297-8466-8aea61a753b1)