### PR TITLE
Fix link-dark issues

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -522,7 +522,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
       <Link
         className={`d-inline ${
           !post.featured_community && !post.featured_local
-            ? "link-dark"
+            ? "text-body"
             : "link-primary"
         }`}
         to={`/post/${post.id}`}
@@ -548,7 +548,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
               <a
                 className={
                   !post.featured_community && !post.featured_local
-                    ? "link-dark"
+                    ? "text-body"
                     : "link-primary"
                 }
                 href={url}
@@ -644,7 +644,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           <p className="small m-0">
             {url && !(hostname(url) === getExternalHost()) && (
               <a
-                className="fst-italic link-dark link-opacity-75 link-opacity-100-hover"
+                className="fst-italic text-body link-opacity-75 link-opacity-100-hover"
                 href={url}
                 title={url}
                 rel={relTags}
@@ -725,7 +725,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
                   <div className="post-title">
                     <h1 className="h5 d-inline text-break">
                       <Link
-                        className="d-inline link-dark"
+                        className="d-inline text-body"
                         to={`/post/${pv.post.id}`}
                         title={I18NextService.i18n.t("comments")}
                       >
@@ -977,7 +977,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     return (
       <button
         type="button"
-        className="btn btn-sm btn-link link-dark link-opacity-75 link-opacity-100-hover py-0 align-baseline"
+        className="btn btn-sm btn-link text-body link-opacity-75 link-opacity-100-hover py-0 align-baseline"
         onClick={linkEvent(this, this.handleShowBody)}
         aria-pressed={!this.state.showBody ? "false" : "true"}
       >


### PR DESCRIPTION
- link-dark appears to be broken on many themes, including our default one. 
- Its safer to use text-body.


## Screenshots

With a dark mode browser plugin:

### Before

<img width="1302" height="866" alt="Screenshot_2025-10-07-18-12-32-518_mark via" src="https://github.com/user-attachments/assets/93b5e472-eeb6-4931-85d4-152f92587bb5" />

### After

<img width="1353" height="858" alt="Screenshot_2025-10-07-18-12-14-593_mark via" src="https://github.com/user-attachments/assets/1e0ebb93-1d08-41c6-8e14-8546d1b1e5bc" />

