### PR TITLE
Increase cache duration for static assets to one year

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -59,7 +59,7 @@ if (process.env["NODE_ENV"] === "development") {
   server.use(
     getStaticDir(),
     express.static(serverPath, {
-      maxAge: 24 * 60 * 60 * 1000, // 1 day
+      maxAge: 365 * 24 * 60 * 60 * 1000, // 1 year
       immutable: true,
     }),
   );

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -39,10 +39,6 @@ export function setCacheControl(
   res: Response,
   next: NextFunction,
 ) {
-  if (process.env.NODE_ENV !== "production") {
-    return next();
-  }
-
   let caching: string;
 
   // Only allow caching for success responses


### PR DESCRIPTION
[Pagespeed Insights](https://pagespeed.web.dev/analysis/https-voyager-lemmy-ml-post-33791/8z88cwehs3?form_factor=mobile) considers one day too short, and it actually doesnt make sense to reload client.js every day. In any case there is a hash in the filename so that the new file is loaded after Lemmy upgrade.

<img width="963" height="399" alt="Screenshot_20251217_141327" src="https://github.com/user-attachments/assets/458860f7-694d-47d1-823f-6d034467dc0f" />
