### PR TITLE
Add a denial reason using the error.message field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "inferno-router": "^8.2.3",
     "inferno-server": "^8.2.3",
     "jwt-decode": "^4.0.0",
-    "lemmy-js-client": "0.19.11-donation-dialog.1",
+    "lemmy-js-client": "0.19.12-name-and-message.1",
     "lodash.isequal": "^4.5.0",
     "markdown-it": "^14.1.0",
     "markdown-it-bidi": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       lemmy-js-client:
-        specifier: 0.19.11-donation-dialog.1
-        version: 0.19.11-donation-dialog.1
+        specifier: 0.19.12-name-and-message.1
+        version: 0.19.12-name-and-message.1
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
@@ -3049,8 +3049,8 @@ packages:
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
-  lemmy-js-client@0.19.11-donation-dialog.1:
-    resolution: {integrity: sha512-dmny1WwteMY07EKLoOGYt46HVc7k6H+o0ZzCPcNcpaAVgK5jJ6fs2i2BfMrEtQwAdRzqyVtVX0gXHy17j/cWGw==}
+  lemmy-js-client@0.19.12-name-and-message.1:
+    resolution: {integrity: sha512-ghX9wY/ERjyKnVfUhDogTw5WC6Sa6bPphBQcrM3xJIbxozo35ENvUaDx/FGZZJ40Wb3HgqXh73d6wTtYdpbXOw==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -7812,7 +7812,7 @@ snapshots:
 
   leac@0.6.0: {}
 
-  lemmy-js-client@0.19.11-donation-dialog.1: {}
+  lemmy-js-client@0.19.12-name-and-message.1: {}
 
   leven@3.1.0: {}
 

--- a/src/server/handlers/catch-all-handler.tsx
+++ b/src/server/handlers/catch-all-handler.tsx
@@ -66,10 +66,7 @@ export default async (req: Request, res: Response) => {
     let errorPageData: ErrorPageData | undefined = undefined;
     let try_site = await client.getSite();
 
-    if (
-      try_site.state === "failed" &&
-      try_site.err.message === "not_logged_in"
-    ) {
+    if (try_site.state === "failed" && try_site.err.name === "not_logged_in") {
       console.error(
         "Incorrect JWT token, skipping auth so frontend can remove jwt cookie",
       );
@@ -118,23 +115,22 @@ export default async (req: Request, res: Response) => {
       }
     } else if (try_site.state === "failed") {
       res.status(500);
-      errorPageData = getErrorPageData(new Error(try_site.err.message), site);
+      errorPageData = getErrorPageData(new Error(try_site.err.name), site);
     }
 
     const error = Object.values(routeData).find(
-      res =>
-        res.state === "failed" && res.err.message !== "couldnt_find_object", // TODO: find a better way of handling errors
+      res => res.state === "failed" && res.err.name !== "couldnt_find_object", // TODO: find a better way of handling errors
     ) as FailedRequestState | undefined;
 
     // Redirect to the 404 if there's an API error
     if (error) {
       console.error(error.err);
 
-      if (error.err.message === "instance_is_private") {
+      if (error.err.name === "instance_is_private") {
         return res.redirect(`/signup`);
       } else {
         res.status(500);
-        errorPageData = getErrorPageData(new Error(error.err.message), site);
+        errorPageData = getErrorPageData(new Error(error.err.name), site);
       }
     }
 
@@ -175,7 +171,7 @@ export default async (req: Request, res: Response) => {
     res.statusCode = 500;
 
     return res.send(
-      process.env.NODE_ENV === "development" ? err.message : "Server error",
+      process.env.NODE_ENV === "development" ? err.name : "Server error",
     );
   }
 };

--- a/src/server/utils/get-error-page-data.ts
+++ b/src/server/utils/get-error-page-data.ts
@@ -5,7 +5,7 @@ export function getErrorPageData(error: Error, site?: GetSiteResponse) {
   const errorPageData: ErrorPageData = {};
 
   if (site) {
-    errorPageData.error = error.message;
+    errorPageData.error = error.name;
   }
 
   const adminMatrixIds = site?.admins

--- a/src/shared/components/common/image-upload-form.tsx
+++ b/src/shared/components/common/image-upload-form.tsx
@@ -86,7 +86,7 @@ export class ImageUploadForm extends Component<
           toast(JSON.stringify(res), "danger");
         }
       } else if (res.state === "failed") {
-        toast(res.err.message, "danger");
+        toast(res.err.name, "danger");
       }
 
       i.setState({ loading: false });

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -498,8 +498,8 @@ export class MarkdownTextArea extends Component<
       }
     } else if (res.state === "failed") {
       i.setState({ imageUploadStatus: undefined });
-      console.error(res.err.message);
-      toast(res.err.message, "danger");
+      console.error(res.err.name);
+      toast(res.err.name, "danger");
 
       throw res.err;
     }

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -816,7 +816,7 @@ export class Community extends Component<CommunityRouteProps, State> {
     this.createAndUpdateComments(createCommentRes);
 
     if (createCommentRes.state === "failed") {
-      toast(I18NextService.i18n.t(createCommentRes.err.message), "danger");
+      toast(I18NextService.i18n.t(createCommentRes.err.name), "danger");
     }
     return createCommentRes;
   }
