### PR TITLE
Show alt text feedback

### DIFF
--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -463,6 +463,28 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
                 </>
               )}
             </div>
+            {url && isMedia(url) && (
+              <div className="mb-3 row">
+                <label
+                  className="col-sm-2 col-form-label"
+                  htmlFor="post-alt-text"
+                >
+                  {I18NextService.i18n.t("column_alttext")}
+                </label>
+                <div className="col-sm-10">
+                  <input
+                    autoComplete="false"
+                    name="alt_text"
+                    placeholder={I18NextService.i18n.t("optional")}
+                    type="text"
+                    className="form-control mb-3"
+                    id="post-alt-text"
+                    value={this.state.form.alt_text}
+                    onInput={e => handleAltTextChange(this, e)}
+                  />
+                </div>
+              </div>
+            )}
             {!isImage(url || "") && (
               <div className="mb-3 row">
                 <label
@@ -510,28 +532,6 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
               onChange={val => handleLanguageChange(this, val)}
               myUserInfo={this.props.myUserInfo}
             />
-            {url && isMedia(url) && (
-              <div className="mb-3 row">
-                <label
-                  className="col-sm-2 col-form-label"
-                  htmlFor="post-alt-text"
-                >
-                  {I18NextService.i18n.t("column_alttext")}
-                </label>
-                <div className="col-sm-10">
-                  <input
-                    autoComplete="false"
-                    name="alt_text"
-                    placeholder={I18NextService.i18n.t("optional")}
-                    type="text"
-                    className="form-control"
-                    id="post-alt-text"
-                    value={this.state.form.alt_text}
-                    onInput={e => handleAltTextChange(this, e)}
-                  />
-                </div>
-              </div>
-            )}
             {!this.props.post_view && (
               <div className="mb-3 row align-items-center">
                 <label

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -346,6 +346,12 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
                   onPaste={e => handleImageUploadPaste(this, e)}
                 />
                 {this.renderSuggestedTitleCopy()}
+                {/* Show a warning for media posts with missing alt text */}
+                {url && isMedia(url) && !this.state.form.alt_text && (
+                  <div className="alert alert-warning" role="alert">
+                    {I18NextService.i18n.t("missing_alt_text")}
+                  </div>
+                )}
                 {url && validURL(url) && (
                   <div>
                     <a


### PR DESCRIPTION
## Description

- Shows a warning if its an image/media post and its missing alt text
- Moves alt text to below the url.
- [Translation PR](https://github.com/LemmyNet/lemmy-translations/pull/260
- Fixes #4013

## Screenshots

<img width="300"  alt="Screenshot_2026-04-06-09-14-50-561_mark via" src="https://github.com/user-attachments/assets/68415e09-8a6d-4656-8fec-1387c297db79" />
