### PR TITLE
Change display format for community name in search

### DIFF
--- a/src/shared/utils/app/community-select-name.ts
+++ b/src/shared/utils/app/community-select-name.ts
@@ -4,5 +4,5 @@ import { CommunityView } from "lemmy-js-client";
 export default function communitySelectName(cv: CommunityView): string {
   return cv.community.local
     ? cv.community.title
-    : `${hostname(cv.community.actor_id)}/${cv.community.title}`;
+    : `!${cv.community.title}@${hostname(cv.community.actor_id)}`;
 }


### PR DESCRIPTION
Use `!name@example.com` instead of `example.com/name` to be more consistent.