### PR TITLE
Highlight new comments using the last read comments time.

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -81,6 +81,7 @@ type CommentNodeProps = {
    **/
   community?: Community;
   admins: PersonView[];
+  readCommentsAt?: string;
   noBorder?: boolean;
   isTopLevel?: boolean;
   viewOnly?: boolean;
@@ -492,6 +493,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
             community={this.community}
             locked={this.props.locked}
             admins={this.props.admins}
+            readCommentsAt={this.props.readCommentsAt}
             viewType={this.props.viewType}
             allLanguages={this.props.allLanguages}
             siteLanguages={this.props.siteLanguages}
@@ -618,8 +620,15 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     return res;
   }
 
+  /**
+   * From the post screen, use the last readCommentsAt time.
+   *
+   * For everything else, use 10 minutes.
+   **/
   get isCommentNew(): boolean {
-    const now = subMinutes(new Date(), 10);
+    const now = this.props.readCommentsAt
+      ? parseISO(this.props.readCommentsAt)
+      : subMinutes(new Date(), 10);
     const then = parseISO(this.commentView.comment.published_at);
     return isBefore(now, then);
   }

--- a/src/shared/components/comment/comment-nodes.tsx
+++ b/src/shared/components/comment/comment-nodes.tsx
@@ -43,6 +43,7 @@ interface CommentNodesProps {
    **/
   community?: Community;
   admins: PersonView[];
+  readCommentsAt?: string;
   maxCommentsShown?: number;
   noBorder?: boolean;
   isTopLevel?: boolean;
@@ -118,6 +119,7 @@ export class CommentNodes extends Component<CommentNodesProps, any> {
               viewOnly={this.props.viewOnly}
               locked={this.props.locked}
               admins={this.props.admins}
+              readCommentsAt={this.props.readCommentsAt}
               showContext={this.props.showContext}
               showCommunity={this.props.showCommunity}
               viewType={this.props.viewType}

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -804,6 +804,9 @@ export class Post extends Component<PostRouteProps, PostState> {
             isTopLevel
             locked={postRes.data.post_view.post.locked}
             admins={siteRes.admins}
+            readCommentsAt={
+              postRes.data.post_view.post_actions?.read_comments_at
+            }
             showContext
             allLanguages={siteRes.all_languages}
             siteLanguages={siteRes.discussion_languages}
@@ -916,6 +919,9 @@ export class Post extends Component<PostRouteProps, PostState> {
             maxCommentsShown={this.state.maxCommentsShown}
             locked={postRes.data.post_view.post.locked}
             admins={siteRes.admins}
+            readCommentsAt={
+              postRes.data.post_view.post_actions?.read_comments_at
+            }
             allLanguages={siteRes.all_languages}
             siteLanguages={siteRes.discussion_languages}
             myUserInfo={this.isoData.myUserInfo}


### PR DESCRIPTION
- Uses the `post_actions.read_comments_at` field for the post screen.
- Everywhere else still uses the 10m default.
- Fixes #3216

