### PR TITLE
Remove webmanifest default description

### DIFF
--- a/src/server/utils/generate-manifest-json.ts
+++ b/src/server/utils/generate-manifest-json.ts
@@ -52,7 +52,7 @@ export default async function (site: Site) {
 
   return {
     name: site.name,
-    description: site.summary ?? "A link aggregator for the fediverse",
+    description: site.summary,
     start_url: "/",
     scope: "/",
     display: "standalone",


### PR DESCRIPTION
This doesnt describe the current instance, but the Lemmy software in general. Its also not using the new text from join-lemmy.org (A decentralized discussion platform for communities).