### PR TITLE
Change icon for save action (fixes #1564)

### DIFF
--- a/src/shared/components/common/content-actions/content-action-dropdown.tsx
+++ b/src/shared/components/common/content-actions/content-action-dropdown.tsx
@@ -195,7 +195,7 @@ export default class ContentActionDropdown extends Component<
         <ActionButton
           onClick={onSave}
           inline
-          icon="star"
+          icon="book-open"
           label={I18NextService.i18n.t(saved ? "unsave" : "save")}
           iconClass={classNames({ "text-warning": saved })}
         />


### PR DESCRIPTION
Not sure where these icons come from, is there any website that allows viewing them? Maybe theres a better icon for the purpose.