### PR TITLE
Fix spoiler escaped characters

### DIFF
--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -62,7 +62,7 @@ const spoilerConfig = {
     const m = tokens[idx].info.trim().match(/^spoiler\s+(.*)$/);
     if (tokens[idx].nesting === 1) {
       // opening tag
-      const summary = mdToHtmlInline(md.utils.escapeHtml(m[1])).__html;
+      const summary = mdToHtmlInline(m[1]).__html;
       return `<details><summary> ${summary} </summary>\n`;
     } else {
       // closing tag


### PR DESCRIPTION
## Description

<!-- Please describe exactly what this PR changes, including URLs and issue
numbers. If it fixes an issue, add "Fixes #XXXX" -->

Spoiler titles with characters like `" & < >` were being rendered as `&quot; &amp; &lt; &gt;`

This was caused by double escaping:
- First by escapeHtml
- Then again by `markdown-it`

Updated to pass raw markdown directly to `mdToHtmlInline()`, allowing `markdown-it` to handle escaping.


Fixes https://github.com/LemmyNet/lemmy-ui/issues/3167

## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before
![2025-06-08-025221_hyprshot](https://github.com/user-attachments/assets/ebdf4e0d-1256-4fcf-8048-95fc7d18665f)


### After
![2025-06-08-025155_hyprshot](https://github.com/user-attachments/assets/0bbf4041-a4d8-46ed-a6f3-86b6b35bfd28)

