### PR TITLE
Disable broken arm release builds.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -61,7 +61,7 @@ steps:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
       tag: ${CI_COMMIT_TAG=nightly}
     when:
       - event: tag


### PR DESCRIPTION
Related to libvips: #1566 

https://woodpecker.join-lemmy.org/repos/135/pipeline/8497