### PR TITLE
Only do ARM docker release builds on full semver (no pre-release text)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '"1.2.3" matches "([A-Z])\w+"'
+      - evaluate: '"1.2.3" matches "\([A-Z]\)\w+"'
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '"1.2.3" matches "([A-Z])\\w+"'
+      - evaluate: '"1.2.3" matches ''([A-Z])'''
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: 1.0.0 matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
+      - evaluate: '1.0.0 matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches  ''^(0|[1-9]\d*).(0|[1-9]\d*).(0|[1-9]\d*)$'''
+      - evaluate: '"1.0.0" matches ''^(0\|[1-9]\d*).(0|[1-9]\d*).(0|[1-9]\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -53,7 +53,7 @@ steps:
       - event: pull_request
 
   # Only publish arm builds on non-pre-release builds
-  publish_release_docker_amd64:
+  publish_release_docker_arm64:
     image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: dessalines/lemmy-ui
@@ -73,7 +73,7 @@ steps:
       # Ensures that its a full semver release, and not a pre-release one like 1.0.0-alpha.1
       - evaluate: '"${CI_COMMIT_TAG}" matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
 
-  publish_release_docker_arm64:
+  publish_release_docker_amd64:
     image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: dessalines/lemmy-ui

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '"1.2.3" matches "\(\[A-Z\]\)\\w+"'
+      - evaluate: '"1.2.3" matches "w+"'
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -15,13 +15,13 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: 1.0.0 matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
+      - evaluate: '1.0.0 matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
 
-  test_when_evaluate_prerelease_semver:
-    commands:
-      - ls .
-    when:
-      - evaluate: 1.0.0-beta.2 matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
+  # test_when_evaluate_prerelease_semver:
+  #   commands:
+  #     - ls .
+  #   when:
+  #     - evaluate: 1.0.0-beta.2 matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,8 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '1.0.0 matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
+      - evaluate: 1.2.3 matchs ''([A-Z])\w+''
+      # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '"1.2.3" matches "\([A-Z]\)\w+"'
+      - evaluate: '"1.2.3" matches "\(\[A-Z\]\)\\w+"'
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,8 +16,8 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
+      # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
+      - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'''
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -62,7 +62,6 @@ steps:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      # Don't do beta builds on arm, only prod ones, since they take too long
       platforms: linux/arm64
       build_args_from_env:
         - CI_PIPELINE_EVENT
@@ -82,7 +81,6 @@ steps:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      # Don't do beta builds on arm, only prod ones, since they take too long
       platforms: linux/amd64
       build_args_from_env:
         - CI_PIPELINE_EVENT

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^(0||[1-9]\d*).(0|[1-9]\d*).(0|[1-9]\d*)$'''
+      - evaluate: '"1.0.0" matches ''^([0-9]+)\.([0-9]+)\.([0-9]+)'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''([0-9]+)\.([0-9]+)\.([0-9]+)'''
+      - evaluate: '"1.0.0" matches ''([0-9]).([0-9]).([0-9])'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^([0-9]+)\.([0-9]+)\.([0-9]+)'''
+      - evaluate: '"1.0.0" matches ''([0-9]+)\.([0-9]+)\.([0-9]+)'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^([0-9]\d*).([0-9]\d*).([0-9]\d*)$'''
+      - evaluate: '"1.0.0" matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '''1.2.3'' matches ''([A-Z\])\w+'''
+      - evaluate: '"1.2.3" matches "([A-Z])\w+"'
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^(0\|[1-9]\d*).(0|[1-9]\d*).(0|[1-9]\d*)$'''
+      - evaluate: '"1.0.0" matches ''^(0||[1-9]\d*).(0|[1-9]\d*).(0|[1-9]\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
+      - evaluate: '"1.0.0-beta.1" matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: "${CI_COMMIT_TAG} matches '^([0-9]\d*).([0-9]\d*).([0-9]\d*)$'"
+      - evaluate: '"${CI_COMMIT_TAG}" matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^(0|[1-9]\\d*).(0|[1-9]\\d*).(0|[1-9]\\d*)$'''
+      - evaluate: '"1.0.0" matches  ''^(0|[1-9]\d*).(0|[1-9]\d*).(0|[1-9]\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"'
+      - evaluate: '"1.0.0" matches "^(0|[1-9]\d\*)\.(0|[1-9]\d\*)\.(0|[1-9]\d\*)$"'
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,12 +19,6 @@ steps:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
       - evaluate: '"1.0.0" matches "^(0|[1-9]\\d*).(0|[1-9]\\d*).(0|[1-9]\\d*)$"'
 
