### PR TITLE
Revert "Development instructions using remote instance"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,17 @@ The official web app for [Lemmy](https://github.com/LemmyNet/lemmy), written in 
 
 Based off of MrFoxPro's [inferno-isomorphic-template](https://github.com/MrFoxPro/inferno-isomorphic-template).
 
-## Development
-
-You need to have [pnpm](https://pnpm.io/installation) installed. Then run the following:
-
-```bash
-git clone https://github.com/LemmyNet/lemmy-ui.git
-cd lemmy-ui
-pnpm install
-LEMMY_UI_DEBUG=true LEMMY_UI_BACKEND_REMOTE=enterprise.lemmy.ml pnpm dev
-```
-
-Finally open `http://0.0.0.0:1234` in your browser. This uses the public test instance `https://enterprise.lemmy.ml/` as backend. You can also connect to any production instance running version 0.19, for example `LEMMY_UI_BACKEND_REMOTE=lemmy.ml`. For more details such as developing with a locally compiled Lemmy backend, read the [documentation](https://join-lemmy.org/docs/contributors/01-overview.html).
-
 ## Configuration
 
 The following environment variables can be used to configure lemmy-ui:
 
-| `ENV_VAR`                      | type     | default          | description                                                                         |
-| ------------------------------ | -------- | ---------------- | ----------------------------------------------------------------------------------- |
-| `LEMMY_UI_HOST`                | `string` | `0.0.0.0:1234`   | The IP / port that the lemmy-ui isomorphic node server is hosted at.                |
-| `LEMMY_UI_LEMMY_INTERNAL_HOST` | `string` | `0.0.0.0:8536`   | The internal IP / port that lemmy is hosted at. Often `lemmy:8536` if using docker. |
-| `LEMMY_UI_LEMMY_EXTERNAL_HOST` | `string` | `0.0.0.0:8536`   | The external IP / port that lemmy is hosted at. Often `DOMAIN.TLD`.                 |
-| `LEMMY_UI_BACKEND_REMOTE`      | `string` | `undefined`      | Domain of a remote Lemmy instance to connect for debugging purposes                 |
-| `LEMMY_UI_HTTPS`               | `bool`   | `false`          | Whether to use https.                                                               |
-| `LEMMY_UI_EXTRA_THEMES_FOLDER` | `string` | `./extra_themes` | A location for additional lemmy css themes.                                         |
-| `LEMMY_UI_DEBUG`               | `bool`   | `false`          | Loads the [Eruda](https://github.com/liriliri/eruda) debugging utility.             |
-| `LEMMY_UI_DISABLE_CSP`         | `bool`   | `false`          | Disables CSP security headers                                                       |
-| `LEMMY_UI_CUSTOM_HTML_HEADER`  | `string` | `undefined`      | Injects a custom script into `<head>`.                                              |
+| `ENV_VAR`                        | type     | default          | description                                                                         |
+|----------------------------------|----------|------------------|-------------------------------------------------------------------------------------|
+| `LEMMY_UI_HOST`                  | `string` | `0.0.0.0:1234`   | The IP / port that the lemmy-ui isomorphic node server is hosted at.                |
+| `LEMMY_UI_LEMMY_INTERNAL_HOST`   | `string` | `0.0.0.0:8536`   | The internal IP / port that lemmy is hosted at. Often `lemmy:8536` if using docker. |
+| `LEMMY_UI_LEMMY_EXTERNAL_HOST`   | `string` | `0.0.0.0:8536`   | The external IP / port that lemmy is hosted at. Often `DOMAIN.TLD`.                 |
+| `LEMMY_UI_HTTPS`                 | `bool`   | `false`          | Whether to use https.                                                               |
+| `LEMMY_UI_EXTRA_THEMES_FOLDER`   | `string` | `./extra_themes` | A location for additional lemmy css themes.                                         |
+| `LEMMY_UI_DEBUG`                 | `bool`   | `false`          | Loads the [Eruda](https://github.com/liriliri/eruda) debugging utility.             |
+| `LEMMY_UI_DISABLE_CSP`           | `bool`   | `false`          | Disables CSP security headers                                                       |
+| `LEMMY_UI_CUSTOM_HTML_HEADER`    | `string` |                  | Injects a custom script into `<head>`.                                              |

--- a/src/server/handlers/catch-all-handler.tsx
+++ b/src/server/handlers/catch-all-handler.tsx
@@ -142,11 +142,7 @@ export default async (req: Request, res: Response) => {
       showAdultConsentModal:
         !!site?.site_view.site.content_warning &&
         !(site.my_user || req.cookies[adultConsentCookieKey]),
-      lemmy_external_host:
-        process.env.LEMMY_UI_BACKEND_REMOTE ??
-        process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST ??
-        testHost,
-      forceHttps: process.env.LEMMY_UI_BACKEND_REMOTE !== undefined,
+      lemmy_external_host: process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST ?? testHost,
     };
 
     const wrapper = (

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -18,7 +18,6 @@ export interface IsoData<T extends RouteData = any> {
   errorPageData?: ErrorPageData;
   showAdultConsentModal: boolean;
   lemmy_external_host: string;
-  forceHttps: boolean;
 }
 
 export type IsoDataOptionalSite<T extends RouteData = any> = Partial<

--- a/src/shared/utils/env/get-base-local.ts
+++ b/src/shared/utils/env/get-base-local.ts
@@ -1,5 +1,5 @@
-import { getHost, getSecure } from "@utils/env";
+import { getHost } from "@utils/env";
 
-export default function getBaseLocal() {
-  return `http${getSecure()}://${getHost()}`;
+export default function getBaseLocal(s = "") {
+  return `http${s}://${getHost()}`;
 }

--- a/src/shared/utils/env/get-external-host.ts
+++ b/src/shared/utils/env/get-external-host.ts
@@ -4,7 +4,5 @@ import { isBrowser } from "@utils/browser";
 export default function getExternalHost() {
   return isBrowser()
     ? window.isoData.lemmy_external_host
-    : (process.env.LEMMY_UI_BACKEND_REMOTE ??
-        process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST ??
-        testHost);
+    : (process.env.LEMMY_UI_LEMMY_EXTERNAL_HOST ?? testHost);
 }

--- a/src/shared/utils/env/get-http-base.ts
+++ b/src/shared/utils/env/get-http-base.ts
@@ -1,5 +1,5 @@
-import { getBaseLocal } from "@utils/env";
+import { getBaseLocal, getSecure } from "@utils/env";
 
 export default function getHttpBase() {
-  return getBaseLocal();
+  return getBaseLocal(getSecure());
 }

--- a/src/shared/utils/env/get-internal-host.ts
+++ b/src/shared/utils/env/get-internal-host.ts
@@ -3,8 +3,6 @@ import { testHost } from "../../config";
 
 export default function getInternalHost() {
   return !isBrowser()
-    ? (process.env.LEMMY_UI_BACKEND_REMOTE ??
-        process.env.LEMMY_UI_LEMMY_INTERNAL_HOST ??
-        testHost)
+    ? (process.env.LEMMY_UI_LEMMY_INTERNAL_HOST ?? testHost)
     : testHost; // used for local dev
 }

--- a/src/shared/utils/env/get-secure.ts
+++ b/src/shared/utils/env/get-secure.ts
@@ -3,9 +3,8 @@ import { isBrowser } from "@utils/browser";
 export default function getSecure() {
   return (
     isBrowser()
-      ? window.location.protocol.includes("https") || window.isoData.forceHttps
-      : process.env.LEMMY_UI_HTTPS === "true" ||
-        process.env.LEMMY_UI_BACKEND_REMOTE !== undefined
+      ? window.location.protocol.includes("https")
+      : process.env.LEMMY_UI_HTTPS === "true"
   )
     ? "s"
     : "";


### PR DESCRIPTION
After deploying 0.19.14-beta.3 to lemmy.ml the site stopped working (even though its fine on enterprise.lemmy.ml). The backend logged lots of errors `actix_http::h1::dispatcher: stream error: request parse error: invalid Header provided`. Most likely there is something wrong with this commit, and its not really worth debugging so Im simply reverting it.