### PR TITLE
Fixed Development Setup Instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can find more information in the [Backend Repository](https://github.com/Lem
 You need to have [pnpm](https://pnpm.io/installation) installed. Then run the following:
 
 ```bash
-git clone https://github.com/LemmyNet/lemmy-ui.git
+git clone https://github.com/LemmyNet/lemmy-ui.git --recursive
 cd lemmy-ui
 pnpm install
 LEMMY_UI_BACKEND=https://voyager.lemmy.ml pnpm dev


### PR DESCRIPTION
When setting up the project with current instructions you get an error for missing translation files that could only be solved with `pnpm translations:init` or `git clone --recursive`

(Couldn't figure out if I successfully updated the previous pull request, so created this new one)