### PR TITLE
Use pattern to validate password length (fixes #3724)

### DIFF
--- a/src/shared/components/common/password-input.tsx
+++ b/src/shared/components/common/password-input.tsx
@@ -102,10 +102,8 @@ class PasswordInput extends Component<PasswordInputProps, PasswordInputState> {
                 onInput={onInput}
                 value={value}
                 required={required !== false}
-                pattern=".+"
+                pattern=".{10,60}"
                 title={I18NextService.i18n.t("invalid_password")}
-                minLength={10}
-                maxLength={60}
               />
               <button
                 className="btn btn-outline-dark"


### PR DESCRIPTION
The maxLength attribute seems to work as intended, the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/maxlength) mention "the browser will generally prevent user from entering more text than the maxlength attribute allows". And Chrome has the same behaviour, so its unlikely that we will get them to change it.

Instead we can use pattern for validation which works as expected in Chromium.