### PR TITLE
UX: Updated Color and Added Icons to Site-Sidebar and Community-Sidebar Buttons

### DIFF
--- a/src/shared/components/common/content-actions/create-item-buttons.tsx
+++ b/src/shared/components/common/content-actions/create-item-buttons.tsx
@@ -37,7 +37,7 @@ export function CreatePostButton({
   myUserInfo,
 }: CreatePostButtonProps) {
   const classes = classNames(
-    "btn btn-light border-light-subtle d-block mb-2 w-100",
+    "btn btn-secondary border-secondary-subtle d-flex gap-1 mb-2 w-100",
     {
       "no-click":
         communityView?.community.deleted ||
@@ -53,7 +53,7 @@ export function CreatePostButton({
 
   return (
     <Link className={classes} to={link}>
-      {I18NextService.i18n.t("create_post")}
+      <Icon icon="edit" /> {I18NextService.i18n.t("create_post")}
     </Link>
   );
 }
@@ -70,13 +70,14 @@ export function CreateCommunityButton({
 }: CreateCommunityButtonProps) {
   const classes = classNames({
     "no-click": !(localSite && canCreateCommunity(localSite, myUserInfo)),
-    "btn btn-light border-light-subtle d-block mb-2 w-100": blockButton,
-    "btn btn-sm btn-light border-light-subtle": !blockButton,
+    "btn btn-outline-secondary border-secondary-subtle d-flex gap-1 mb-2 w-100":
+      blockButton,
+    "btn btn-sm btn-outline-secondary border-secondary-subtle": !blockButton,
   });
 
   return (
     <Link className={classes} to="/create_community">
-      {I18NextService.i18n.t("create_community")}
+      <Icon icon="edit" /> {I18NextService.i18n.t("create_community")}
     </Link>
   );
 }
@@ -91,13 +92,14 @@ export function CreateMultiCommunityButton({
 }: CreateMultiCommunityButtonProps) {
   const classes = classNames({
     "no-click": userNotLoggedInOrBanned(myUserInfo),
-    "btn btn-light border-light-subtle d-block mb-2 w-100": blockButton,
-    "btn btn-sm btn-light border-light-subtle": !blockButton,
+    "btn btn-outline-secondary border-secondary-subtle d-flex gap-1 mb-2 w-100":
+      blockButton,
+    "btn btn-sm btn-outline-secondary border-secondary-subtle": !blockButton,
   });
 
   return (
     <Link className={classes} to="/create_multi_community">
-      {I18NextService.i18n.t("create_multi_community")}
+      <Icon icon="edit" /> {I18NextService.i18n.t("create_multi_community")}
     </Link>
   );
 }

--- a/src/shared/components/common/content-actions/create-item-buttons.tsx
+++ b/src/shared/components/common/content-actions/create-item-buttons.tsx
@@ -37,7 +37,7 @@ export function CreatePostButton({
   myUserInfo,
 }: CreatePostButtonProps) {
   const classes = classNames(
-    "btn btn-secondary border-secondary-subtle d-flex gap-1 mb-2 w-100",
+    "btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100",
     {
       "no-click":
         communityView?.community.deleted ||
@@ -70,9 +70,8 @@ export function CreateCommunityButton({
 }: CreateCommunityButtonProps) {
   const classes = classNames({
     "no-click": !(localSite && canCreateCommunity(localSite, myUserInfo)),
-    "btn btn-outline-secondary border-secondary-subtle d-flex gap-1 mb-2 w-100":
-      blockButton,
-    "btn btn-sm btn-outline-secondary border-secondary-subtle": !blockButton,
+    "btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100": blockButton,
+    "btn btn-sm btn-light border-light-subtle": !blockButton,
   });
 
   return (
@@ -92,9 +91,8 @@ export function CreateMultiCommunityButton({
 }: CreateMultiCommunityButtonProps) {
   const classes = classNames({
     "no-click": userNotLoggedInOrBanned(myUserInfo),
-    "btn btn-outline-secondary border-secondary-subtle d-flex gap-1 mb-2 w-100":
-      blockButton,
-    "btn btn-sm btn-outline-secondary border-secondary-subtle": !blockButton,
+    "btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100": blockButton,
+    "btn btn-sm btn-light border-light-subtle": !blockButton,
   });
 
   return (

--- a/src/shared/components/common/subscribe-button.tsx
+++ b/src/shared/components/common/subscribe-button.tsx
@@ -30,7 +30,7 @@ export function SubscribeButton({
 }: SubscribeButtonProps) {
   const buttonClass = classNames("btn", {
     "btn-link p-0": isLink,
-    [`btn-light border-light-subtle d-block mb-2 w-100 btn-${followState === "pending" ? "warning" : "secondary"}`]:
+    [`btn-light border-light-subtle d-flex gap-1 mb-2 w-100 btn-${followState === "pending" ? "warning" : "secondary"}`]:
       !isLink,
   });
 
@@ -43,6 +43,7 @@ export function SubscribeButton({
           data-bs-toggle="modal"
           data-bs-target="#remoteFetchModal"
         >
+          <Icon icon="bookmark" />
           {I18NextService.i18n.t("subscribe")}
         </button>
         <RemoteFetchModal apId={apId} />

--- a/src/shared/components/community/community-link.tsx
+++ b/src/shared/components/community/community-link.tsx
@@ -100,19 +100,20 @@ type CommunitySettingLinkProps = {
 export function CommunitySettingsLink({
   community,
 }: CommunitySettingLinkProps) {
-  const classes = classNames(
-    "btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100",
-    {
-      "no-click": community.removed,
-    },
-  );
+  const classes = classNames("btn btn-light border-light-subtle mb-2 w-100", {
+    "no-click": community.removed,
+  });
 
   const link = `${communityLink(community).link}/settings`;
 
   return (
-    <Link className={classes} to={link}>
-      <Icon icon="settings" classes="me-1" />
-      {I18NextService.i18n.t("settings")}
+    <Link
+      className={classes}
+      to={link}
+      aria-label={I18NextService.i18n.t("settings")}
+      title={I18NextService.i18n.t("settings")}
+    >
+      <Icon icon="settings" />
     </Link>
   );
 }

--- a/src/shared/components/community/community-link.tsx
+++ b/src/shared/components/community/community-link.tsx
@@ -7,6 +7,7 @@ import { relTags } from "@utils/config";
 import { PictrsImage } from "../common/pictrs-image";
 import classNames from "classnames";
 import { I18NextService } from "@services/index";
+import { Icon } from "@components/common/icon";
 
 interface CommunityLinkProps {
   community: Community;
@@ -100,7 +101,7 @@ export function CommunitySettingsLink({
   community,
 }: CommunitySettingLinkProps) {
   const classes = classNames(
-    "btn btn-light border-light-subtle d-block mb-2 w-100",
+    "btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100",
     {
       "no-click": community.removed,
     },
@@ -110,6 +111,7 @@ export function CommunitySettingsLink({
 
   return (
     <Link className={classes} to={link}>
+      <Icon icon="settings" classes="me-1" />
       {I18NextService.i18n.t("settings")}
     </Link>
   );

--- a/src/shared/components/community/community-sidebar.tsx
+++ b/src/shared/components/community/community-sidebar.tsx
@@ -373,7 +373,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
     return (
       !subscribed && (
         <button
-          className="btn btn-outline-danger mb-2 w-100"
+          className="btn btn-outline-danger d-flex gap-1 mb-2 w-100"
           onClick={() => handleBlock(this)}
         >
           <Icon icon="slash" />

--- a/src/shared/components/community/community-sidebar.tsx
+++ b/src/shared/components/community/community-sidebar.tsx
@@ -142,64 +142,69 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                       )}
                     </>
                   )}
-                  <button
-                    className="btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100"
-                    onClick={() => handleShowReportModal(this)}
-                  >
-                    <Icon icon="flag" />{" "}
-                    {I18NextService.i18n.t("create_report")}
-                  </button>
-                  <CommunityReportModal
-                    onSubmit={reason => handleSubmitReport(this, reason)}
-                    onCancel={() => handleHideReportModal(this)}
-                    show={this.state.showReportModal}
-                  />
-                  <Link
-                    className="btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100"
-                    to={`/modlog/${community.id}`}
-                  >
-                    <Icon icon="history" /> {I18NextService.i18n.t("modlog")}
-                  </Link>
-                  {this.amModOrAdminAndLocal() && (
-                    <CommunitySettingsLink community={community} />
-                  )}
-                  {amAdmin(myUserInfo) && (
-                    <>
-                      <button
-                        className="btn btn-outline-danger d-flex gap-1 mb-2 w-100"
-                        onClick={() => handleShowRemoveDialog(this)}
-                      >
-                        <Icon icon="x" />
-                        {I18NextService.i18n.t(
-                          !communityView.community.removed
-                            ? "remove"
-                            : "restore",
-                        )}
-                      </button>
-                      <ModActionFormModal
-                        onSubmit={reason => handleRemove(this, reason)}
-                        modActionType="remove-community"
-                        isRemoved={communityView.community.removed}
-                        onCancel={() => handleHideRemoveDialog(this)}
-                        show={this.state.showRemoveDialog}
-                      />
-                      <button
-                        className="btn btn-outline-danger d-flex gap-1 mb-2 w-100"
-                        onClick={() => handleShowPurgeDialog(this)}
-                        aria-label={I18NextService.i18n.t("purge_community")}
-                      >
-                        <Icon icon="purge" />
-                        {I18NextService.i18n.t("purge_community")}
-                      </button>
-                      <ModActionFormModal
-                        onSubmit={reason => handlePurge(this, reason)}
-                        modActionType="purge-community"
-                        community={communityView.community}
-                        onCancel={() => handleHidePurgeDialog(this)}
-                        show={this.state.showPurgeDialog}
-                      />
-                    </>
-                  )}
+                  <div className={"d-flex gap-1"}>
+                    <button
+                      className="btn btn-light border-light-subtle mb-2 w-100"
+                      onClick={() => handleShowReportModal(this)}
+                      aria-label={I18NextService.i18n.t("create_report")}
+                      title={I18NextService.i18n.t("create_report")}
+                    >
+                      <Icon icon="flag" />{" "}
+                    </button>
+                    <CommunityReportModal
+                      onSubmit={reason => handleSubmitReport(this, reason)}
+                      onCancel={() => handleHideReportModal(this)}
+                      show={this.state.showReportModal}
+                    />
+                    <Link
+                      className="btn btn-light border-light-subtle mb-2 w-100"
+                      to={`/modlog/${community.id}`}
+                      aria-label={I18NextService.i18n.t("modlog")}
+                      title={I18NextService.i18n.t("modlog")}
+                    >
+                      <Icon icon="history" />
+                    </Link>
+                    {this.amModOrAdminAndLocal() && (
+                      <CommunitySettingsLink community={community} />
+                    )}
+                    {amAdmin(myUserInfo) && (
+                      <>
+                        <button
+                          className="btn btn-light mb-2 w-100"
+                          onClick={() => handleShowRemoveDialog(this)}
+                          title={I18NextService.i18n.t(
+                            !communityView.community.removed
+                              ? "remove"
+                              : "restore",
+                          )}
+                        >
+                          <Icon icon="x" />
+                        </button>
+                        <ModActionFormModal
+                          onSubmit={reason => handleRemove(this, reason)}
+                          modActionType="remove-community"
+                          isRemoved={communityView.community.removed}
+                          onCancel={() => handleHideRemoveDialog(this)}
+                          show={this.state.showRemoveDialog}
+                        />
+                        <button
+                          className="btn btn-light mb-2 w-100"
+                          onClick={() => handleShowPurgeDialog(this)}
+                          aria-label={I18NextService.i18n.t("purge_community")}
+                          title={I18NextService.i18n.t("purge_community")}
+                        >
+                          <Icon icon="purge" />
+                        </button>
+                        <ModActionFormModal
+                          onSubmit={reason => handlePurge(this, reason)}
+                          modActionType="purge-community"
+                          community={communityView.community}
+                          onCancel={() => handleHidePurgeDialog(this)}
+                          show={this.state.showPurgeDialog}
+                        />
+                      </>
+                    )}
+                  </div>
                   <>
                     {this.props.myUserInfo && this.blockCommunity()}
                     {canViewCommunity_ && (
@@ -368,7 +373,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
     return (
       !subscribed && (
         <button
-          className="btn btn-outline-danger d-flex gap-1 mb-2 w-100"
+          className="btn btn-outline-danger mb-2 w-100"
           onClick={() => handleBlock(this)}
         >
           <Icon icon="slash" />

--- a/src/shared/components/community/community-sidebar.tsx
+++ b/src/shared/components/community/community-sidebar.tsx
@@ -143,9 +143,10 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                     </>
                   )}
                   <button
-                    className="btn btn-light border-light-subtle d-block mb-2 w-100"
+                    className="btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100"
                     onClick={() => handleShowReportModal(this)}
                   >
+                    <Icon icon="flag" />{" "}
                     {I18NextService.i18n.t("create_report")}
                   </button>
                   <CommunityReportModal
@@ -154,10 +155,10 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                     show={this.state.showReportModal}
                   />
                   <Link
-                    className="btn btn-light border-light-subtle d-block mb-2 w-100"
+                    className="btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100"
                     to={`/modlog/${community.id}`}
                   >
-                    {I18NextService.i18n.t("modlog")}
+                    <Icon icon="history" /> {I18NextService.i18n.t("modlog")}
                   </Link>
                   {this.amModOrAdminAndLocal() && (
                     <CommunitySettingsLink community={community} />
@@ -165,9 +166,10 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                   {amAdmin(myUserInfo) && (
                     <>
                       <button
-                        className="btn btn-light border-light-subtle d-block mb-2 w-100"
+                        className="btn btn-outline-danger d-flex gap-1 mb-2 w-100"
                         onClick={() => handleShowRemoveDialog(this)}
                       >
+                        <Icon icon="x" />
                         {I18NextService.i18n.t(
                           !communityView.community.removed
                             ? "remove"
@@ -182,10 +184,11 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                         show={this.state.showRemoveDialog}
                       />
                       <button
-                        className="btn btn-light border-light-subtle d-block mb-2 w-100"
+                        className="btn btn-outline-danger d-flex gap-1 mb-2 w-100"
                         onClick={() => handleShowPurgeDialog(this)}
                         aria-label={I18NextService.i18n.t("purge_community")}
                       >
+                        <Icon icon="purge" />
                         {I18NextService.i18n.t("purge_community")}
                       </button>
                       <ModActionFormModal
@@ -365,9 +368,10 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
     return (
       !subscribed && (
         <button
-          className="btn btn-danger d-block mb-2 w-100"
+          className="btn btn-outline-danger d-flex gap-1 mb-2 w-100"
           onClick={() => handleBlock(this)}
         >
+          <Icon icon="slash" />
           {I18NextService.i18n.t(
             blocked_at ? "unblock_community" : "block_community",
           )}

--- a/src/shared/components/home/site-sidebar.tsx
+++ b/src/shared/components/home/site-sidebar.tsx
@@ -126,24 +126,26 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
           blockButton
         />
         <CreateMultiCommunityButton myUserInfo={myUserInfo} blockButton />
-        <Link
-          className="btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100"
-          to="/modlog"
-        >
-          {" "}
-          <Icon icon="history" />
-          {I18NextService.i18n.t("modlog")}
-        </Link>
-        {amAdmin(myUserInfo) && (
+        <div className={"d-flex gap-1"}>
           <Link
-            className="btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100"
-            to="/admin"
+            className="btn btn-light border-light-subtle mb-2 w-100"
+            to="/modlog"
+            aria-label={I18NextService.i18n.t("modlog")}
+            title={I18NextService.i18n.t("modlog")}
           >
-            {" "}
-            <Icon icon="settings" />
-            {I18NextService.i18n.t("settings")}
+            <Icon icon="history" />
           </Link>
-        )}
+          {amAdmin(myUserInfo) && (
+            <Link
+              className="btn btn-light border-light-subtle mb-2 w-100"
+              to="/admin"
+              aria-label={I18NextService.i18n.t("settings")}
+              title={I18NextService.i18n.t("settings")}
+            >
+              <Icon icon="settings" />
+            </Link>
+          )}
+        </div>
         {this.props.localSite && (
           <LocalSiteBadges localSite={this.props.localSite} />
         )}

--- a/src/shared/components/home/site-sidebar.tsx
+++ b/src/shared/components/home/site-sidebar.tsx
@@ -127,16 +127,20 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
         />
         <CreateMultiCommunityButton myUserInfo={myUserInfo} blockButton />
         <Link
-          className="btn btn-light border-light-subtle d-block mb-2 w-100"
+          className="btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100"
           to="/modlog"
         >
+          {" "}
+          <Icon icon="history" />
           {I18NextService.i18n.t("modlog")}
         </Link>
         {amAdmin(myUserInfo) && (
           <Link
-            className="btn btn-light border-light-subtle d-block mb-2 w-100"
+            className="btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100"
             to="/admin"
           >
+            {" "}
+            <Icon icon="settings" />
             {I18NextService.i18n.t("settings")}
           </Link>
         )}

--- a/src/shared/components/multi-community/multi-community-link.tsx
+++ b/src/shared/components/multi-community/multi-community-link.tsx
@@ -80,13 +80,14 @@ export function MultiCommunitySettingsLink({
   multi,
 }: MultiCommunitySettingLinkProps) {
   const classes = classNames(
-    "btn btn-light border-light-subtle d-block mb-2 w-100",
+    "btn btn-light border-light-subtle d-flex gap-1 mb-2 w-100",
   );
 
   const link = `${multiCommunityLink(multi).link}/settings`;
 
   return (
     <Link className={classes} to={link}>
+      <Icon icon="settings" />
       {I18NextService.i18n.t("settings")}
     </Link>
   );


### PR DESCRIPTION
UX: Updated Text Alignment, Color and Added Icons to Site-Sidebar and Community-Sidebar Buttons

Another draft related to #3823

## Description

<!-- Please describe exactly what this PR changes, including URLs and issue
numbers. If it fixes an issue, add "Fixes #XXXX" -->

## Screenshots

<!-- Please include before and after screenshots if applicable -->

### Before
## community-sidebar
<img width="273" height="451" alt="image" src="https://github.com/user-attachments/assets/cd0b06f2-a704-4400-a276-32cd37d3d069" />
## site-sidebar
<img width="306" height="573" alt="image" src="https://github.com/user-attachments/assets/545a8200-2177-4245-a994-c20d7b859100" />

### After
## community-sidebar
<img width="310" height="573" alt="image" src="https://github.com/user-attachments/assets/0c0ef584-3bc2-47ed-bf9a-35540497aa75" />
## site-sidebar
<img width="345" height="645" alt="image" src="https://github.com/user-attachments/assets/8807a428-e792-47ab-8f2b-d75c2bbf9b7f" />
