### PR TITLE
Properly render multi-line deny reason (fixes #3103)

### DIFF
--- a/src/shared/components/common/registration-application.tsx
+++ b/src/shared/components/common/registration-application.tsx
@@ -111,7 +111,7 @@ export class RegistrationApplication extends Component<
                   <div>
                     {I18NextService.i18n.t("deny_reason")}:{" "}
                     <div
-                      className="md-div d-inline-flex"
+                      className="md-div"
                       dangerouslySetInnerHTML={mdToHtml(ra.deny_reason, () =>
                         this.forceUpdate(),
                       )}


### PR DESCRIPTION
<img width="995" height="824" alt="Screenshot_20250919_160221" src="https://github.com/user-attachments/assets/e620ea7f-de7e-4b8d-b6af-bba7b38d6615" />
