### PR TITLE
Hide Next button for Overview, Saved, Upvoted

### DIFF
--- a/src/shared/components/person/person-details.tsx
+++ b/src/shared/components/person/person-details.tsx
@@ -124,7 +124,16 @@ export class PersonDetails extends Component<PersonDetailsProps, any> {
             (this.props.view === PersonDetailsView.Comments &&
               this.props.limit > this.props.personRes.comments.length) ||
             (this.props.view === PersonDetailsView.Posts &&
-              this.props.limit > this.props.personRes.posts.length)
+              this.props.limit > this.props.personRes.posts.length) ||
+            ((this.props.view === PersonDetailsView.Overview ||
+              this.props.view === PersonDetailsView.Saved) &&
+              this.props.limit > this.props.personRes.posts.length &&
+              this.props.limit > this.props.personRes.comments.length) ||
+            (this.props.view === PersonDetailsView.Upvoted &&
+              this.props.likedCommentsRes !== undefined &&
+              this.props.limit > this.props.likedCommentsRes.comments.length &&
+              this.props.likedPostsRes !== undefined &&
+              this.props.limit > this.props.likedPostsRes.posts.length)
           }
         />
       </div>


### PR DESCRIPTION
## Description

Hide the next button for Overview, Saved, Upvoted views on users' profiles when there are no more posts or comments left. Like it's done for the Comments and Posts views already.

Issue persists on the Uploads view but that would require a bit more work.

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/552e8b5a-164e-4b6b-97c2-f670d890d6fe)
![before-2](https://github.com/user-attachments/assets/8e6f755c-ec5f-41de-b745-bb90218689a8)

### After
![after](https://github.com/user-attachments/assets/e1e4e08d-d405-4f32-9087-22088eab5299)
![after-2](https://github.com/user-attachments/assets/1c8c6157-ed9d-4f79-ab11-128b5b83639d)
