### PR TITLE
Don't show edit mark if comment was edited in less than 5 minutes

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -157,7 +157,11 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
   }
 
   get commentView(): CommentNodeView {
-    return this.props.node.comment_view;
+    const cv = this.props.node.comment_view;
+    if (this.isCommentRecentlyUpdated(cv)) {
+      delete cv.comment.updated;
+    }
+    return cv;
   }
 
   get commentId(): CommentId {
@@ -575,6 +579,16 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     const now = subMinutes(new Date(), 10);
     const then = parseISO(this.commentView.comment.published);
     return isBefore(now, then);
+  }
+
+  isCommentRecentlyUpdated(cv: CommentNodeView): boolean {
+    const updated = new Date(cv.comment.updated);
+    const published = new Date(cv.comment.published);
+    let timedelta = 0;
+    if (!isNaN(updated.getTime())) {
+      timedelta = updated - published;
+    }
+    return 0 < timedelta <= 5 * 60 * 1000;
   }
 
   handleCommentCollapse(i: CommentNode) {


### PR DESCRIPTION
## Description

Don't show the edit mark in a comment if it was edited in less than 5 minutes from the moment it was published.

## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before

![before](https://github.com/user-attachments/assets/832ca46c-627e-446f-86f3-05d558ccd6ee)

### After

![after](https://github.com/user-attachments/assets/8215c983-edbc-4162-b8ea-b7a3d6168419)