### PR TITLE
Fix Arabic user/community names (fixes #2207)

### DIFF
--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -297,8 +297,9 @@ export class Community extends Component<CommunityRouteProps, State> {
   async fetchCommunity(props: CommunityRouteProps) {
     const token = (this.fetchCommunityToken = Symbol());
     this.setState({ communityRes: LOADING_REQUEST });
+    const name = decodeURIComponent(props.match.params.name);
     const communityRes = await HttpService.client.getCommunity({
-      name: props.match.params.name,
+      name,
     });
     if (token === this.fetchCommunityToken) {
       this.setState({ communityRes });
@@ -329,9 +330,7 @@ export class Community extends Component<CommunityRouteProps, State> {
   static async fetchInitialData({
     headers,
     query: { dataType, cursor, sort, postTimeRange, showHidden },
-    match: {
-      params: { name: communityName },
-    },
+    match: { params: props },
   }: InitialFetchRequest<
     CommunityPathProps,
     CommunityProps
@@ -340,6 +339,7 @@ export class Community extends Component<CommunityRouteProps, State> {
       new LemmyHttp(getHttpBaseInternal(), { headers }),
     );
 
+    const communityName = decodeURIComponent(props.name);
     const communityForm: GetCommunity = {
       name: communityName,
     };
@@ -807,7 +807,7 @@ export class Community extends Component<CommunityRouteProps, State> {
   async fetchData(props: CommunityRouteProps) {
     const token = (this.fetchDataToken = Symbol());
     const { dataType, cursor, sort, postTimeRange, showHidden } = props;
-    const { name } = props.match.params;
+    const name = decodeURIComponent(props.match.params.name);
 
     if (dataType === DataType.Post) {
       this.setState({ postsRes: LOADING_REQUEST, commentsRes: EMPTY_REQUEST });

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -363,16 +363,15 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
   }
 
   fetchUserDataToken?: symbol;
-  async fetchUserData(props: ProfileRouteProps, showBothLoading = false) {
+  async fetchUserData(props_: ProfileRouteProps, showBothLoading = false) {
     const token = (this.fetchUserDataToken = Symbol());
     const {
       cursor,
       view,
       filter,
-      match: {
-        params: { username },
-      },
-    } = props;
+      match: { params: props },
+    } = props_;
+    const username = decodeURIComponent(props.username);
     const isMe = usernameIsPerson(
       username, // amCurrentUser would use the old username
       this.isoData.myUserInfo?.local_user_view.person,
@@ -400,12 +399,12 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
     await Promise.all([
       needPerson &&
         HttpService.client.getPersonDetails({
-          username: props.match.params.username,
+          username,
         }),
       needContent &&
         HttpService.client.listPersonContent({
           type_,
-          username: props.match.params.username,
+          username,
           ...cursorComponents(cursor),
           limit: fetchLimit,
         }),
@@ -471,9 +470,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
   static async fetchInitialData({
     headers,
     query: { view, cursor, filter },
-    match: {
-      params: { username },
-    },
+    match: { params: props },
     myUserInfo,
   }: InitialFetchRequest<
     ProfilePathProps,
@@ -482,6 +479,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
     const client = wrapClient(
       new LemmyHttp(getHttpBaseInternal(), { headers }),
     );
+    const username = decodeURIComponent(props.username);
     const isMe = usernameIsPerson(username, myUserInfo?.local_user_view.person);
 
     const needUploads = isMe && view === "Uploads";


### PR DESCRIPTION
<img width="861" height="441" alt="Screenshot_20250919_163640" src="https://github.com/user-attachments/assets/efad6d5c-cb74-42c9-a4a6-4d46c3628ae7" />

I wonder if there are any other params missing this decoding.