### PR TITLE
Remove outline for username button

### DIFF
--- a/src/shared/components/app/navbar.tsx
+++ b/src/shared/components/app/navbar.tsx
@@ -381,7 +381,7 @@ export class Navbar extends Component<NavbarProps, NavbarState> {
                     <li id="dropdownUser" className="dropdown">
                       <button
                         type="button"
-                        className="btn btn-outline-secondary dropdown-toggle"
+                        className="btn dropdown-toggle"
                         aria-expanded="false"
                         data-bs-toggle="dropdown"
                       >


### PR DESCRIPTION
The username with dropdown on the top right somehow received an outline during 1.0 changes. Removing this to be consistent with 0.19