-  # test_when_evaluate_prerelease_semver:
-  #   commands:
-  #     - ls .
-  #   when:
-  #     - evaluate: 1.0.0-beta.2 matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
-
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''([0-9]+).([0-9]+).([0-9]+)'''
+      - evaluate: '"1.0.0-beta.2" matches ''([0-9]+).([0-9]+).([0-9]+)'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: 1.2.3 matchs ''([A-Z])\w+''
+      - evaluate: '''1.2.3'' matches ''([A-Z])\w+'''
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -11,65 +11,77 @@ steps:
     when:
       - event: [pull_request, tag]
 
-  prettier_check:
-    image: jauderho/prettier:3.8.2-alpine
+  test_when_evaluate_full_semver:
     commands:
-      - prettier --no-config --arrow-parens avoid -c .
+      - ls .
     when:
-      - event: pull_request
+      - evaluate: 1.0.0 matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
 
-  bash_fmt:
-    image: alpine:3
+  test_when_evaluate_prerelease_semver:
     commands:
-      - apk add shfmt
-      - shfmt -i 2 -d */**.bash
-      - shfmt -i 2 -d */**.sh
+      - ls .
     when:
-      - event: pull_request
+      - evaluate: 1.0.0-beta.2 matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
 
-  install:
-    image: node:24-alpine
-    commands:
-      - *install_pnpm
-      - pnpm i
-    when:
-      - event: pull_request
+  # prettier_check:
+  #   image: jauderho/prettier:3.8.2-alpine
+  #   commands:
+  #     - prettier --no-config --arrow-parens avoid -c .
+  #   when:
+  #     - event: pull_request
 
-  lint:
-    image: node:24-alpine
-    commands:
-      - *install_pnpm
-      - pnpm lint
-    when:
-      - event: pull_request
+  # bash_fmt:
+  #   image: alpine:3
+  #   commands:
+  #     - apk add shfmt
+  #     - shfmt -i 2 -d */**.bash
+  #     - shfmt -i 2 -d */**.sh
+  #   when:
+  #     - event: pull_request
 
-  build_dev:
-    image: node:24-alpine
-    commands:
-      - *install_pnpm
-      - pnpm prebuild:dev
-      - pnpm build:dev
-    when:
-      - event: pull_request
+  # install:
+  #   image: node:24-alpine
+  #   commands:
+  #     - *install_pnpm
+  #     - pnpm i
+  #   when:
+  #     - event: pull_request
 
-  publish_release_docker:
-    image: woodpeckerci/plugin-docker-buildx
-    settings:
-      repo: dessalines/lemmy-ui
-      dockerfile: Dockerfile
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      # Don't do beta builds on arm, only prod ones, since they take too long
-      platforms: linux/amd64
-      # platforms: linux/amd64,linux/arm64
-      build_args_from_env:
-        - CI_PIPELINE_EVENT
-      tag: ${CI_COMMIT_TAG=nightly}
-    when:
-      - event: tag
-      - event: cron
+  # lint:
+  #   image: node:24-alpine
+  #   commands:
+  #     - *install_pnpm
+  #     - pnpm lint
+  #   when:
+  #     - event: pull_request
+
+  # build_dev:
+  #   image: node:24-alpine
+  #   commands:
+  #     - *install_pnpm
+  #     - pnpm prebuild:dev
+  #     - pnpm build:dev
+  #   when:
+  #     - event: pull_request
+
+  # publish_release_docker:
+  #   image: woodpeckerci/plugin-docker-buildx
+  #   settings:
+  #     repo: dessalines/lemmy-ui
+  #     dockerfile: Dockerfile
+  #     username:
+  #       from_secret: docker_username
+  #     password:
+  #       from_secret: docker_password
+  #     # Don't do beta builds on arm, only prod ones, since they take too long
+  #     platforms: linux/amd64
+  #     # platforms: linux/amd64,linux/arm64
+  #     build_args_from_env:
+  #       - CI_PIPELINE_EVENT
+  #     tag: ${CI_COMMIT_TAG=nightly}
+  #   when:
+  #     - event: tag
+  #     - event: cron
 
   notify_success:
     image: alpine:3

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,10 +16,8 @@ steps:
     commands:
       - ls .
     when:
-      # - evaluate: 
-      # '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: >
-        "1.0.0" matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
+      # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
+      - evaluate: '"1.0.0" matches ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,8 +16,10 @@ steps:
     commands:
       - ls .
     when:
-      # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^(0||[1-9]\d*)\.(0||[1-9]\d*)\.(0||[1-9]\d*)$'''
+      # - evaluate: 
+      # '"1.2.3" matches ''([A-Z])/w+'''
+      - evaluate: >
+        "1.0.0" matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '1.0.0 matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
+      - evaluate: 1.0.0 matches '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^([0-9]+).([0-9]+).([0-9]+)'''
+      - evaluate: '"1.0.0" matches ''^([0-9]\d*).([0-9]\d*).([0-9]\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '"1.2.3" matches "w+"'
+      - evaluate: '"1.2.3" matches "([A-Z])\\w+"'
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'''
+      - evaluate: '"1.0.0" matches ''^(0\|[1-9]\d*)\.(0\|[1-9]\d*)\.(0\|[1-9]\d*)$'''
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '${CI_COMMIT_TAG} matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
+      - evaluate: "${CI_COMMIT_TAG} matches ''^([0-9]\\d*).([0-9]\\d*).([0-9]\\d*)$''"
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,8 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0-beta.1" matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
+      - evaluate: '${CI_COMMIT_TAG} matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
+      - evaluate: '"1.0.0" matches "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"'
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''([0-9]).([0-9]).([0-9])'''
+      - evaluate: '"1.0.0" matches ''([0-9]+).([0-9]+).([0-9]+)'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '''1.2.3'' matches ''([A-Z])\w+'''
+      - evaluate: '''1.2.3'' matches ''([A-Z\])\w+'''
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches "^(0|[1-9]\d\*)\.(0|[1-9]\d\*)\.(0|[1-9]\d\*)$"'
+      - evaluate: '"1.0.0" matches "^(0|[1-9]\\d*).(0|[1-9]\\d*).(0|[1-9]\\d*)$"'
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: '"1.2.3" matches ''([A-Z])'''
+      - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
       # - evaluate: '"1.0.0" matches ''^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$\'''
 
   # test_when_evaluate_prerelease_semver:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -11,72 +11,85 @@ steps:
     when:
       - event: [pull_request, tag]
 
