### PR TITLE
Fix enable_nsfw

### DIFF
--- a/src/shared/utils/app.ts
+++ b/src/shared/utils/app.ts
@@ -331,7 +331,7 @@ export function enableDownvotes(siteRes: GetSiteResponse): boolean {
 }
 
 export function enableNsfw(siteRes?: GetSiteResponse): boolean {
-  return !!siteRes?.site_view.site.content_warning;
+  return !siteRes?.site_view.local_site.disallow_nsfw_content;
 }
 
 export async function fetchCommunities(q: string) {


### PR DESCRIPTION
Enable nsfw was using the existence of a content warning, whereas it really should've use the `disallow_nsfw_content` field.
