### PR TITLE
Fixed Development Setup Instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,9 @@ You can find more information in the [Backend Repository](https://github.com/Lem
 You need to have [pnpm](https://pnpm.io/installation) installed. Then run the following:
 
 ```bash
-git clone https://github.com/LemmyNet/lemmy-ui.git
+git clone https://github.com/LemmyNet/lemmy-ui.git --recursive
 cd lemmy-ui
 pnpm install
-pnpm translations:init
 LEMMY_UI_BACKEND=https://voyager.lemmy.ml pnpm dev
 ```
 


### PR DESCRIPTION
## Description

`pnpm translations:init` needs to be run before running pnpm dev in order to set up the dev environment, otherwise you get an error that translations are missing

Added the information to the README

