### PR TITLE
Fix vote percentage (fixes #3865)

### DIFF
--- a/src/shared/components/common/vote-buttons.tsx
+++ b/src/shared/components/common/vote-buttons.tsx
@@ -431,8 +431,8 @@ function UpvotePct(props: UpvotePctProps) {
   const thresholdCheck = pct < UPVOTE_PCT_THRESHOLD;
 
   const upvotesPctTippy = I18NextService.i18n.t("upvote_percentage", {
-    count: Number(pct),
-    formattedCount: Number(pct),
+    count: pct,
+    formattedCount: pctStr,
   });
 
   return (
@@ -442,7 +442,6 @@ function UpvotePct(props: UpvotePctProps) {
         aria-label={upvotesPctTippy}
         data-tippy-content={upvotesPctTippy}
       >
-        <Icon icon="smile" classes="me-1 icon-inline small" />
         {pctStr}
       </button>
     )


### PR DESCRIPTION
<img width="284" height="89" alt="Screenshot_20260210_103126" src="https://github.com/user-attachments/assets/df38db20-80b1-46fa-bc87-a2dc944264e2" />

The percentage also seems to have a different font color (blue), but I dont see where that comes from.