### PR TITLE
[0.19] Always escape HTML attributes in emoji autocomplete and custom emoji markdown renderer

### DIFF
--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -207,28 +207,17 @@ export function setupMarkdown() {
   ) {
     //Provide custom renderer for our emojis to allow us to add a css class and force size dimensions on them.
     const item = tokens[idx] as any;
-    let title = item.attrs.length >= 3 ? item.attrs[2][1] : "";
+    const title = item.attrs.length > 2 ? item.attrs[2][1] : "";
     const splitTitle = title.split(/ (.*)/, 2);
     const isEmoji = splitTitle[0] === "emoji";
-    if (isEmoji) {
-      title = splitTitle[1];
+    const imgElement =
+      defaultImageRenderer?.(tokens, idx, options, env, self) ?? "";
+    if (imgElement) {
+      return isEmoji
+        ? `<span class="icon icon-emoji">${imgElement}</span>`
+        : imgElement;
     }
-    const customEmoji = customEmojisLookup.get(title);
-    const isLocalEmoji = customEmoji !== undefined;
-    if (!isLocalEmoji) {
-      const imgElement =
-        defaultImageRenderer?.(tokens, idx, options, env, self) ?? "";
-      if (imgElement) {
-        return `<span class='${
-          isEmoji ? "icon icon-emoji" : ""
-        }'>${imgElement}</span>`;
-      } else return "";
-    }
-    return `<img class="icon icon-emoji" src="${
-      customEmoji!.custom_emoji.image_url
-    }" title="${customEmoji!.custom_emoji.shortcode}" alt="${
-      customEmoji!.custom_emoji.alt_text
-    }"/>`;
+    return "";
   };
   md.renderer.rules.table_open = function () {
     return '<table class="table">';
@@ -373,7 +362,7 @@ export async function setupTribute() {
           .concat(
             Array.from(customEmojisLookup.entries()).map(k => ({
               key: k[0],
-              val: `<img class="icon icon-emoji" src="${k[1].custom_emoji.image_url}" title="${k[1].custom_emoji.shortcode}" alt="${k[1].custom_emoji.alt_text}" />`,
+              val: `<img class="icon icon-emoji" src="${md.utils.escapeHtml(k[1].custom_emoji.image_url)}" title="${md.utils.escapeHtml(k[1].custom_emoji.shortcode)}" alt="${md.utils.escapeHtml(k[1].custom_emoji.alt_text)}" />`,
             })),
           ),
         allowSpaces: false,


### PR DESCRIPTION
Backport of #3168.

Also partially backports changes from #2715/#2718 to always use image attributes from markdown source instead of overwriting local emojis with the current custom emojis configured on the site.

## Description

Fixes lack of HTML escaping when custom emojis are used.

This also adjusts the emoji detection in the markdown image renderer to treat any image with a title starting with `emoji ` to be an emoji, appending the relevant classes for styling. This improves compatibility for emojis from other instances and also allows users to use self-defined emojis not defined in the instance custom emoji configuration.

When rendering markdown, Lemmy will no longer use the URL and alt text defined in the custom emojis on the current instance to replace the values in markdown but instead always use the values in markdown.
This ensures that an admin changing custom emojis for the instance will not replace what is displayed in places where the emoji was previously referenced.
This may change what is displayed to users when an admin previously edited custom emojis by reverting the displayed values back to the ones originally embedded in markdown.