### PR TITLE
Downscale proxied thumbnails (fixes #2591)

### DIFF
--- a/src/shared/components/common/pictrs-image.tsx
+++ b/src/shared/components/common/pictrs-image.tsx
@@ -99,7 +99,11 @@ export class PictrsImage extends Component<PictrsImageProps, PictrsImageState> {
     }
 
     // If there's no match, then it's not a pictrs image
-    if (!url.pathname.includes("/pictrs/image/")) {
+    if (
+      !url.pathname.includes("/pictrs/image/") &&
+      !url.pathname.includes("/api/v3/image_proxy") &&
+      !url.pathname.includes("/api/v4/image/proxy")
+    ) {
       return this.state.src;
     }
 


### PR DESCRIPTION
Its as easy as this. Both proxied and unproxied image are loaded without problems, and in both cases the thumbnail is the same size (256px).