### PR TITLE
Change textarea placeholder for locked posts

### DIFF
--- a/src/shared/components/comment/comment-form.tsx
+++ b/src/shared/components/comment/comment-form.tsx
@@ -45,6 +45,9 @@ export class CommentForm extends Component<CommentFormProps, any> {
           ? this.props.node.comment_view.comment.content
           : undefined
         : undefined;
+    const placeholder = this.props.disabled
+      ? I18NextService.i18n.t("locked_post_comment_placeholder")
+      : I18NextService.i18n.t("comment_here");
 
     return (
       <div
@@ -62,7 +65,7 @@ export class CommentForm extends Component<CommentFormProps, any> {
             disabled={this.props.disabled}
             onSubmit={this.handleCommentSubmit}
             onReplyCancel={this.props.onReplyCancel}
-            placeholder={I18NextService.i18n.t("comment_here") ?? undefined}
+            placeholder={placeholder ?? undefined}
             allLanguages={this.props.allLanguages}
             siteLanguages={this.props.siteLanguages}
           />


### PR DESCRIPTION
## Description

Change the placeholder for the comment area of a locked post. Fixes https://github.com/LemmyNet/lemmy-ui/issues/3183. Relates to https://github.com/LemmyNet/lemmy-translations/pull/174.

## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before

<img width="966" height="338" alt="image" src="https://github.com/user-attachments/assets/5e6b1b90-93be-43c7-9cba-f220e036ea06" />

### After

<img width="966" height="338" alt="image" src="https://github.com/user-attachments/assets/83315eff-3e5f-4f53-a51b-4212daacb93b" />

