### PR TITLE
In comment search results show post and community (fixes #1959)

### DIFF
--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -303,6 +303,7 @@ const commentListing = (comments: CommentView[], isoData: IsoData) => {
               viewOnly
               postLocked
               isTopLevel
+              showCommunity
               myUserInfo={isoData.myUserInfo}
               localSite={isoData.siteRes.site_view.local_site}
               allLanguages={isoData.siteRes.all_languages}
@@ -849,6 +850,7 @@ export class Search extends Component<SearchRouteProps, SearchState> {
         viewOnly
         postLocked
         isTopLevel
+        showCommunity
         allLanguages={siteRes.all_languages}
         siteLanguages={siteRes.discussion_languages}
         myUserInfo={this.isoData.myUserInfo}


### PR DESCRIPTION
<img width="725" height="215" alt="Screenshot_20251002_153258" src="https://github.com/user-attachments/assets/6dcb321e-5b98-434a-ba19-7f8c776d20c0" />

Basically looks the same as comment listing on the homepage now.