### PR TITLE
Fixing comment create and comment edit loading indicators.

### DIFF
--- a/src/shared/components/comment/comment-form.tsx
+++ b/src/shared/components/comment/comment-form.tsx
@@ -29,6 +29,7 @@ interface CommentFormProps {
   myUserInfo: MyUserInfo | undefined;
   onCreateComment(form: CreateComment): void;
   onEditComment(form: EditComment): void;
+  loading: boolean;
 }
 
 export class CommentForm extends Component<CommentFormProps, any> {
@@ -71,6 +72,7 @@ export class CommentForm extends Component<CommentFormProps, any> {
             allLanguages={this.props.allLanguages}
             siteLanguages={this.props.siteLanguages}
             myUserInfo={this.props.myUserInfo}
+            loading={this.props.loading}
           />
         ) : (
           <div className="alert alert-warning" role="alert">

--- a/src/shared/components/comment/comment-nodes.tsx
+++ b/src/shared/components/comment/comment-nodes.tsx
@@ -8,6 +8,7 @@ import {
   BanPerson,
   BlockCommunity,
   BlockPerson,
+  CommentId,
   Community,
   CreateComment,
   CreateCommentLike,
@@ -59,6 +60,8 @@ interface CommentNodesProps {
   depth?: number;
   myUserInfo: MyUserInfo | undefined;
   localSite: LocalSite;
+  createLoading: CommentId | undefined;
+  editLoading: CommentId | undefined;
   onSaveComment(form: SaveComment): void;
   onCreateComment(form: CreateComment): void;
   onEditComment(form: EditComment): void;
@@ -116,6 +119,8 @@ export class CommentNodes extends Component<CommentNodesProps, any> {
               postLockedOrRemovedOrDeleted={
                 this.props.postLockedOrRemovedOrDeleted
               }
+              createLoading={this.props.createLoading}
+              editLoading={this.props.editLoading}
               admins={this.props.admins}
               readCommentsAt={this.props.readCommentsAt}
               showContext={this.props.showContext}

--- a/src/shared/components/comment/comment-report.tsx
+++ b/src/shared/components/comment/comment-report.tsx
@@ -95,6 +95,8 @@ export class CommentReport extends Component<
           node={commentToFlatNode(comment_view)}
           admins={this.props.admins}
           viewType={"flat"}
+          createLoading={undefined}
+          editLoading={undefined}
           viewOnly
           showCommunity
           showContext={false}

--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -55,6 +55,7 @@ interface MarkdownTextAreaProps {
   siteLanguages?: LanguageId[];
   renderAsDiv?: boolean;
   myUserInfo: MyUserInfo | undefined;
+  loading?: boolean;
 }
 
 interface ImageUploadStatus {
@@ -67,8 +68,6 @@ interface MarkdownTextAreaState {
   languageId?: number;
   previewMode: boolean;
   imageUploadStatus?: ImageUploadStatus;
-  loading: boolean;
-  submitted: boolean;
 }
 
 @tippyMixin
@@ -83,8 +82,6 @@ export class MarkdownTextArea extends Component<
     content: this.props.initialContent,
     languageId: this.props.initialLanguageId,
     previewMode: false,
-    loading: false,
-    submitted: false,
   };
 
   constructor(props: any, context: any) {
@@ -132,8 +129,7 @@ export class MarkdownTextArea extends Component<
           message={I18NextService.i18n.t("block_leaving")}
           when={
             !this.props.hideNavigationWarnings &&
-            ((!!this.state.content && !this.state.submitted) ||
-              this.state.loading)
+            (!!this.state.content || this.props.loading)
           }
         />
         <div className="mb-3 row">
@@ -271,7 +267,7 @@ export class MarkdownTextArea extends Component<
                 className="btn btn-sm btn-secondary ms-2"
                 disabled={this.isDisabled || !this.state.content}
               >
-                {this.state.loading && <Spinner className="me-1" />}
+                {this.props.loading && <Spinner className="me-1" />}
                 {this.props.buttonTitle}
               </button>
             )}
@@ -578,9 +574,7 @@ export class MarkdownTextArea extends Component<
   handleSubmit(i: MarkdownTextArea, event: any) {
     event.preventDefault();
     if (i.state.content) {
-      i.setState({ loading: true, submitted: true });
       i.props.onSubmit?.(i.state.content, i.state.languageId);
-      i.setState({ loading: false });
     }
   }
 
@@ -796,7 +790,7 @@ export class MarkdownTextArea extends Component<
 
   get isDisabled() {
     return (
-      this.state.loading ||
+      this.props.loading ||
       this.props.disabled ||
       !!this.state.imageUploadStatus
     );

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -19,8 +19,8 @@ import {
   resourcesSettled,
 } from "@utils/helpers";
 import { scrollMixin } from "../mixins/scroll-mixin";
-import type { QueryParams, StringBoolean } from "@utils/types";
-import { RouteDataResponse } from "@utils/types";
+import type { CommentIdAndRes, QueryParams, StringBoolean } from "@utils/types";
+import { commentLoading, RouteDataResponse } from "@utils/types";
 import { NoOptionI18nKeys } from "i18next";
 import { Component, InfernoNode, MouseEventHandler, linkEvent } from "inferno";
 import { T } from "inferno-i18next-dess";
@@ -116,6 +116,8 @@ import { MultiCommunityLink } from "@components/multi-community/multi-community-
 interface HomeState {
   postsRes: RequestState<PagedResponse<PostView>>;
   commentsRes: RequestState<PagedResponse<CommentView>>;
+  createCommentRes: CommentIdAndRes;
+  editCommentRes: CommentIdAndRes;
   showSubscribedMobile: boolean;
   showSidebarMobile: boolean;
   subscribedCollapsed: boolean;
@@ -267,6 +269,8 @@ export class Home extends Component<HomeRouteProps, HomeState> {
   state: HomeState = {
     postsRes: EMPTY_REQUEST,
     commentsRes: EMPTY_REQUEST,
+    createCommentRes: { commentId: 0, res: EMPTY_REQUEST },
+    editCommentRes: { commentId: 0, res: EMPTY_REQUEST },
     siteRes: this.isoData.siteRes,
     showSubscribedMobile: false,
     showSidebarMobile: false,
@@ -874,6 +878,8 @@ export class Home extends Component<HomeRouteProps, HomeState> {
           return (
             <CommentNodes
               nodes={commentsToFlatNodes(comments)}
+              createLoading={commentLoading(this.state.createCommentRes)}
+              editLoading={commentLoading(this.state.editCommentRes)}
               viewType={"flat"}
               isTopLevel
               showCommunity
@@ -1124,29 +1130,43 @@ export class Home extends Component<HomeRouteProps, HomeState> {
   }
 
   async handleCreateComment(form: CreateComment) {
-    const createCommentRes = await HttpService.client.createComment(form);
-    this.createAndUpdateComments(createCommentRes);
+    this.setState({
+      createCommentRes: {
+        commentId: form.parent_id ?? 0,
+        res: LOADING_REQUEST,
+      },
+    });
+    const res = await HttpService.client.createComment(form);
+    this.setState({
+      createCommentRes: {
+        commentId: form.parent_id ?? 0,
+        res,
+      },
+    });
+    this.createAndUpdateComments(res);
 
-    if (createCommentRes.state === "failed") {
-      toast(
-        I18NextService.i18n.t(createCommentRes.err.name as NoOptionI18nKeys),
-        "danger",
-      );
+    if (res.state === "failed") {
+      toast(I18NextService.i18n.t(res.err.name as NoOptionI18nKeys), "danger");
     }
-    return createCommentRes;
+    return res;
   }
 
   async handleEditComment(form: EditComment) {
-    const editCommentRes = await HttpService.client.editComment(form);
-    this.findAndUpdateCommentEdit(editCommentRes);
+    this.setState({
+      editCommentRes: { commentId: form.comment_id, res: LOADING_REQUEST },
+    });
 
-    if (editCommentRes.state === "failed") {
-      toast(
-        I18NextService.i18n.t(editCommentRes.err.name as NoOptionI18nKeys),
-        "danger",
-      );
+    const res = await HttpService.client.editComment(form);
+    this.setState({
+      editCommentRes: { commentId: form.comment_id, res },
+    });
+
+    this.findAndUpdateCommentEdit(res);
+
+    if (res.state === "failed") {
+      toast(I18NextService.i18n.t(res.err.name as NoOptionI18nKeys), "danger");
     }
-    return editCommentRes;
+    return res;
   }
 
   async handlePersonNote(form: NotePerson) {

--- a/src/shared/components/person/notifications.tsx
+++ b/src/shared/components/person/notifications.tsx
@@ -12,7 +12,11 @@ import {
   resourcesSettled,
 } from "@utils/helpers";
 import { scrollMixin } from "../mixins/scroll-mixin";
-import { RouteDataResponse } from "@utils/types";
+import {
+  CommentIdAndRes,
+  commentLoading,
+  RouteDataResponse,
+} from "@utils/types";
 import classNames from "classnames";
 import { Component, InfernoNode, linkEvent } from "inferno";
 import {
@@ -103,6 +107,9 @@ interface NotificationsState {
   messageType: NotificationDataType;
   notifsRes: RequestState<PagedResponse<NotificationView>>;
   markAllAsReadRes: RequestState<SuccessResponse>;
+  privateMessageRes: RequestState<PrivateMessageResponse>;
+  createCommentRes: CommentIdAndRes;
+  editCommentRes: CommentIdAndRes;
   cursor?: PaginationCursor;
   siteRes: GetSiteResponse;
   isIsomorphic: boolean;
@@ -132,6 +139,9 @@ export class Notifications extends Component<
     siteRes: this.isoData.siteRes,
     notifsRes: EMPTY_REQUEST,
     markAllAsReadRes: EMPTY_REQUEST,
+    privateMessageRes: EMPTY_REQUEST,
+    createCommentRes: { commentId: 0, res: EMPTY_REQUEST },
+    editCommentRes: { commentId: 0, res: EMPTY_REQUEST },
     isIsomorphic: false,
   };
 
@@ -345,6 +355,8 @@ export class Notifications extends Component<
           <CommentNode
             key={item.notification.id}
             node={commentToFlatNode(data)}
+            createLoading={commentLoading(this.state.createCommentRes)}
+            editLoading={commentLoading(this.state.editCommentRes)}
             viewType={"flat"}
             showCommunity
             showContext
@@ -387,6 +399,9 @@ export class Notifications extends Component<
             onEdit={this.handleEditMessage}
             read={item.notification.read}
             onMarkRead={this.handleMessageMarkAsRead}
+            createOrEditLoading={
+              this.state.privateMessageRes.state === "loading"
+            }
           />
         );
       case "post":
@@ -595,7 +610,19 @@ export class Notifications extends Component<
   }
 
   async handleCreateComment(form: CreateComment) {
+    this.setState({
+      createCommentRes: {
+        commentId: form.parent_id ?? 0,
+        res: LOADING_REQUEST,
+      },
+    });
     const res = await HttpService.client.createComment(form);
+    this.setState({
+      createCommentRes: {
+        commentId: form.parent_id ?? 0,
+        res,
+      },
+    });
 
     if (res.state === "success") {
       toast(I18NextService.i18n.t("reply_sent"));
@@ -606,7 +633,14 @@ export class Notifications extends Component<
   }
 
   async handleEditComment(form: EditComment) {
+    this.setState({
+      editCommentRes: { commentId: form.comment_id, res: LOADING_REQUEST },
+    });
+
     const res = await HttpService.client.editComment(form);
+    this.setState({
+      editCommentRes: { commentId: form.comment_id, res },
+    });
 
     if (res.state === "success") {
       toast(I18NextService.i18n.t("edit"));
@@ -726,7 +760,10 @@ export class Notifications extends Component<
   }
 
   async handleEditMessage(form: EditPrivateMessage): Promise<boolean> {
+    this.setState({ privateMessageRes: LOADING_REQUEST });
     const res = await HttpService.client.editPrivateMessage(form);
+    this.setState({ privateMessageRes: res });
+
     this.findAndUpdateMessage(res);
     if (res.state === "failed") {
       toast(I18NextService.i18n.t(res.err.name as NoOptionI18nKeys), "danger");
@@ -760,7 +797,10 @@ export class Notifications extends Component<
   }
 
   async handleCreateMessage(form: CreatePrivateMessage): Promise<boolean> {
+    this.setState({ privateMessageRes: LOADING_REQUEST });
     const res = await HttpService.client.createPrivateMessage(form);
+    this.setState({ privateMessageRes: res });
+
     this.setState(s => {
       if (s.notifsRes.state === "success" && res.state === "success") {
         s.notifsRes.data.items.unshift({

--- a/src/shared/components/person/person-details.tsx
+++ b/src/shared/components/person/person-details.tsx
@@ -38,6 +38,7 @@ import {
   NotePerson,
   LockComment,
   BlockCommunity,
+  CommentId,
 } from "lemmy-js-client";
 import { CommentNodes } from "../comment/comment-nodes";
 import { PostListing } from "../post/post-listing";
@@ -55,6 +56,8 @@ interface PersonDetailsProps {
   showAdultConsentModal: boolean;
   myUserInfo: MyUserInfo | undefined;
   localSite: LocalSite;
+  createLoading: CommentId | undefined;
+  editLoading: CommentId | undefined;
   onSaveComment(form: SaveComment): Promise<void>;
   onCreateComment(form: CreateComment): Promise<RequestState<CommentResponse>>;
   onEditComment(form: EditComment): Promise<RequestState<CommentResponse>>;
@@ -104,6 +107,8 @@ export class PersonDetails extends Component<PersonDetailsProps, any> {
             noBorder
             showCommunity
             showContext
+            createLoading={this.props.createLoading}
+            editLoading={this.props.editLoading}
             hideImages={false}
             allLanguages={this.props.allLanguages}
             siteLanguages={this.props.siteLanguages}

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -23,8 +23,8 @@ import {
   getApubName,
 } from "@utils/helpers";
 import { amAdmin, canAdmin } from "@utils/roles";
-import type { QueryParams } from "@utils/types";
-import { RouteDataResponse } from "@utils/types";
+import type { CommentIdAndRes, QueryParams } from "@utils/types";
+import { commentLoading, RouteDataResponse } from "@utils/types";
 import classNames from "classnames";
 import { format } from "date-fns";
 import { NoOptionI18nKeys } from "i18next";
@@ -132,6 +132,8 @@ interface ProfileState {
   personHiddenRes: RequestState<PagedResponse<PostView>>;
   uploadsRes: RequestState<PagedResponse<LocalImageView>>;
   registrationRes: RequestState<RegistrationApplicationResponse>;
+  createCommentRes: CommentIdAndRes;
+  editCommentRes: CommentIdAndRes;
   personBlocked: boolean;
   banReason?: string;
   banExpireDays?: number;
@@ -312,6 +314,8 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
     personHiddenRes: EMPTY_REQUEST,
     uploadsRes: EMPTY_REQUEST,
     registrationRes: EMPTY_REQUEST,
+    createCommentRes: { commentId: 0, res: EMPTY_REQUEST },
+    editCommentRes: { commentId: 0, res: EMPTY_REQUEST },
     personBlocked: false,
     siteRes: this.isoData.siteRes,
     showBanDialog: false,
@@ -715,6 +719,8 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
                     admins={siteRes.admins}
                     sort={sort}
                     limit={fetchLimit}
+                    createLoading={commentLoading(this.state.createCommentRes)}
+                    editLoading={commentLoading(this.state.editCommentRes)}
                     enableNsfw={enableNsfw(siteRes)}
                     showAdultConsentModal={this.isoData.showAdultConsentModal}
                     myUserInfo={this.isoData.myUserInfo}
@@ -1403,17 +1409,37 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
   }
 
   async handleCreateComment(form: CreateComment) {
-    const createCommentRes = await HttpService.client.createComment(form);
-    this.createAndUpdateComments(createCommentRes);
+    this.setState({
+      createCommentRes: {
+        commentId: form.parent_id ?? 0,
+        res: LOADING_REQUEST,
+      },
+    });
+    const res = await HttpService.client.createComment(form);
+    this.setState({
+      createCommentRes: {
+        commentId: form.parent_id ?? 0,
+        res,
+      },
+    });
+    this.createAndUpdateComments(res);
 
-    return createCommentRes;
+    return res;
   }
 
   async handleEditComment(form: EditComment) {
-    const editCommentRes = await HttpService.client.editComment(form);
-    this.findAndUpdateComment(editCommentRes);
+    this.setState({
+      editCommentRes: { commentId: form.comment_id, res: LOADING_REQUEST },
+    });
 
-    return editCommentRes;
+    const res = await HttpService.client.editComment(form);
+    this.setState({
+      editCommentRes: { commentId: form.comment_id, res },
+    });
+
+    this.findAndUpdateComment(res);
+
+    return res;
   }
 
   async handleDeleteComment(form: DeleteComment) {

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -25,7 +25,13 @@ import {
 } from "@utils/helpers";
 import { scrollMixin } from "../mixins/scroll-mixin";
 import { isImage } from "@utils/media";
-import { CommentNodeType, QueryParams, RouteDataResponse } from "@utils/types";
+import {
+  CommentIdAndRes,
+  commentLoading,
+  CommentNodeType,
+  QueryParams,
+  RouteDataResponse,
+} from "@utils/types";
 import classNames from "classnames";
 import { Component, createRef, linkEvent } from "inferno";
 import {
@@ -125,6 +131,8 @@ type PostData = RouteDataResponse<{
 interface PostState {
   postRes: RequestState<GetPostResponse>;
   commentsRes: RequestState<PagedResponse<CommentSlimView>>;
+  createCommentRes: CommentIdAndRes;
+  editCommentRes: CommentIdAndRes;
   siteRes: GetSiteResponse;
   showSidebarMobile: boolean;
   maxCommentsShown: number;
@@ -251,6 +259,8 @@ export class Post extends Component<PostRouteProps, PostState> {
   state: PostState = {
     postRes: EMPTY_REQUEST,
     commentsRes: EMPTY_REQUEST,
+    createCommentRes: { commentId: 0, res: EMPTY_REQUEST },
+    editCommentRes: { commentId: 0, res: EMPTY_REQUEST },
     siteRes: this.isoData.siteRes,
     showSidebarMobile: false,
     maxCommentsShown: commentsShownInterval,
@@ -667,6 +677,7 @@ export class Post extends Component<PostRouteProps, PostState> {
                   myUserInfo={this.isoData.myUserInfo}
                   onCreateComment={this.handleCreateToplevelComment}
                   onEditComment={() => {}}
+                  loading={commentLoading(this.state.createCommentRes) === 0}
                 />
               )}
               <div className="d-block d-md-none">
@@ -863,6 +874,8 @@ export class Post extends Component<PostRouteProps, PostState> {
             postLockedOrRemovedOrDeleted={postLockedDeletedOrRemoved(
               postRes.data.post_view,
             )}
+            createLoading={commentLoading(this.state.createCommentRes)}
+            editLoading={commentLoading(this.state.editCommentRes)}
             admins={siteRes.admins}
             readCommentsAt={
               postRes.data.post_view.post_actions?.read_comments_at
@@ -983,6 +996,8 @@ export class Post extends Component<PostRouteProps, PostState> {
             postLockedOrRemovedOrDeleted={postLockedDeletedOrRemoved(
               postRes.data.post_view,
             )}
+            createLoading={commentLoading(this.state.createCommentRes)}
+            editLoading={commentLoading(this.state.editCommentRes)}
             admins={siteRes.admins}
             readCommentsAt={
               postRes.data.post_view.post_actions?.read_comments_at
@@ -1190,17 +1205,37 @@ export class Post extends Component<PostRouteProps, PostState> {
   }
 
   async handleCreateComment(form: CreateComment) {
-    const createCommentRes = await HttpService.client.createComment(form);
-    this.createAndUpdateComments(createCommentRes);
+    this.setState({
+      createCommentRes: {
+        commentId: form.parent_id ?? 0,
+        res: LOADING_REQUEST,
+      },
+    });
+    const res = await HttpService.client.createComment(form);
+    this.setState({
+      createCommentRes: {
+        commentId: form.parent_id ?? 0,
+        res,
+      },
+    });
+    this.createAndUpdateComments(res);
 
-    return createCommentRes;
+    return res;
   }
 
   async handleEditComment(form: EditComment) {
-    const editCommentRes = await HttpService.client.editComment(form);
-    this.findAndUpdateCommentEdit(editCommentRes);
+    this.setState({
+      editCommentRes: { commentId: form.comment_id, res: LOADING_REQUEST },
+    });
 
-    return editCommentRes;
+    const res = await HttpService.client.editComment(form);
+    this.setState({
+      editCommentRes: { commentId: form.comment_id, res },
+    });
+
+    this.findAndUpdateCommentEdit(res);
+
+    return res;
   }
 
   async handlePersonNote(form: NotePerson) {

--- a/src/shared/components/private_message/create-private-message.tsx
+++ b/src/shared/components/private_message/create-private-message.tsx
@@ -6,6 +6,7 @@ import {
   GetPersonDetails,
   GetPersonDetailsResponse,
   LemmyHttp,
+  PrivateMessageResponse,
 } from "lemmy-js-client";
 import { InitialFetchRequest } from "@utils/types";
 import { FirstLoadService, I18NextService } from "../../services";
@@ -34,6 +35,7 @@ type CreatePrivateMessageData = RouteDataResponse<{
 
 interface CreatePrivateMessageState {
   recipientRes: RequestState<GetPersonDetailsResponse>;
+  createMessageRes: RequestState<PrivateMessageResponse>;
   recipientId: number;
   isIsomorphic: boolean;
 }
@@ -55,6 +57,7 @@ export class CreatePrivateMessage extends Component<
   private isoData = setIsoData<CreatePrivateMessageData>(this.context);
   state: CreatePrivateMessageState = {
     recipientRes: EMPTY_REQUEST,
+    createMessageRes: EMPTY_REQUEST,
     recipientId: getRecipientIdFromProps(this.props),
     isIsomorphic: false,
   };
@@ -143,6 +146,9 @@ export class CreatePrivateMessage extends Component<
                 myUserInfo={this.isoData.myUserInfo}
                 onCreate={this.handlePrivateMessageCreate}
                 recipient={res.person_view.person}
+                createOrEditLoading={
+                  this.state.createMessageRes.state === "loading"
+                }
               />
             </div>
           </div>
@@ -167,7 +173,9 @@ export class CreatePrivateMessage extends Component<
     form: CreatePrivateMessageI,
     bypassNavWarning: () => void,
   ): Promise<boolean> {
+    this.setState({ createMessageRes: LOADING_REQUEST });
     const res = await HttpService.client.createPrivateMessage(form);
+    this.setState({ createMessageRes: res });
 
     if (res.state === "success") {
       toast(I18NextService.i18n.t("message_sent"));

--- a/src/shared/components/private_message/private-message-form.tsx
+++ b/src/shared/components/private_message/private-message-form.tsx
@@ -29,6 +29,7 @@ interface PrivateMessageFormProps {
     form: EditPrivateMessage,
     bypassNavWarning: () => void,
   ): Promise<boolean>;
+  createOrEditLoading: boolean;
 }
 
 interface PrivateMessageFormState {
@@ -137,6 +138,7 @@ export class PrivateMessageForm extends Component<
                   : capitalizeFirstLetter(I18NextService.i18n.t("send_message"))
               }
               myUserInfo={this.props.myUserInfo}
+              loading={this.props.createOrEditLoading}
             />
           </div>
         </div>

--- a/src/shared/components/private_message/private-message.tsx
+++ b/src/shared/components/private_message/private-message.tsx
@@ -19,16 +19,6 @@ import ModActionFormModal from "../common/modal/mod-action-form-modal";
 import { tippyMixin } from "../mixins/tippy-mixin";
 import { mark_as_read_i18n } from "@utils/app";
 
-interface PrivateMessageState {
-  showReply: boolean;
-  showEdit: boolean;
-  collapsed: boolean;
-  viewSource: boolean;
-  showReportDialog: boolean;
-  deleteLoading: boolean;
-  readLoading: boolean;
-}
-
 interface PrivateMessageProps {
   private_message_view: PrivateMessageView;
   myUserInfo: MyUserInfo | undefined;
@@ -38,6 +28,17 @@ interface PrivateMessageProps {
   onEdit(form: EditPrivateMessage): Promise<boolean>;
   read: boolean;
   onMarkRead(privateMessageId: PrivateMessageId, read: boolean): void;
+  createOrEditLoading: boolean;
+}
+
+interface PrivateMessageState {
+  showReply: boolean;
+  showEdit: boolean;
+  collapsed: boolean;
+  viewSource: boolean;
+  showReportDialog: boolean;
+  deleteLoading: boolean;
+  readLoading: boolean;
 }
 
 @tippyMixin
@@ -131,6 +132,7 @@ export class PrivateMessage extends Component<
               myUserInfo={this.props.myUserInfo}
               onEdit={this.handleEdit}
               onCancel={this.handleReplyCancel}
+              createOrEditLoading={this.props.createOrEditLoading}
             />
           )}
           {!this.state.showEdit && !this.state.collapsed && (
@@ -266,6 +268,7 @@ export class PrivateMessage extends Component<
                 myUserInfo={this.props.myUserInfo}
                 onCreate={this.handleCreate}
                 onCancel={this.handleReplyCancel}
+                createOrEditLoading={this.props.createOrEditLoading}
               />
             </div>
           </div>

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -354,6 +354,8 @@ const commentListing = (
               key={c.comment.id}
               nodes={[commentToFlatNode(c)]}
               viewType={"flat"}
+              createLoading={undefined}
+              editLoading={undefined}
               viewOnly
               postLockedOrRemovedOrDeleted
               isTopLevel
@@ -938,6 +940,8 @@ export class Search extends Component<SearchRouteProps, SearchState> {
       <CommentNodes
         nodes={commentsToFlatNodes(comments)}
         viewType={"flat"}
+        createLoading={undefined}
+        editLoading={undefined}
         viewOnly
         postLockedOrRemovedOrDeleted
         isTopLevel

--- a/src/shared/utils/types.ts
+++ b/src/shared/utils/types.ts
@@ -9,6 +9,8 @@ import {
   CommentSlimView,
   PersonId,
   Community,
+  CommentId,
+  CommentResponse,
 } from "lemmy-js-client";
 import { RequestState } from "@services/HttpService";
 import { Match } from "inferno-router/dist/Route";
@@ -107,6 +109,24 @@ export function isCommentNodeFull(
   node: CommentNodeType,
 ): node is CommentNodeFull {
   return (node as CommentNodeFull).view.comment_view.post !== undefined;
+}
+
+/** A helper type to set which comment is loading
+ *
+ * For creates, the comment id is the parent (or zero)
+ **/
+export type CommentIdAndRes = {
+  commentId: CommentId;
+  res: RequestState<CommentResponse>;
+};
+
+/** Determines if the comment is loading **/
+export function commentLoading(
+  commentIdAndRes: CommentIdAndRes,
+): number | undefined {
+  return commentIdAndRes.res.state === "loading"
+    ? commentIdAndRes.commentId
+    : undefined;
 }
 
 export type RouteData = Record<string, RequestState<any>>;


### PR DESCRIPTION
- This moves all the incorrect *internal* loading logic, above to the actual API calls.
- It was a little complicated by the CommentNodes component, so the loading indicator also has to point to which specific comment is being edited (or the parent comment if its a comment creation).
- Fixes #3666