@@ -826,7 +826,7 @@ export class Community extends Component<CommunityRouteProps, State> {
     this.findAndUpdateCommentEdit(editCommentRes);
 
     if (editCommentRes.state === "failed") {
-      toast(I18NextService.i18n.t(editCommentRes.err.message), "danger");
+      toast(I18NextService.i18n.t(editCommentRes.err.name), "danger");
     }
     return editCommentRes;
   }

--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -77,7 +77,7 @@ export class CreateCommunity extends Component<
       const name = res.data.community_view.community.name;
       this.props.history.replace(`/c/${name}`);
     } else if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
       this.setState({ loading: false });
     } else {
       this.setState({ loading: false });

--- a/src/shared/components/home/emojis-form.tsx
+++ b/src/shared/components/home/emojis-form.tsx
@@ -510,8 +510,8 @@ export class EmojiForm extends Component<EmojiFormProps, EmojiFormState> {
           toast(JSON.stringify(res), "danger");
         }
       } else if (res.state === "failed") {
-        console.error(res.err.message);
-        toast(res.err.message, "danger");
+        console.error(res.err.name);
+        toast(res.err.name, "danger");
       }
     });
   }

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -852,7 +852,7 @@ export class Home extends Component<HomeRouteProps, HomeState> {
     this.createAndUpdateComments(createCommentRes);
 
     if (createCommentRes.state === "failed") {
-      toast(I18NextService.i18n.t(createCommentRes.err.message), "danger");
+      toast(I18NextService.i18n.t(createCommentRes.err.name), "danger");
     }
     return createCommentRes;
   }
