### PR TITLE
Target same js version for babel and webpack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
       "@babel/preset-env",
       {
         "loose": true,
-        "browserslistEnv": "package.json"
+        "browserslistEnv": "package.json" // matches webpack target config
       }
     ],
     ["@babel/typescript", { "isTSX": true, "allExtensions": true }]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "prettier --write"
     ]
   },
-  "browserslist": "fully supports es6",
+  "browserslist": "fully supports es6 and supports async-functions",
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@babel/plugin-transform-class-properties": "^7.25.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,7 +131,7 @@ module.exports = (env, argv) => {
   const clientConfig = {
     ...base,
     entry: "./src/client/index.tsx",
-    target: "web",
+    target: "browserslist", // from package.json, matches babel config
     output: {
       ...base.output,
       filename: "js/client.js",
@@ -155,7 +155,7 @@ module.exports = (env, argv) => {
   const embeddedConfig = {
     ...base,
     entry: "./src/embedded/index.ts",
-    target: "browserslist", // looks up package.json
+    target: "browserslist", // from package.json, matches babel config
     output: {
       ...base.output,
       filename: "js/embedded.js",


### PR DESCRIPTION
Relevant: #3908

This allows babel to use async/wait too, and reduces client.js size by about 30kb uncompressed.

We did have mismatched targets in the past, where babel would convert all arrow functions, just for webpack to wrap everything inside one.