### PR TITLE
Add bg-secondary-subtle to make placeholders more subtle.

### DIFF
--- a/src/shared/components/common/loading-skeleton.tsx
+++ b/src/shared/components/common/loading-skeleton.tsx
@@ -44,13 +44,13 @@ class PostsLoadingSkeletonItem extends Component<any, any> {
       <div className="my-3">
         <div className="col flex-grow-1">
           <div className="row">
-            <div className="col flex-grow-0 order-last order-sm-first">
-              <PostThumbnailLoadingSkeleton />
-            </div>
             <div className="col flex-grow-1">
               <LoadingSkeletonLine size={12} />
               <LoadingSkeletonLine size={8} />
               <LoadingSkeletonLine size={4} />
+            </div>
+            <div className="col flex-grow-0 order-last">
+              <PostThumbnailLoadingSkeleton />
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Fixes #3932

You shouldn't mess with the opacity, since `placeholder-glow` needs to do that: https://getbootstrap.com/docs/5.3/components/placeholders/#animation

But you can change the base text color, so I made it more subtle:

<img width="2859" height="1131" alt="Screenshot_2026-03-03-09-19-48-479_org cromite cromite" src="https://github.com/user-attachments/assets/c8ab97b5-db85-42f0-95fe-211c7ceed9e2" />