-  test_when_evaluate_full_semver:
+  prettier_check:
+    image: jauderho/prettier:3.8.2-alpine
+    commands:
+      - prettier --no-config --arrow-parens avoid -c .
+    when:
+      - event: pull_request
+
+  bash_fmt:
+    image: alpine:3
+    commands:
+      - apk add shfmt
+      - shfmt -i 2 -d */**.bash
+      - shfmt -i 2 -d */**.sh
+    when:
+      - event: pull_request
+
+  install:
     image: node:24-alpine
     commands:
-      - ls .
+      - *install_pnpm
+      - pnpm i
     when:
+      - event: pull_request
+
+  lint:
+    image: node:24-alpine
+    commands:
+      - *install_pnpm
+      - pnpm lint
+    when:
+      - event: pull_request
+
+  build_dev:
+    image: node:24-alpine
+    commands:
+      - *install_pnpm
+      - pnpm prebuild:dev
+      - pnpm build:dev
+    when:
+      - event: pull_request
+
+  # Only publish arm builds on non-pre-release builds
+  publish_release_docker_amd64:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: dessalines/lemmy-ui
+      dockerfile: Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      # Don't do beta builds on arm, only prod ones, since they take too long
+      platforms: linux/arm64
+      build_args_from_env:
+        - CI_PIPELINE_EVENT
+      tag: ${CI_COMMIT_TAG=nightly}
+    when:
+      - event: tag
+      - event: cron
+      # Ensures that its a full semver release, and not a pre-release one like 1.0.0-alpha.1
       - evaluate: '"${CI_COMMIT_TAG}" matches ''^([0-9]\\\d*).([0-9]\\\d*).([0-9]\\\d*)$'''
 
