### PR TITLE
Don't allow post_url_only and post_title_only to be checked at same time in search.

### DIFF
--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -1179,12 +1179,14 @@ export class Search extends Component<SearchRouteProps, SearchState> {
 
   handleTitleOnlyChange(i: Search, event: any) {
     const titleOnly = event.target.checked;
-    i.updateUrl({ titleOnly, q: i.getQ() });
+    // Don't allow post url and post title only to be checked at the same time
+    i.updateUrl({ titleOnly, q: i.getQ(), postUrlOnly: false });
   }
 
   handlePostUrlOnlyChange(i: Search, event: any) {
     const postUrlOnly = event.target.checked;
-    i.updateUrl({ postUrlOnly, q: i.getQ() });
+    // Don't allow post url and post title only to be checked at the same time
+    i.updateUrl({ postUrlOnly, q: i.getQ(), titleOnly: false });
   }
 
   handleTypeChange(i: Search, event: any) {


### PR DESCRIPTION
- Fixes #3619