@@ -862,7 +862,7 @@ export class Home extends Component<HomeRouteProps, HomeState> {
     this.findAndUpdateCommentEdit(editCommentRes);
 
     if (editCommentRes.state === "failed") {
-      toast(I18NextService.i18n.t(editCommentRes.err.message), "danger");
+      toast(I18NextService.i18n.t(editCommentRes.err.name), "danger");
     }
     return editCommentRes;
   }

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -81,18 +81,19 @@ async function handleLoginSubmit(i: Login, event: any) {
     });
     switch (loginRes.state) {
       case "failed": {
-        if (loginRes.err.message === "missing_totp_token") {
+        if (loginRes.err.name === "missing_totp_token") {
           i.setState({ show2faModal: true });
         } else {
-          // TODO: We shouldn't be passing error messages as args into i18next
-          toast(
-            I18NextService.i18n.t(
-              loginRes.err.message === "registration_application_is_pending"
-                ? "registration_application_pending"
-                : loginRes.err.message,
-            ),
-            "danger",
+          let errStr = I18NextService.i18n.t(
+            loginRes.err.name === "registration_application_is_pending"
+              ? "registration_application_pending"
+              : loginRes.err.name,
           );
+          // If there's an error message, append it
+          if (loginRes.err.message) {
+            errStr = `${errStr}: ${loginRes.err.message}`;
+          }
+          toast(errStr, "danger");
         }
 
         i.setState({ loginRes });

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -406,7 +406,7 @@ export class Signup extends Component<
       });
       switch (registerRes.state) {
         case "failed": {
-          toast(registerRes.err.message, "danger");
+          toast(registerRes.err.name, "danger");
           i.setState({ registerRes: EMPTY_REQUEST });
           break;
         }

--- a/src/shared/components/person/inbox.tsx
+++ b/src/shared/components/person/inbox.tsx
@@ -900,7 +900,7 @@ export class Inbox extends Component<InboxRouteProps, InboxState> {
       toast(I18NextService.i18n.t("edit"));
       this.findAndUpdateComment(res);
     } else if (res.state === "failed") {
-      toast(res.err.message, "danger");
+      toast(res.err.name, "danger");
     }
 
     return res;
@@ -992,7 +992,7 @@ export class Inbox extends Component<InboxRouteProps, InboxState> {
     const res = await HttpService.client.editPrivateMessage(form);
     this.findAndUpdateMessage(res);
     if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
     return res.state !== "failed";
   }
@@ -1023,7 +1023,7 @@ export class Inbox extends Component<InboxRouteProps, InboxState> {
       return s;
     });
     if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
     return res.state !== "failed";
   }
@@ -1095,7 +1095,7 @@ export class Inbox extends Component<InboxRouteProps, InboxState> {
     if (res.state === "success") {
       toast(I18NextService.i18n.t("report_created"));
     } else if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
   }
 

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -186,7 +186,7 @@ async function handleGenerateTotp(i: Settings) {
   const generateTotpRes = await HttpService.client.generateTotpSecret();
 
   if (generateTotpRes.state === "failed") {
-    toast(generateTotpRes.err.message, "danger");
+    toast(generateTotpRes.err.name, "danger");
   } else {
     i.setState({ show2faModal: true });
   }
@@ -1721,7 +1721,7 @@ export class Settings extends Component<SettingsRouteProps, SettingsState> {
       i.exportSettingsLink.current?.click();
     } else if (res.state === "failed") {
       toast(
-        res.err.message === "rate_limit_error"
+        res.err.name === "rate_limit_error"
           ? I18NextService.i18n.t("import_export_rate_limit_error")
           : I18NextService.i18n.t("export_error"),
         "danger",
@@ -1809,7 +1809,7 @@ export class Settings extends Component<SettingsRouteProps, SettingsState> {
       }
     } else if (res.state === "failed") {
       toast(
-        res.err.message === "rate_limit_error"
+        res.err.name === "rate_limit_error"
           ? I18NextService.i18n.t("import_export_rate_limit_error")
           : I18NextService.i18n.t("import_error"),
         "danger",

--- a/src/shared/components/post/create-post.tsx
+++ b/src/shared/components/post/create-post.tsx
@@ -386,7 +386,7 @@ export class CreatePost extends Component<
       this.setState({
         loading: false,
       });
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
   }
 

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -259,8 +259,8 @@ function handleImageUpload(i: PostForm, event: any) {
         toast(JSON.stringify(res), "danger");
       }
     } else if (res.state === "failed") {
-      console.error(res.err.message);
-      toast(res.err.message, "danger");
+      console.error(res.err.name);
+      toast(res.err.name, "danger");
       i.setState({ imageLoading: false });
     }
   });

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -877,7 +877,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       toast(I18NextService.i18n.t("edited_post"));
       this.setState({ loading: false, showEdit: false });
     } else if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
       this.setState({ loading: false });
     }
   }

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -1391,7 +1391,7 @@ export class Post extends Component<PostRouteProps, PostState> {
       return s;
     });
     if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
   }
 
@@ -1406,7 +1406,7 @@ export class Post extends Component<PostRouteProps, PostState> {
       return s;
     });
     if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
   }
 
@@ -1421,7 +1421,7 @@ export class Post extends Component<PostRouteProps, PostState> {
       return s;
     });
     if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
   }
 
@@ -1436,7 +1436,7 @@ export class Post extends Component<PostRouteProps, PostState> {
       return s;
     });
     if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
   }
 

--- a/src/shared/components/private_message/create-private-message.tsx
+++ b/src/shared/components/private_message/create-private-message.tsx
@@ -181,7 +181,7 @@ export class CreatePrivateMessage extends Component<
       // Navigate to the front
       this.context.router.history.push("/");
     } else if (res.state === "failed") {
-      toast(I18NextService.i18n.t(res.err.message), "danger");
+      toast(I18NextService.i18n.t(res.err.name), "danger");
     }
 
     return res.state !== "failed";


### PR DESCRIPTION
- All the ordinary i18n errors now use error.name .
- Fixes #1096

What it looks like now:

![Screenshot_20250606_110311_Via_1](https://github.com/user-attachments/assets/0fa49202-20ee-456c-a8be-672109cb99bd)
