### PR TITLE
Always escape HTML attributes in emoji autocomplete and custom emoji markdown renderer

### DIFF
--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -209,29 +209,17 @@ export function setupMarkdown() {
   ) {
     //Provide custom renderer for our emojis to allow us to add a css class and force size dimensions on them.
     const item = tokens[idx] as any;
-    const url = item.attrs.length > 0 ? item.attrs[0][1] : "";
-    const altText = item.attrs.length > 1 ? item.attrs[1][1] : "";
     const title = item.attrs.length > 2 ? item.attrs[2][1] : "";
     const splitTitle = title.split(/ (.*)/, 2);
     const isEmoji = splitTitle[0] === "emoji";
-    let shortcode: string | undefined;
-    if (isEmoji) {
-      shortcode = splitTitle[1];
+    const imgElement =
+      defaultImageRenderer?.(tokens, idx, options, env, self) ?? "";
+    if (imgElement) {
+      return isEmoji
+        ? `<span class="icon icon-emoji">${imgElement}</span>`
+        : imgElement;
     }
-    // customEmojisLookup is empty in SSR, CSR rerenders markdown anyway
-    const isLocalEmoji = shortcode && customEmojisLookup.has(shortcode);
-    if (!isLocalEmoji) {
-      const imgElement =
-        defaultImageRenderer?.(tokens, idx, options, env, self) ?? "";
-      if (imgElement) {
-        return `<span class='${
-          isEmoji ? "icon icon-emoji" : ""
-        }'>${imgElement}</span>`;
-      } else return "";
-    }
-    return `<img class="icon icon-emoji" src="${
-      url
-    }" title="${shortcode}" alt="${altText}"/>`;
+    return "";
   };
   md.renderer.rules.table_open = function () {
     return '<table class="table">';
@@ -339,7 +327,7 @@ export async function setupTribute() {
           .concat(
             Array.from(customEmojisLookup.entries()).map(k => ({
               key: k[0],
-              val: `<img class="icon icon-emoji" src="${k[1].custom_emoji.image_url}" title="${k[1].custom_emoji.shortcode}" alt="${k[1].custom_emoji.alt_text}" />`,
+              val: `<img class="icon icon-emoji" src="${md.utils.escapeHtml(k[1].custom_emoji.image_url)}" title="${md.utils.escapeHtml(k[1].custom_emoji.shortcode)}" alt="${md.utils.escapeHtml(k[1].custom_emoji.alt_text)}" />`,
             })),
           ),
         allowSpaces: false,


### PR DESCRIPTION
## Description

Fixes lack of HTML escaping when custom emojis are used.

This also adjusts the emoji detection in the markdown image renderer to treat any image with a title starting with `emoji ` to be an emoji, appending the relevant classes for styling. This improves compatibility for emojis from other instances and also allows users to use self-defined emojis not defined in the instance custom emoji configuration.