### PR TITLE
Click anywhere on byline to collapse a comment

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -2,7 +2,7 @@ import { colorList, getCommentParentId } from "@utils/app";
 import { futureDaysToUnixTime, numToSI } from "@utils/helpers";
 import classNames from "classnames";
 import { isBefore, parseISO, subMinutes } from "date-fns";
-import { Component, linkEvent } from "inferno";
+import { Component, InfernoMouseEvent, linkEvent } from "inferno";
 import { Link } from "inferno-router";
 import {
   AddAdmin,
@@ -199,7 +199,12 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
           })}
         >
           <div className="ms-2">
-            <div className="d-flex flex-wrap align-items-center text-muted small">
+            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
+            <div
+              className="d-flex flex-wrap align-items-center text-muted small"
+              onClick={linkEvent(this, this.handleCommentCollapse)}
+              role="group"
+            >
               <button
                 className="btn btn-sm btn-link text-muted me-2"
                 onClick={linkEvent(this, this.handleCommentCollapse)}
@@ -577,7 +582,8 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     return isBefore(now, then);
   }
 
-  handleCommentCollapse(i: CommentNode) {
+  handleCommentCollapse(i: CommentNode, event: InfernoMouseEvent<any>) {
+    event.stopPropagation();
     i.setState({ collapsed: !i.state.collapsed });
   }
 


### PR DESCRIPTION
## Description

This PR intends to increase target clickable area in furtherance of accessibility. Similarly to Reddit, allows the user to click anywhere alongside the byline (username, etc.) to collapse a comment. Affects URLs at `/post/*`.

Does not fix a separate issue.

## Disclaimer

This PR departs a bit from convention by exempting a code change from a couple of lint rules, and here is why I believe these are an exception. (For reference, the lint rules relate to clickable element requirements.): 

The button element for collapsing comments still exists as before, with the key and click handlers, and continues to serve as an accessibility-friendly way to toggle the `collapsed?` state of a CommentNode. This PR simply expands the clickable region (which is itself for accessibility reasons), but having screen readers treat the entire region as a button or clickable element is not a desired behavior, since it may contain other clickable elements within. This is intended as a convenience for graphical users (desktop, mobile).

## Screenshots

No visual difference, but new behavior:

![click-anywhere](https://github.com/user-attachments/assets/ea44b4a6-279f-490c-aafe-ec933ec42539)
