### PR TITLE
Add icon to indicate new accounts (fixes #2389)

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -280,11 +280,10 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 isPostCreator={this.isPostCreator}
                 isModerator={creator_is_moderator}
                 isAdmin={creator_is_admin}
-                person={cv.creator}
+                creator={cv.creator}
                 isBanned={cv.creator_banned}
                 isBannedFromCommunity={cv.creator_banned_from_community}
                 myUserInfo={this.props.myUserInfo}
-                targetPersonId={cv.creator.id}
                 personActions={cv.person_actions}
               />
 

--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -277,7 +277,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 isPostCreator={this.isPostCreator}
                 isModerator={creator_is_moderator}
                 isAdmin={creator_is_admin}
-                isBot={cv.creator.bot_account}
+                person={cv.creator}
                 isBanned={cv.creator_banned}
                 isBannedFromCommunity={cv.creator_banned_from_community}
               />

--- a/src/shared/components/common/modal/view-votes-modal.tsx
+++ b/src/shared/components/common/modal/view-votes-modal.tsx
@@ -59,8 +59,7 @@ function voteViewTable(votes: VoteView[], myUserInfo: MyUserInfo | undefined) {
                 />
                 <UserBadges
                   classNames="ms-1"
-                  isBot={v.creator.bot_account}
-                  isDeleted={v.creator.deleted}
+                  person={v.creator}
                   isBanned={v.creator_banned}
                   isBannedFromCommunity={v.creator_banned_from_community}
                 />

--- a/src/shared/components/common/modal/view-votes-modal.tsx
+++ b/src/shared/components/common/modal/view-votes-modal.tsx
@@ -59,11 +59,10 @@ function voteViewTable(votes: VoteView[], myUserInfo: MyUserInfo | undefined) {
                 />
                 <UserBadges
                   classNames="ms-1"
-                  person={v.creator}
+                  creator={v.creator}
                   isBanned={v.creator_banned}
                   isBannedFromCommunity={v.creator_banned_from_community}
                   myUserInfo={myUserInfo}
-                  targetPersonId={v.creator.id}
                 />
               </td>
               <td className="text-end">{scoreToIcon(v.score)}</td>

--- a/src/shared/components/common/user-badges.tsx
+++ b/src/shared/components/common/user-badges.tsx
@@ -2,15 +2,15 @@ import classNames from "classnames";
 import { Component } from "inferno";
 import { I18NextService } from "../../services";
 import { tippyMixin } from "../mixins/tippy-mixin";
+import { Person } from "lemmy-js-client";
 
 interface UserBadgesProps {
   isBanned?: boolean;
   isBannedFromCommunity?: boolean;
-  isDeleted?: boolean;
   isPostCreator?: boolean;
   isModerator?: boolean;
   isAdmin?: boolean;
-  isBot?: boolean;
+  person?: Person;
   classNames?: string;
 }
 
@@ -39,14 +39,26 @@ function getRoleLabelPill({
 @tippyMixin
 export class UserBadges extends Component<UserBadgesProps> {
   render() {
+    const isBot = this.props.person?.bot_account;
+    const isDeleted = this.props.person?.deleted;
+    var isNewAccount = false;
+    if (this.props.person !== undefined) {
+      // 7 days ago
+      // https://stackoverflow.com/a/563442
+      var date = new Date();
+      date.setDate(date.getDate() - 7);
+      isNewAccount = new Date(this.props.person?.published_at) > date;
+    }
+
     return (
       (this.props.isBanned ||
         this.props.isBannedFromCommunity ||
-        this.props.isDeleted ||
+        isDeleted ||
         this.props.isPostCreator ||
         this.props.isModerator ||
         this.props.isAdmin ||
-        this.props.isBot) && (
+        isBot ||
+        isNewAccount) && (
         <span
           className={classNames(
             "row d-inline-flex gx-1",
@@ -73,7 +85,7 @@ export class UserBadges extends Component<UserBadgesProps> {
               })}
             </span>
           )}
-          {this.props.isDeleted && (
+          {isDeleted && (
             <span className="col">
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("deleted"),
@@ -112,12 +124,21 @@ export class UserBadges extends Component<UserBadgesProps> {
               })}
             </span>
           )}
-          {this.props.isBot && (
+          {isBot && (
             <span className="col">
               {getRoleLabelPill({
                 label: I18NextService.i18n.t("bot_account").toLowerCase(),
                 tooltip: I18NextService.i18n.t("bot_account"),
               })}
+            </span>
+          )}
+          {isNewAccount && (
+            <span
+              className="col"
+              aria-label={I18NextService.i18n.t("new_account_label")}
+              data-tippy-content={I18NextService.i18n.t("new_account_label")}
+            >
+              🌱
             </span>
           )}
         </span>

--- a/src/shared/components/common/user-badges.tsx
+++ b/src/shared/components/common/user-badges.tsx
@@ -2,7 +2,8 @@ import classNames from "classnames";
 import { Component } from "inferno";
 import { I18NextService } from "../../services";
 import { tippyMixin } from "../mixins/tippy-mixin";
-import { MyUserInfo, Person, PersonActions, PersonId } from "lemmy-js-client";
+import { MyUserInfo, Person, PersonActions } from "lemmy-js-client";
+import { isWeekOld } from "@utils/date";
 
 interface UserBadgesProps {
   isBanned?: boolean;
@@ -10,9 +11,8 @@ interface UserBadgesProps {
   isPostCreator?: boolean;
   isModerator?: boolean;
   isAdmin?: boolean;
-  person?: Person;
+  creator: Person;
   myUserInfo?: MyUserInfo;
-  targetPersonId: PersonId;
   personActions?: PersonActions;
   classNames?: string;
 }
@@ -42,24 +42,17 @@ function getRoleLabelPill({
 @tippyMixin
 export class UserBadges extends Component<UserBadgesProps> {
   render() {
-    const isBot = this.props.person?.bot_account;
-    const isDeleted = this.props.person?.deleted;
-    var isNewAccount = false;
-    if (this.props.person !== undefined) {
-      // 7 days ago
-      // https://stackoverflow.com/a/563442
-      var date = new Date();
-      date.setDate(date.getDate() - 7);
-      isNewAccount = new Date(this.props.person?.published_at) > date;
-    }
+    const isBot = this.props.creator?.bot_account;
+    const isDeleted = this.props.creator?.deleted;
+    const isNewAccount = !isWeekOld(new Date(this.props.creator.published_at));
 
-    const local_user_view = this.props.myUserInfo?.local_user_view;
+    const localUserView = this.props.myUserInfo?.local_user_view;
     // Only show the person votes if:
     const showPersonVotes =
       // the setting is turned on,
-      local_user_view?.local_user.show_person_votes &&
+      localUserView?.local_user.show_person_votes &&
       // for other users,
-      local_user_view.person?.id !== this.props.targetPersonId &&
+      localUserView.person?.id !== this.props.creator?.id &&
       // and theres at least one up or downvote
       (this.props.personActions?.upvotes ||
         this.props.personActions?.downvotes);

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -816,9 +816,8 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
                       <UserBadges
                         classNames="ms-1"
                         isBanned={pv.creator_banned}
-                        isDeleted={pv.person.deleted}
                         isAdmin={pv.is_admin}
-                        isBot={pv.person.bot_account}
+                        person={pv.person}
                       />
                     </li>
                   </ul>

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -822,9 +822,8 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
                         classNames="ms-1"
                         isBanned={pv.creator_banned}
                         isAdmin={pv.is_admin}
-                        person={pv.person}
+                        creator={pv.person}
                         myUserInfo={this.isoData.myUserInfo}
-                        targetPersonId={pv.person.id}
                         personActions={pv.person_actions}
                       />
                     </li>

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -437,7 +437,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           classNames="ms-1"
           isModerator={pv.creator_is_moderator}
           isAdmin={pv.creator_is_admin}
-          isBot={pv.creator.bot_account}
+          person={pv.creator}
           isBanned={pv.creator_banned}
           isBannedFromCommunity={pv.creator_banned_from_community}
         />

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -440,11 +440,10 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           classNames="ms-1"
           isModerator={pv.creator_is_moderator}
           isAdmin={pv.creator_is_admin}
-          person={pv.creator}
+          creator={pv.creator}
           isBanned={pv.creator_banned}
           isBannedFromCommunity={pv.creator_banned_from_community}
           myUserInfo={this.props.myUserInfo}
-          targetPersonId={pv.creator.id}
           personActions={pv.person_actions}
         />
         {this.props.showCommunity && (

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -8,6 +8,7 @@ import {
   getYear,
   setYear,
   formatDistanceToNowStrict,
+  subDays,
 } from "date-fns";
 
 export function futureDaysToUnixTime(days?: number): number | undefined {
@@ -72,4 +73,11 @@ function convertUTCDateToLocalDate(date: Date): Date {
 
 export function nowBoolean(bool?: boolean): string | undefined {
   return bool ? new Date().toISOString() : undefined;
+}
+
+// Returns true if the date is more than 6 days ago.
+// https://stackoverflow.com/a/563442
+export function isWeekOld(date: Date): boolean {
+  const weekAgo = subDays(new Date(), 7);
+  return date < weekAgo;
 }

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -75,7 +75,7 @@ export function nowBoolean(bool?: boolean): string | undefined {
   return bool ? new Date().toISOString() : undefined;
 }
 
-// Returns true if the date is more than 6 days ago.
+// Returns true if the date is more than 7 days ago.
 // https://stackoverflow.com/a/563442
 export function isWeekOld(date: Date): boolean {
   const weekAgo = subDays(new Date(), 7);


### PR DESCRIPTION
## Description

Its a good idea to indicate new accounts. On one hand this makes it easy to welcome new users, on the other hand it can make mods aware of potential troll or alt accounts.

<img width="450" height="116" alt="Screenshot_20250902_102321" src="https://github.com/user-attachments/assets/409514eb-af5d-491a-83ad-73b576b0d3d8" />

Translation: https://github.com/LemmyNet/lemmy-translations/pull/181