### PR TITLE
Fix "show context" (fixes #3496)

### DIFF
--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -1002,7 +1002,7 @@ export class Post extends Component<PostRouteProps, PostState> {
     if (this.state.commentsRes.state === "success") {
       const comments = this.state.commentsRes.data.comments;
       if (comments.length) {
-        return buildCommentsTree(comments, !!getCommentIdFromProps(this.props));
+        return buildCommentsTree(comments, getCommentIdFromProps(this.props));
       }
     }
     return [];

--- a/src/shared/utils/app.ts
+++ b/src/shared/utils/app.ts
@@ -26,6 +26,7 @@ import {
   Person,
   CommentSlimView,
   Community,
+  CommentId,
 } from "lemmy-js-client";
 import {
   CommentNodeI,
@@ -55,15 +56,13 @@ import Toastify from "toastify-js";
 
 export function buildCommentsTree(
   comments: CommentSlimView[],
-  parentComment: boolean,
+  parentCommentId?: CommentId,
 ): CommentNodeI[] {
   const map = new Map<number, CommentNodeI>();
-  const depthOffset = !parentComment
-    ? 0
-    : (getDepthFromComment(comments[0].comment) ?? 0);
+  const parentComment = comments.find(c => c.comment.id === parentCommentId);
+  const depthOffset = getDepthFromComment(parentComment?.comment) ?? 0;
 
-  const comments_sorted = comments.sort((a, b) => a.comment.id - b.comment.id);
-  for (const comment_view of comments_sorted) {
+  for (const comment_view of comments) {
     const depthI = getDepthFromComment(comment_view.comment) ?? 0;
     const depth = depthI ? depthI - depthOffset : 0;
     const node: CommentNodeI = {
@@ -77,8 +76,8 @@ export function buildCommentsTree(
   const tree: CommentNodeI[] = [];
 
   // if its a parent comment fetch, then push the first comment to the top node.
-  if (parentComment) {
-    const cNode = map.get(comments[0].comment.id);
+  if (parentCommentId) {
+    const cNode = map.get(parentCommentId);
     if (cNode) {
       tree.push(cNode);
     }

--- a/src/shared/utils/app.ts
+++ b/src/shared/utils/app.ts
@@ -62,7 +62,8 @@ export function buildCommentsTree(
     ? 0
     : (getDepthFromComment(comments[0].comment) ?? 0);
 
-  for (const comment_view of comments) {
+  const comments_sorted = comments.sort((a, b) => a.comment.id - b.comment.id);
+  for (const comment_view of comments_sorted) {
     const depthI = getDepthFromComment(comment_view.comment) ?? 0;
     const depth = depthI ? depthI - depthOffset : 0;
     const node: CommentNodeI = {


### PR DESCRIPTION
Seems like lemmy-ui assumes that parent comments are always listed first, but this is not the case anymore. Worth considering to fix this in the backend instead as it may affect other frontends too.