### PR TITLE
RequestState without wrapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "inferno-router": "^9.1.0",
     "inferno-server": "^9.1.0",
     "jwt-decode": "^4.0.0",
-    "lemmy-js-client": "1.0.0-search.3",
+    "lemmy-js-client": "1.0.0-request-state.0",
     "markdown-it": "^14.1.0",
     "markdown-it-bidi": "^0.2.0",
     "markdown-it-container": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       lemmy-js-client:
-        specifier: 1.0.0-search.3
-        version: 1.0.0-search.3
+        specifier: 1.0.0-request-state.0
+        version: 1.0.0-request-state.0
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.1
@@ -3416,8 +3416,8 @@ packages:
   leac@0.7.0:
     resolution: {integrity: sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==}
 
-  lemmy-js-client@1.0.0-search.3:
-    resolution: {integrity: sha512-eHI7x7Kpz7z6QwaN35JPB8wIlXz0PBB277y4WXxUbpAUKUU9kByJeohzHJ4Sqz0lXQ5dJ3//tqR7Z3kCocrYxQ==}
+  lemmy-js-client@1.0.0-request-state.0:
+    resolution: {integrity: sha512-sd26d3Ywfg1VxHr4Od/iX75fp1L8TV2jzk8/urwRCayGNX1HbDisxvlZueDqawb0hNlbhxuPpeSxOLM//qS2OA==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -8818,7 +8818,7 @@ snapshots:
 
   leac@0.7.0: {}
 
-  lemmy-js-client@1.0.0-search.3:
+  lemmy-js-client@1.0.0-request-state.0:
     dependencies:
       '@tsoa/runtime': 6.6.0
     transitivePeerDependencies:

--- a/src/server/handlers/catch-all-handler.tsx
+++ b/src/server/handlers/catch-all-handler.tsx
@@ -67,7 +67,7 @@ export default async (req: Request, res: Response) => {
       console.error(
         "Incorrect JWT token, skipping auth so frontend can remove jwt cookie",
       );
-      await client.setHeaders({});
+      client.setHeaders({});
       tryUser = await client.getMyUser();
     }
 

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -1506,7 +1506,7 @@ async function handleMarkPageAsRead(i: Home, myUserInfo?: MyUserInfo) {
 }
 
 async function handleHideDonationDialog(myUserInfo?: MyUserInfo) {
-  const res = await HttpService.client.donationDialogShown();
+  const res = await HttpService.client.markDonationDialogShown();
   if (res.state === "success") {
     if (myUserInfo !== undefined) {
       myUserInfo.local_user_view.local_user.last_donation_notification_at =

--- a/src/shared/components/home/login.tsx
+++ b/src/shared/components/home/login.tsx
@@ -195,7 +195,7 @@ async function handleSubmitTotp(i: Login, totp: string) {
 }
 
 async function handleLoginSuccess(i: Login, loginRes: LoginResponse) {
-  await UserService.Instance.login({
+  UserService.Instance.login({
     res: loginRes,
   });
   const [site, myUser] = await Promise.all([

--- a/src/shared/components/home/oauth/oauth-callback.tsx
+++ b/src/shared/components/home/oauth/oauth-callback.tsx
@@ -151,7 +151,7 @@ async function handleOAuthLoginSuccess(
   prev: string,
   loginRes: LoginResponse,
 ) {
-  await UserService.Instance.login({
+  UserService.Instance.login({
     res: loginRes,
   });
   const [site, myUser] = await Promise.all([

--- a/src/shared/components/home/setup.tsx
+++ b/src/shared/components/home/setup.tsx
@@ -195,7 +195,7 @@ async function handleRegisterSubmit(
     if (i.state.registerRes.state === "success") {
       const data = i.state.registerRes.data;
 
-      await UserService.Instance.login({ res: data });
+      UserService.Instance.login({ res: data });
       i.setState({ doneRegisteringUser: true });
     }
   }

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -466,9 +466,7 @@ async function handleRegisterSubmit(
 
         // Only log them in if a jwt was set
         if (data.jwt) {
-          await UserService.Instance.login({
-            res: data,
-          });
+          UserService.Instance.login({ res: data });
 
           const myUserRes = await HttpService.client.getMyUser();
 

--- a/src/shared/services/HttpService.ts
+++ b/src/shared/services/HttpService.ts
@@ -1,94 +1,21 @@
 import { getBackendHostExternal } from "@utils/env";
 import { LemmyHttp } from "lemmy-js-client";
+import {
+  wrapClient,
+  WrappedLemmyHttp,
+} from "lemmy-js-client/wrapper/request_state";
 
-export const EMPTY_REQUEST = {
-  state: "empty",
-} as const;
-
-export type EmptyRequestState = typeof EMPTY_REQUEST;
-
-export const LOADING_REQUEST = {
-  state: "loading",
-} as const;
-
-type LoadingRequestState = typeof LOADING_REQUEST;
-
-export type FailedRequestState = {
-  state: "failed";
-  err: Error;
-};
-
-type SuccessRequestState<T> = {
-  state: "success";
-  data: T;
-};
-
-/**
- * Shows the state of an API request.
- *
- * Can be empty, loading, failed, or success
- */
-export type RequestState<T> =
-  | EmptyRequestState
-  | LoadingRequestState
-  | FailedRequestState
-  // undefined and null produce an EmptyRequestState
-  | (T extends null | undefined | void ? never : SuccessRequestState<T>);
-
-export type WrappedLemmyHttp = WrappedLemmyHttpClient & {
-  [K in keyof LemmyHttp]: LemmyHttp[K] extends (...args: unknown[]) => unknown
-    ? (
-        ...args: Parameters<LemmyHttp[K]>
-      ) => Promise<RequestState<Awaited<ReturnType<LemmyHttp[K]>>>>
-    : never;
-};
-
-function getHttpClientFunctionNames(): Set<keyof LemmyHttp> {
-  const properties = new Set<keyof LemmyHttp>();
-  let proto: object = LemmyHttp.prototype;
-  while (proto && proto !== Object.prototype) {
-    Object.getOwnPropertyNames(proto)
-      .filter(name => name !== "constructor")
-      .filter(name => typeof LemmyHttp.prototype[name] === "function")
-      .forEach(name => properties.add(name as keyof LemmyHttp));
-    proto = Object.getPrototypeOf(proto) as object;
-  }
-  return properties;
-}
-
-class WrappedLemmyHttpClient {
-  rawClient: LemmyHttp;
-
-  constructor(client: LemmyHttp) {
-    this.rawClient = client;
-
-    for (const key of getHttpClientFunctionNames()) {
-      this[key] = async (...args: unknown[]) => {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          const res = (await (this.rawClient[key] as CallableFunction)(
-            ...args,
-          )) as unknown;
-
-          return {
-            data: res,
-            state: !(res === undefined || res === null) ? "success" : "empty",
-          };
-        } catch (error) {
-          return {
-            state: "failed",
-            err: error as Error,
-          };
-        }
-      };
-    }
-  }
-}
-
-export function wrapClient(client: LemmyHttp) {
-  // unfortunately, this verbose cast is necessary
-  return new WrappedLemmyHttpClient(client) as unknown as WrappedLemmyHttp;
-}
+export {
+  EMPTY_REQUEST,
+  EmptyRequestState,
+  LOADING_REQUEST,
+  LoadingRequestState,
+  FailedRequestState,
+  SuccessRequestState,
+  RequestState,
+  WrappedLemmyHttp,
+  wrapClient,
+} from "lemmy-js-client/wrapper/request_state";
 
 export class HttpService {
   static #_instance: HttpService;

--- a/src/shared/services/HttpService.ts
+++ b/src/shared/services/HttpService.ts
@@ -1,10 +1,7 @@
 import { getBackendHostExternal } from "@utils/env";
 import { LemmyHttp } from "lemmy-js-client";
-import {
-  wrapClient,
-  WrappedLemmyHttp,
-} from "lemmy-js-client/wrapper/request_state";
 
+export type WrappedLemmyHttp = LemmyHttp;
 export {
   EMPTY_REQUEST,
   EmptyRequestState,
@@ -13,9 +10,11 @@ export {
   FailedRequestState,
   SuccessRequestState,
   RequestState,
-  WrappedLemmyHttp,
-  wrapClient,
-} from "lemmy-js-client/wrapper/request_state";
+} from "lemmy-js-client";
+
+export function wrapClient(client: LemmyHttp) {
+  return client;
+}
 
 export class HttpService {
   static #_instance: HttpService;

--- a/src/shared/services/UserService.ts
+++ b/src/shared/services/UserService.ts
@@ -24,13 +24,13 @@ export class UserService {
 
   private constructor() {}
 
-  static async init() {
+  static init() {
     const s = new this();
-    await s.#setAuthInfo();
+    s.#setAuthInfo();
     return s;
   }
 
-  public async login({
+  public login({
     res,
     showToast = true,
   }: {
@@ -42,7 +42,7 @@ export class UserService {
         toast(I18NextService.i18n.t("logged_in"));
       }
       setAuthCookie(res.jwt);
-      await this.#setAuthInfo();
+      this.#setAuthInfo();
     }
   }
 
@@ -80,12 +80,12 @@ export class UserService {
     }
   }
 
-  async #setAuthInfo() {
+  #setAuthInfo() {
     if (isBrowser()) {
       const auth = cookie.parse(document.cookie)[authCookieName];
 
       if (auth) {
-        await HttpService.client.setHeaders({
+        HttpService.client.setHeaders({
           Authorization: `Bearer ${auth}`,
         });
         this.authInfo = { auth, claims: jwtDecode(auth) };
@@ -98,4 +98,4 @@ export class UserService {
   }
 }
 
-const instance: UserService = await UserService.init();
+const instance: UserService = UserService.init();


### PR DESCRIPTION
Minimal changes to get https://github.com/LemmyNet/lemmy-js-client/pull/946 working. `wrapClient` just returns the passed in client.
