### PR TITLE
Use a functional component for LanguageList.

### DIFF
--- a/src/shared/components/common/language-list.tsx
+++ b/src/shared/components/common/language-list.tsx
@@ -1,10 +1,12 @@
 import { I18NextService } from "@services/index";
 import { Language } from "lemmy-js-client";
 
-export function renderLanguageList(
-  allLanguages?: Language[],
-  languageIds?: number[],
-) {
+interface LanguageListProps {
+  allLanguages?: Language[];
+  languageIds?: number[];
+}
+
+export function LanguageList({ allLanguages, languageIds }: LanguageListProps) {
   const langs = allLanguages?.filter(x => languageIds?.includes(x.id));
 
   const showLanguages =

--- a/src/shared/components/community/sidebar.tsx
+++ b/src/shared/components/community/sidebar.tsx
@@ -28,7 +28,7 @@ import { CommunityLink } from "../community/community-link";
 import { PersonListing } from "../person/person-listing";
 import { tippyMixin } from "../mixins/tippy-mixin";
 import CommunityReportModal from "@components/common/modal/community-report-modal";
-import { renderLanguageList } from "@components/common/language-list";
+import { LanguageList } from "@components/common/language-list";
 
 interface SidebarProps {
   community_view: CommunityView;
@@ -272,10 +272,10 @@ export class Sidebar extends Component<SidebarProps, SidebarState> {
                   )}
                 </p>
               </div>
-              {renderLanguageList(
-                this.props.allLanguages,
-                this.props.siteLanguages,
-              )}
+              <LanguageList
+                allLanguages={this.props.allLanguages}
+                languageIds={this.props.siteLanguages}
+              />
               <Badges
                 communityId={id}
                 subject={this.props.community_view.community}

--- a/src/shared/components/home/site-sidebar.tsx
+++ b/src/shared/components/home/site-sidebar.tsx
@@ -14,7 +14,7 @@ import { BannerIconHeader } from "../common/banner-icon-header";
 import { Icon } from "../common/icon";
 import { PersonListing } from "../person/person-listing";
 import { tippyMixin } from "../mixins/tippy-mixin";
-import { renderLanguageList } from "@components/common/language-list";
+import { LanguageList } from "@components/common/language-list";
 
 interface SiteSidebarProps {
   site: Site;
@@ -103,7 +103,10 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
       <div>
         {site.description && <h6>{site.description}</h6>}
         {site.sidebar && this.siteSidebar(site.sidebar)}
-        {renderLanguageList(this.props.allLanguages, this.props.siteLanguages)}
+        <LanguageList
+          allLanguages={this.props.allLanguages}
+          languageIds={this.props.siteLanguages}
+        />
         {this.props.localSite && <Badges subject={this.props.localSite} />}
         {this.props.admins && this.admins(this.props.admins)}
       </div>


### PR DESCRIPTION
Used a functional component.

Really we should *always* be using these, even internally for a component. But for now we should at least make sure external ones always use components. 