### PR TITLE
[0.19] Display UserBadges for Bot, Banned and Deleted users in all PersonListings

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -223,8 +223,6 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
                 isPostCreator={this.isPostCreator}
                 isMod={creator_is_moderator}
                 isAdmin={creator_is_admin}
-                isBot={cv.creator.bot_account}
-                isBanned={cv.creator.banned}
                 isBannedFromCommunity={cv.creator_banned_from_community}
               />
 

--- a/src/shared/components/person/person-listing.tsx
+++ b/src/shared/components/person/person-listing.tsx
@@ -8,6 +8,7 @@ import { Person } from "lemmy-js-client";
 import { relTags } from "../../config";
 import { PictrsImage } from "../common/pictrs-image";
 import { CakeDay } from "./cake-day";
+import { UserBadges } from "../common/user-badges";
 
 interface PersonListingProps {
   person: Person;
@@ -62,6 +63,13 @@ export class PersonListing extends Component<PersonListingProps, any> {
         )}
 
         {isCakeDay(person.published) && <CakeDay creatorName={name} />}
+
+        <UserBadges
+          classNames="ms-1"
+          isBot={person.bot_account}
+          isDeleted={person.deleted}
+          isBanned={person.banned}
+        />
       </>
     );
   }

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -667,13 +667,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
                       />
                     </li>
                     <li className="list-inline-item">
-                      <UserBadges
-                        classNames="ms-1"
-                        isBanned={pv.person.banned}
-                        isDeleted={pv.person.deleted}
-                        isAdmin={pv.is_admin}
-                        isBot={pv.person.bot_account}
-                      />
+                      <UserBadges classNames="ms-1" isAdmin={pv.is_admin} />
                     </li>
                   </ul>
                 </div>

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -426,8 +426,6 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
           classNames="ms-1"
           isMod={pv.creator_is_moderator}
           isAdmin={pv.creator_is_admin}
-          isBot={pv.creator.bot_account}
-          isBanned={pv.creator.banned}
           isBannedFromCommunity={pv.creator_banned_from_community}
         />
         {this.props.showCommunity && (


### PR DESCRIPTION
## Description

Fixes #4034 for 0.19.
I did not look into whether this can applied the same to 1.0.
We've been running this on LW for some time already.

The text for deleted users is a bit suboptimal in some places, and it can lead to confusion when users who deleted their account have comments that are not deleted, where it could be interpreted as the comment being deleted instead of the user.

## Screenshots

<img width="724" height="46" alt="image" src="https://github.com/user-attachments/assets/e58cac34-546f-4592-8ec1-09f610e03de8" />

<img width="642" height="164" alt="image" src="https://github.com/user-attachments/assets/6bcd4bba-c6f4-4606-88e8-bf9902101900" />

### Before

Mostly missing

### After

Present everywhere