### PR TITLE
Attempt to optimize initial page load

### DIFF
--- a/src/server/utils/create-ssr-html.tsx
+++ b/src/server/utils/create-ssr-html.tsx
@@ -91,34 +91,10 @@ export async function createSsrHtml(
     <!DOCTYPE html>
     <html ${helmet.htmlAttributes.toString()}>
     <head>
-    <script nonce="${cspNonce}">
-    window.isoData = ${serialize(isoData)};
-
-    ${embeddedScript}
-    </script>
-    ${lazyScripts}
-  
-    <!-- A remote debugging utility for mobile -->
-    ${erudaStr}
-  
-    <!-- Custom injected script -->
-    ${customHtmlHeaderWithNonce}
-  
-    ${helmet.title.toString()}
-    ${helmet.meta.toString()}
-  
-    <style>
-    #app[data-adult-consent] {
-      filter: blur(10px);
-      -webkit-filter: blur(10px);
-      -moz-filter: blur(10px);
-      -o-filter: blur(10px);
-      -ms-filter: blur(10px);
-      pointer-events: none;
-    }
-    </style>
 
     <!-- Required meta tags -->
+    ${helmet.title.toString()}
+    ${helmet.meta.toString()}
     <meta name="Description" content="Lemmy">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -133,13 +109,14 @@ export async function createSsrHtml(
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href=${appleTouchIcon} />
     <link rel="apple-touch-startup-image" href=${appleTouchIcon} />
-  
-    <!-- Styles -->
-    <link rel="stylesheet" type="text/css" href="${getStaticDir()}/styles/styles.css" />
-  
-    <!-- Current theme and more -->
-    ${helmet.link.toString() || fallbackTheme}
     
+    <!-- specify icon size so they arent rendered too large before css is loaded -->
+    <style>
+    .icon {
+    width: 1em;
+    height: 1em;
+      }
+    </style>
     </head>
   
     <body ${helmet.bodyAttributes.toString()}>
@@ -150,8 +127,42 @@ export async function createSsrHtml(
       </noscript>
   
       <div id='root'>${root}</div>
-      <script defer src='${getStaticDir()}/js/client.js'></script>
     </body>
+
+    <!-- 
+      Styles with deferred loading
+      https://www.filamentgroup.com/lab/load-css-simpler/
+    -->
+    <link rel="stylesheet" href="${getStaticDir()}/styles/styles.css" media="print" onload="this.media='all'">
+
+  
+    <!-- Current theme and more -->
+    ${helmet.link.toString() || fallbackTheme}
+
+    <script nonce="${cspNonce}">
+    window.isoData = ${serialize(isoData)};
+
+    ${embeddedScript}
+    </script>
+      <script defer src='${getStaticDir()}/js/client.js'></script>
+    ${lazyScripts}
+
+      <!-- A remote debugging utility for mobile -->
+          ${erudaStr}
+          
+    <!-- Custom injected script -->
+    ${customHtmlHeaderWithNonce}
+  
+    <style>
+    #app[data-adult-consent] {
+      filter: blur(10px);
+      -webkit-filter: blur(10px);
+      -moz-filter: blur(10px);
+      -o-filter: blur(10px);
+      -ms-filter: blur(10px);
+      pointer-events: none;
+    }
+    </style>
   </html>
   `;
 }


### PR DESCRIPTION
[Chrome dev tools](https://developer.chrome.com/docs/devtools/performance/overview) have some optimization suggestions so I tried them:
- Moved all styles and scripts to footer
- Also use deferred loading for main styles

As a result the "Insight" for render blocking requests goes away, as the browser doesnt have to wait for css to finish loading before rendering the page. However this means the page is first rendered without styling and results in significant cumulative layout shift.

Measurements with 4x cpu slowdown and slow 4g network, eruda commented out:
main branch: LCP 5.6s, CLS 0
voyager (prod build): LCP 3.7s, CLS 0
this branch: LCP 5.25s, CLS 0.9

And with fast 4g network:
main branch: LCP 1.6s, CLS 0
voyager (prod build): 0.8s, CLS 0
this branch: LCP 1.3s, CLS 1

So while it solves one problem it creates another, and its not clear that its worth the benefit. We could potentially create a smaller css file which is loaded before html and only blocks rendering for a short time (similar to what I did for icons). Maybe there are tools to create this automatically.

Edit: Tried with [minimalcss](https://github.com/peterbe/minimalcss) but it produces empty output. Also tried [penthouse](https://github.com/pocketjoso/penthouse) via the hosted version but using that doesnt resolve the layout shift at all. Tried [uncss](https://github.com/uncss/uncss) as well but it didnt reduce CLS either.