### PR TITLE
Round vote percentage

### DIFF
--- a/src/shared/components/common/vote-buttons.tsx
+++ b/src/shared/components/common/vote-buttons.tsx
@@ -106,12 +106,13 @@ function tippy(
     });
 
   const pct = calculateUpvotePct(counts.upvotes, counts.downvotes);
+  const pctStr = `${pct.toFixed(0)}%`;
 
   const upvotePctStr =
     showPercentage(localUser, localSite, type) &&
     I18NextService.i18n.t("upvote_percentage", {
       count: Number(pct),
-      formattedCount: Number(pct),
+      formattedCount: pctStr,
     });
 
   const upvoteStr =

--- a/src/shared/utils/app.ts
+++ b/src/shared/utils/app.ts
@@ -775,7 +775,7 @@ export function isAnonymousPath(pathname: string) {
 }
 
 export function calculateUpvotePct(upvotes: number, downvotes: number): number {
-  return Math.round((upvotes / (upvotes + downvotes)) * 100);
+  return (upvotes / (upvotes + downvotes)) * 100;
 }
 
 export function postViewToPersonContentCombinedView(


### PR DESCRIPTION


## Description

Instead of showing the upvote percentage as e.g. "93.93939393939394%", show a rounded number e.g. "94%".

## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before

<img width="862" height="408" alt="image" src="https://github.com/user-attachments/assets/471b6564-6bf3-4c0a-9cfa-ceef09fb4686" />

### After

<img width="449" height="176" alt="image" src="https://github.com/user-attachments/assets/453b620f-afd1-4272-bb67-6281990e4ec7" />
