### PR TITLE
Changed "open links in new tab" option to include links to posts/comments

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -407,6 +407,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           className="text-body"
           to={`/post/${post.id}`}
           title={I18NextService.i18n.t("comments")}
+          target={this.linkTarget}
         >
           <div className="thumbnail rounded bg-light d-flex justify-content-center">
             <Icon icon="message-square" classes="d-flex align-items-center" />
@@ -727,6 +728,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         className="btn btn-link btn-sm text-muted ps-0"
         title={title}
         to={`/post/${pv.post.id}?scrollToComments=true`}
+        target={this.linkTarget}
         data-tippy-content={title}
         onClick={this.props.onScrollIntoCommentsClick}
       >


### PR DESCRIPTION
This patches lemmy ui to open posts in new tabs when the option is enabled, which I believe is the expected behavior, and a common feature of most mobile clients.

## Description

This addresses what I and others consider an issue with how the ui handles opening links in a new tab, as described in issue #2147. By default, clicking any link will navigate the current page to the new one, replacing it. If you enable the setting "open links in new tab", it changes the behavior of the web client to open links to external websites in new tabs, but not links to posts, comments, etc.

As navigating to a post causes you to lose your place in the feed, I assume that the intended purpose of the setting is to prevent that, so you are able to read post after post without disturbing the main page.

This patch adds the necessary target attribute to the Post title links, as well as the comment icon linked to the Post.

## Reproduction

1. Enable the "open links in new tab" option in settings.
2. Click on a post title or comment icon.
3. The link does not open in a new tab, but replaces the current page.