### PR TITLE
Fix reload of admin settings (fixes #3884)

### DIFF
--- a/src/shared/components/common/media-uploads.tsx
+++ b/src/shared/components/common/media-uploads.tsx
@@ -67,8 +67,8 @@ export class MediaUploads extends Component<Props, any> {
                 <PictrsImage src={buildImageUrl(i.local_image.pictrs_alias)} />
               </div>
               <div className={cols}>{this.deleteImageBtn(i.local_image)}</div>
+              <hr />
             </div>
-            <hr />
           </>
         ))}
       </div>

--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -508,8 +508,8 @@ export class AdminSettings extends Component<
                 </div>
                 <div className={dataCols}>{admin.person.post_count}</div>
                 <div className={dataCols}>{admin.person.comment_count}</div>
+                <hr />
               </div>
-              <hr />
             </>
           ))}
         </div>
@@ -614,8 +614,8 @@ export class AdminSettings extends Component<
                   <div className={dataCols}>
                     {local_user.person.comment_count}
                   </div>
+                  <hr />
                 </div>
-                <hr />
               </>
             ))}
             <PaginatorCursor

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -311,8 +311,8 @@ export function InstanceList({
                 new Date(i.instance.updated_at ?? i.instance.published_at),
               ) && " 💀"}
             </div>
+            <hr />
           </div>
-          <hr />
         </>
       ))}
     </div>


### PR DESCRIPTION
If an element has `key` then all siblings also need to have key. Solved it by moving those siblings (<hr> elements) into children.