### PR TITLE
Hide mod/admin badges on post and comment listings

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -810,10 +810,8 @@ function CommentHeader({
   myUserInfo,
 }: CommentHeaderProps) {
   const {
-    creator_is_moderator,
     creator_banned_from_community,
     creator_banned,
-    creator_is_admin,
     comment: { deleted, removed, language_id, distinguished, locked, post_id },
     creator,
     person_actions,
@@ -832,8 +830,6 @@ function CommentHeader({
       )}
       <UserBadges
         classNames="ms-1"
-        isModerator={creator_is_moderator}
-        isAdmin={creator_is_admin}
         creator={creator}
         isBanned={creator_banned}
         isBannedFromCommunity={creator_banned_from_community}

--- a/src/shared/components/community/community-settings.tsx
+++ b/src/shared/components/community/community-settings.tsx
@@ -392,8 +392,6 @@ export class CommunitySettings extends Component<RouteProps, State> {
                     />
                     <UserBadges
                       classNames="ms-1"
-                      isAdmin={false}
-                      isBanned={false}
                       myUserInfo={myUserInfo}
                       creator={m.moderator}
                     />

--- a/src/shared/components/post/common.tsx
+++ b/src/shared/components/post/common.tsx
@@ -170,8 +170,6 @@ export function PostCreatedLine({
       />
       <UserBadges
         classNames="ms-1"
-        isModerator={postView.creator_is_moderator}
-        isAdmin={postView.creator_is_admin}
         creator={postView.creator}
         isBanned={postView.creator_banned}
         isBannedFromCommunity={postView.creator_banned_from_community}

--- a/src/shared/components/post/cross-posts.tsx
+++ b/src/shared/components/post/cross-posts.tsx
@@ -145,8 +145,6 @@ function ExpandedCrossPosts({
                   />
                   <UserBadges
                     classNames="ms-1"
-                    isModerator={pv.creator_is_moderator}
-                    isAdmin={pv.creator_is_admin}
                     creator={pv.creator}
                     isBanned={pv.creator_banned}
                     isBannedFromCommunity={pv.creator_banned_from_community}

--- a/src/shared/components/search.tsx
+++ b/src/shared/components/search.tsx
@@ -234,7 +234,6 @@ const personListing = (
             />
             <UserBadges
               classNames="ms-1"
-              isAdmin={p.is_admin}
               isBanned={p.banned}
               myUserInfo={myUserInfo}
               personActions={p.person_actions}


### PR DESCRIPTION
With this change only the user profile indicates that someone is an admin. This should make admins and mods less hesitant to participate in discussions as normal user. And people wont think that comments are official communication when they are not. It will also make "mark comment distinguished" more useful (https://github.com/LemmyNet/lemmy/issues/6308).