### PR TITLE
Don't show edit mark if comment was edited in less than 5 minutes

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -170,7 +170,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     const {
       creator_is_moderator,
       creator_is_admin,
-      comment: { id, language_id, published, distinguished, updated },
+      comment: { id, language_id, published, distinguished },
       creator,
       community,
       post,
@@ -260,7 +260,10 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 counts={counts}
               />
               <span>
-                <MomentTime published={published} updated={updated} />
+                <MomentTime
+                  published={published}
+                  updated={this.commentUpdatedTime}
+                />
               </span>
             </div>
             {/* end of user row */}
@@ -575,6 +578,24 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     const now = subMinutes(new Date(), 10);
     const then = parseISO(this.commentView.comment.published);
     return isBefore(now, then);
+  }
+
+  isCommentRecentlyUpdated(): boolean {
+    const comment = this.commentView.comment;
+    if (comment.updated) {
+      const published = new Date(comment.published);
+      const updated = new Date(comment.updated);
+      const update_limit = subMinutes(updated, 5);
+      return isBefore(update_limit, published);
+    }
+    return false;
+  }
+
+  get commentUpdatedTime(): string {
+    if (this.isCommentRecentlyUpdated()) {
+      return "";
+    }
+    return this.commentView.comment.updated;
   }
 
   handleCommentCollapse(i: CommentNode) {

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -170,7 +170,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     const {
       creator_is_moderator,
       creator_is_admin,
-      comment: { id, language_id, published, distinguished },
+      comment: { id, language_id, published, distinguished, updated },
       creator,
       community,
       post,
@@ -260,10 +260,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 counts={counts}
               />
               <span>
-                <MomentTime
-                  published={published}
-                  updated={this.commentUpdatedTime}
-                />
+                <MomentTime published={published} updated={updated} />
               </span>
             </div>
             {/* end of user row */}
@@ -578,24 +575,6 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     const now = subMinutes(new Date(), 10);
     const then = parseISO(this.commentView.comment.published);
     return isBefore(now, then);
-  }
-
-  isCommentRecentlyUpdated(): boolean {
-    const comment = this.commentView.comment;
-    if (comment.updated) {
-      const published = new Date(comment.published);
-      const updated = new Date(comment.updated);
-      const update_limit = subMinutes(updated, 5);
-      return isBefore(update_limit, published);
-    }
-    return false;
-  }
-
-  get commentUpdatedTime(): string {
-    if (this.isCommentRecentlyUpdated()) {
-      return "";
-    }
-    return this.commentView.comment.updated;
   }
 
   handleCommentCollapse(i: CommentNode) {

--- a/src/shared/components/common/moment-time.tsx
+++ b/src/shared/components/common/moment-time.tsx
@@ -42,8 +42,9 @@ export class MomentTime extends Component<MomentTimeProps, any> {
       const updated = new Date(this.props.updated);
       const updateLimit = addMinutes(published, 5);
       return isBefore(updated, updateLimit);
+    } else {
+      return false;
     }
-    return false;
   }
 
   get updatedTime(): string | undefined {

--- a/src/shared/components/common/moment-time.tsx
+++ b/src/shared/components/common/moment-time.tsx
@@ -46,11 +46,12 @@ export class MomentTime extends Component<MomentTimeProps, any> {
     return false;
   }
 
-  get updatedTime(): string {
-    if (this.isRecentlyUpdated()) {
-      return "";
+  get updatedTime(): string | undefined {
+    if (!this.isRecentlyUpdated()) {
+      return this.props.updated;
+    } else {
+      return;
     }
-    return this.props.updated || "";
   }
 
   render() {

--- a/src/shared/components/common/moment-time.tsx
+++ b/src/shared/components/common/moment-time.tsx
@@ -1,5 +1,5 @@
 import { capitalizeFirstLetter, formatPastDate } from "@utils/helpers";
-import { format, parseISO } from "date-fns";
+import { addMinutes, format, isBefore, parseISO } from "date-fns";
 import { Component } from "inferno";
 import { I18NextService } from "../../services";
 import { Icon } from "./icon";
@@ -24,7 +24,7 @@ export class MomentTime extends Component<MomentTimeProps, any> {
   }
 
   createdAndModifiedTimes() {
-    const updated = this.props.updated;
+    const updated = this.updatedTime;
     let line = `${capitalizeFirstLetter(
       I18NextService.i18n.t("created"),
     )}: ${formatDate(this.props.published)}`;
@@ -36,15 +36,32 @@ export class MomentTime extends Component<MomentTimeProps, any> {
     return line;
   }
 
+  isRecentlyUpdated(): boolean {
+    if (this.props.updated) {
+      const published = new Date(this.props.published);
+      const updated = new Date(this.props.updated);
+      const updateLimit = addMinutes(published, 5);
+      return isBefore(updated, updateLimit);
+    }
+    return false;
+  }
+
+  get updatedTime(): string {
+    if (this.isRecentlyUpdated()) {
+      return "";
+    }
+    return this.props.updated || "";
+  }
+
   render() {
-    if (!this.props.ignoreUpdated && this.props.updated) {
+    if (!this.props.ignoreUpdated && this.updatedTime) {
       return (
         <span
           data-tippy-content={this.createdAndModifiedTimes()}
           className="moment-time fst-italic pointer unselectable"
         >
           <Icon icon="edit-2" classes="icon-inline me-1" />
-          {formatPastDate(this.props.updated)}
+          {formatPastDate(this.updatedTime)}
         </span>
       );
     } else {


### PR DESCRIPTION
## Description

Implements #3121: Don't show the edit mark in a comment if it was edited in less than 5 minutes from the moment it was published.

## Screenshots

### Before

![before](https://github.com/user-attachments/assets/5c5761cb-3ecc-4d78-a199-9575d8c5cc06)

### After

![after](https://github.com/user-attachments/assets/1efd55fa-ae3e-41fc-bf93-218be808e4cd)