### PR TITLE
Fixing default theme to check "browser"

### DIFF
--- a/src/shared/components/app/theme.tsx
+++ b/src/shared/components/app/theme.tsx
@@ -78,7 +78,10 @@ export class Theme extends Component<Props, State> {
   }
 
   renderTheme(theme: string) {
-    const hasTheme = theme !== "instance" && theme !== "instance-compact";
+    const hasTheme =
+      theme !== "instance" &&
+      theme !== "instance-compact" &&
+      theme !== "browser";
 
     const detectedBsTheme = {};
     if (this.lightQuery) {
@@ -102,7 +105,8 @@ export class Theme extends Component<Props, State> {
       );
     } else if (
       this.props.defaultTheme !== "instance" &&
-      this.props.defaultTheme !== "instance-compact"
+      this.props.defaultTheme !== "instance-compact" &&
+      this.props.defaultTheme !== "browser"
     ) {
       return (
         <>


### PR DESCRIPTION
- Had to do with not checking the "browser" theme in the logic.
- Fixes #4105

Makes sure it uses the `litely` and `darkly`, when the server has no default theme (IE called browser)