### PR TITLE
Display resolved objects at top of search results (fixes #3656)

### DIFF
--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -246,7 +246,7 @@ const multiCommunityListing = (
 const personListing = (
   persons: PersonView[],
   myUserInfo: MyUserInfo | undefined,
-  showHeader: boolean = false,
+  showHeader: boolean = true,
 ) => {
   return (
     persons.length > 0 && (
@@ -1094,12 +1094,12 @@ export class Search extends Component<SearchRouteProps, SearchState> {
   get resultsCount(): number {
     const { searchRes: r } = this.state;
 
-    const searchCount =
-      r.state === "success"
-        ? r.data.search.length + Number(r.data.resolve !== undefined)
-        : 0;
-
-    return searchCount;
+    if (r.state === "success") {
+      const resolveCount = r.data.resolve !== undefined ? 1 : 0;
+      return r.data.search.length + resolveCount;
+    } else {
+      return 0;
+    }
   }
 
   searchToken?: symbol;


### PR DESCRIPTION
Looks like this:
<img width="968" height="349" alt="Screenshot_20251205_124049" src="https://github.com/user-attachments/assets/b2ad89a1-904e-4fd3-a7f3-914160eb5bb0" />

And here with a comment which contains the resolved url (so it is returned as search result):
<img width="968" height="492" alt="Screenshot_20251205_124102" src="https://github.com/user-attachments/assets/72d44a81-5f52-4cac-9320-375989b6db86" />
