### PR TITLE
Consistent size for action buttons (ref #3503)

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -454,7 +454,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                         />
                         <button
                           type="button"
-                          className="btn btn-sm btn-link btn-animate text-muted"
+                          className="btn btn-sm btn-link btn-animate text-muted py-0"
                           onClick={linkEvent(this, handleToggleViewSource)}
                           data-tippy-content={I18NextService.i18n.t(
                             "view_source",

--- a/src/shared/components/common/content-actions/action-button.tsx
+++ b/src/shared/components/common/content-actions/action-button.tsx
@@ -56,7 +56,7 @@ export default class ActionButton extends Component<
     return (
       <button
         className={classNames(
-          "btn btn-link btn-sm",
+          "btn btn-link",
           inline || inlineWithText
             ? "btn-animate text-body py-0"
             : "d-flex align-items-center rounded-0 dropdown-item",

--- a/src/shared/components/common/content-actions/content-action-dropdown.tsx
+++ b/src/shared/components/common/content-actions/content-action-dropdown.tsx
@@ -235,7 +235,7 @@ export default class ContentActionDropdown extends Component<
 
         <div className="dropdown">
           <button
-            className="btn btn-sm btn-link btn-animate text-muted py-0 dropdown-toggle"
+            className="btn btn-link btn-animate text-muted py-0 dropdown-toggle"
             data-tippy-content={I18NextService.i18n.t("more")}
             data-bs-toggle="dropdown"
             aria-expanded="false"

--- a/src/shared/components/common/content-actions/cross-post-button.tsx
+++ b/src/shared/components/common/content-actions/cross-post-button.tsx
@@ -7,7 +7,7 @@ import { InfernoNode } from "inferno";
 export default function CrossPostButton(props: CrossPostParams): InfernoNode {
   return (
     <Link
-      className="btn btn-sm btn-link btn-animate text-muted py-0"
+      className="btn btn-link btn-animate text-muted py-0"
       to={{
         pathname: "/create_post",
         state: props,

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -804,7 +804,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         {this.commentsButton}
         {canShare() && (
           <button
-            className="btn btn-sm btn-link btn-animate text-muted py-0"
+            className="btn btn-link btn-animate text-muted py-0"
             onClick={linkEvent(this, this.handleShare)}
             type="button"
           >
@@ -812,14 +812,14 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           </button>
         )}
         <Link
-          className="btn btn-sm btn-link btn-animate text-muted"
+          className="btn btn-link btn-animate text-muted py-0"
           to={`/post/${id}`}
           title={I18NextService.i18n.t("link")}
         >
           <Icon icon="link" classes="icon-inline" />
         </Link>
         <a
-          className="btn btn-sm btn-link btn-animate text-muted py-0"
+          className="btn btn-link btn-animate text-muted py-0"
           title={I18NextService.i18n.t("fedilink")}
           href={ap_id}
         >
@@ -828,7 +828,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
         {this.props.markable && this.props.myUserInfo && (
           <button
             type="button"
-            className="btn btn-sm btn-link btn-animate text-muted"
+            className="btn btn-link btn-animate text-muted py-0"
             onClick={this.handleMarkPostAsRead}
             data-tippy-content={
               this.props.read
@@ -915,7 +915,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
 
     return (
       <Link
-        className="btn btn-sm btn-link text-muted ps-0"
+        className="btn btn-sm btn-link text-muted ps-0 py-0"
         title={title}
         to={`/post/${pv.post.id}?scrollToComments=true`}
         data-tippy-content={title}
@@ -947,7 +947,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   get viewSourceButton() {
     return (
       <button
-        className="btn btn-sm btn-link btn-animate text-muted py-0"
+        className="btn btn-link btn-animate text-muted py-0"
         onClick={linkEvent(this, this.handleViewSource)}
         data-tippy-content={I18NextService.i18n.t("view_source")}
         aria-label={I18NextService.i18n.t("view_source")}
@@ -977,7 +977,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     return (
       <button
         type="button"
-        className="btn btn-sm btn-link link-dark link-opacity-75 link-opacity-100-hover py-0 align-baseline"
+        className="btn btn-link link-dark link-opacity-75 link-opacity-100-hover align-baseline py-0"
         onClick={linkEvent(this, this.handleShowBody)}
         aria-pressed={!this.state.showBody ? "false" : "true"}
       >


### PR DESCRIPTION
Dont use `btn-sm` but instead use `py-0` for all action buttons (this was previously inconsistent). Previously post action buttons were 31 or 23px high. Now post buttons are rendered larger and use less vertical space with 23 or 26px (its difficult to make them all the exact same height).