-  # prettier_check:
-  #   image: jauderho/prettier:3.8.2-alpine
-  #   commands:
-  #     - prettier --no-config --arrow-parens avoid -c .
-  #   when:
-  #     - event: pull_request
-
-  # bash_fmt:
-  #   image: alpine:3
-  #   commands:
-  #     - apk add shfmt
-  #     - shfmt -i 2 -d */**.bash
-  #     - shfmt -i 2 -d */**.sh
-  #   when:
-  #     - event: pull_request
-
-  # install:
-  #   image: node:24-alpine
-  #   commands:
-  #     - *install_pnpm
-  #     - pnpm i
-  #   when:
-  #     - event: pull_request
-
-  # lint:
-  #   image: node:24-alpine
-  #   commands:
-  #     - *install_pnpm
-  #     - pnpm lint
-  #   when:
-  #     - event: pull_request
-
-  # build_dev:
-  #   image: node:24-alpine
-  #   commands:
-  #     - *install_pnpm
-  #     - pnpm prebuild:dev
-  #     - pnpm build:dev
-  #   when:
-  #     - event: pull_request
-
-  # publish_release_docker:
-  #   image: woodpeckerci/plugin-docker-buildx
-  #   settings:
-  #     repo: dessalines/lemmy-ui
-  #     dockerfile: Dockerfile
-  #     username:
-  #       from_secret: docker_username
-  #     password:
-  #       from_secret: docker_password
-  #     # Don't do beta builds on arm, only prod ones, since they take too long
-  #     platforms: linux/amd64
-  #     # platforms: linux/amd64,linux/arm64
-  #     build_args_from_env:
-  #       - CI_PIPELINE_EVENT
-  #     tag: ${CI_COMMIT_TAG=nightly}
-  #   when:
-  #     - event: tag
-  #     - event: cron
+  publish_release_docker_arm64:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: dessalines/lemmy-ui
+      dockerfile: Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      # Don't do beta builds on arm, only prod ones, since they take too long
+      platforms: linux/amd64
+      build_args_from_env:
+        - CI_PIPELINE_EVENT
+      tag: ${CI_COMMIT_TAG=nightly}
+    when:
+      - event: tag
+      - event: cron
 
   notify_success:
     image: alpine:3

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: "${CI_COMMIT_TAG} matches ''^([0-9]\\d*).([0-9]\\d*).([0-9]\\d*)$''"
+      - evaluate: "${CI_COMMIT_TAG} matches '^([0-9]\\d*).([0-9]\\d*).([0-9]\\d*)$'"
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches ''^(0\|[1-9]\d*)\.(0\|[1-9]\d*)\.(0\|[1-9]\d*)$'''
+      - evaluate: '"1.0.0" matches ''^(0||[1-9]\d*)\.(0||[1-9]\d*)\.(0||[1-9]\d*)$'''
 
   # test_when_evaluate_prerelease_semver:
   #   commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -12,6 +12,7 @@ steps:
       - event: [pull_request, tag]
 
   test_when_evaluate_full_semver:
+    image: node:24-alpine
     commands:
       - ls .
     when:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0" matches "^(0|[1-9]\\d*).(0|[1-9]\\d*).(0|[1-9]\\d*)$"'
+      - evaluate: '"1.0.0" matches ''^(0|[1-9]\\d*).(0|[1-9]\\d*).(0|[1-9]\\d*)$'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -16,7 +16,7 @@ steps:
     commands:
       - ls .
     when:
-      - evaluate: "${CI_COMMIT_TAG} matches '^([0-9]\\d*).([0-9]\\d*).([0-9]\\d*)$'"
+      - evaluate: "${CI_COMMIT_TAG} matches '^([0-9]\d*).([0-9]\d*).([0-9]\d*)$'"
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,7 +17,7 @@ steps:
       - ls .
     when:
       # - evaluate: '"1.2.3" matches ''([A-Z])/w+'''
-      - evaluate: '"1.0.0-beta.2" matches ''([0-9]+).([0-9]+).([0-9]+)'''
+      - evaluate: '"1.0.0" matches ''^([0-9]+).([0-9]+).([0-9]+)'''
 
   # prettier_check:
   #   image: jauderho/prettier:3.8.2-alpine


### PR DESCRIPTION
Our arm builds take like 6+ hours, so this adds a regex check to only do arm releases when its a full semver version like `1.0.0`, and not a pre-release like `1.0.0-alpha.1`

Tested with strings and it seems to be working. yaml and regex are not fun getting to work together.