### PR TITLE
Remove env var LEMMY_UI_HTTPS (fixes #3573)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ The following environment variables can be used to configure lemmy-ui:
 | `LEMMY_UI_BACKEND_INTERNAL`    | `string` | `0.0.0.0:8536`   | The internal IP / port that lemmy is hosted at. Often `lemmy:8536` if using docker. |
 | `LEMMY_UI_BACKEND_EXTERNAL`    | `string` | `0.0.0.0:8536`   | The external IP / port that lemmy is hosted at. Often `DOMAIN.TLD`.                 |
 | `LEMMY_UI_BACKEND_REMOTE`      | `string` | `undefined`      | Domain of a remote Lemmy instance to connect for debugging purposes                 |
-| `LEMMY_UI_HTTPS`               | `bool`   | `false`          | Whether to use https.                                                               |
 | `LEMMY_UI_EXTRA_THEMES_FOLDER` | `string` | `./extra_themes` | A location for additional lemmy css themes.                                         |
 | `LEMMY_UI_DISABLE_CSP`         | `bool`   | `false`          | Disables CSP security headers                                                       |
 | `LEMMY_UI_CUSTOM_HTML_HEADER`  | `string` | `undefined`      | Injects a custom script into `<head>`.                                              |

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,7 +10,6 @@ export LEMMY_UI_BACKEND_REMOTE=voyager.lemmy.ml
 # Use this to develop locally. Change TEST.TLD to your test server.
 # export LEMMY_UI_BACKEND_INTERNAL=0.0.0.0:8536
 # export LEMMY_UI_BACKEND_EXTERNAL=TEST.TLD:8536
-# export LEMMY_UI_HTTPS=false
 
 pnpm i
 pnpm dev

--- a/src/shared/utils/env.ts
+++ b/src/shared/utils/env.ts
@@ -41,8 +41,7 @@ function getSecure() {
   return (
     isBrowser()
       ? window.location.protocol.includes("https") || window.isoData.forceHttps
-      : process.env.LEMMY_UI_HTTPS === "true" ||
-        process.env.LEMMY_UI_BACKEND_REMOTE !== undefined
+      : process.env.LEMMY_UI_BACKEND_REMOTE !== undefined
   )
     ? "s"
     : "";


### PR DESCRIPTION
It seems like this was only used to generate absolute urls like for RSS feeds. As these use relative paths now it doesnt seem necessary anymore.