### PR TITLE
Change large card view to use full width

### DIFF
--- a/src/shared/components/common/media-uploads.tsx
+++ b/src/shared/components/common/media-uploads.tsx
@@ -58,7 +58,7 @@ export class MediaUploads extends Component<Props, never> {
               <div className={cols}>
                 <PictrsImage
                   src={buildImageUrl(i.local_image.pictrs_alias)}
-                  type="full_size"
+                  type="large_thumbnail"
                 />
               </div>
               <div className={cols}>{this.deleteImageBtn(i.local_image)}</div>

--- a/src/shared/components/common/pictrs-image.tsx
+++ b/src/shared/components/common/pictrs-image.tsx
@@ -195,9 +195,12 @@ export function buildPictrsSrc(src: string, type: PictrsImageType): string {
       url.searchParams.set("max_size", thumbnailSize.toString());
       break;
     case "icon":
+    case "icon_without_banner":
       url.searchParams.set("max_size", iconThumbnailSize.toString());
       break;
     case "banner":
+    case "icon_and_banner":
+    case "card_top":
       url.searchParams.set("max_size", bannerSize.toString());
       break;
     case "full_size":

--- a/src/shared/components/common/pictrs-image.tsx
+++ b/src/shared/components/common/pictrs-image.tsx
@@ -200,6 +200,8 @@ export function buildPictrsSrc(src: string, type: PictrsImageType): string {
     case "banner":
       url.searchParams.set("max_size", bannerSize.toString());
       break;
+    case "full_size":
+      break;
     default:
       url.searchParams.set("max_size", defaultImgSize.toString());
       break;

--- a/src/shared/components/common/pictrs-image.tsx
+++ b/src/shared/components/common/pictrs-image.tsx
@@ -18,7 +18,7 @@ const defaultImgSize = 512;
 const bannerSize = 2048;
 
 type PictrsImageType =
-  | "full_size"
+  | "large_thumbnail"
   | "thumbnail"
   | "icon"
   | "banner"
@@ -203,7 +203,9 @@ export function buildPictrsSrc(src: string, type: PictrsImageType): string {
     case "card_top":
       url.searchParams.set("max_size", bannerSize.toString());
       break;
-    case "full_size":
+    case "large_thumbnail":
+      // Use bannerSize here for slight downscaling, but larger than thumbnail
+      url.searchParams.set("max_size", bannerSize.toString());
       break;
     default:
       url.searchParams.set("max_size", defaultImgSize.toString());

--- a/src/shared/components/post/post-listing-card.tsx
+++ b/src/shared/components/post/post-listing-card.tsx
@@ -349,7 +349,7 @@ function PostImg({
     <div className="my-2">
       <PictrsImage
         src={imageSrc}
-        type="full_size"
+        type="large_thumbnail"
         alt={post.alt_text}
         imageDetails={postView.image_details}
         nsfw={postView.post.nsfw || postView.community.nsfw}

--- a/src/shared/components/post/post-listings.tsx
+++ b/src/shared/components/post/post-listings.tsx
@@ -222,8 +222,8 @@ export class PostListings extends Component<PostListingsProps, never> {
 function postListingModeCols(mode: PostListingMode): string {
   switch (mode) {
     case "list":
-      return "col-12";
     case "card":
+      return "col-12";
     case "small_card":
       return "col-12 col-md-6";
   }

--- a/src/shared/components/post/post-listings.tsx
+++ b/src/shared/components/post/post-listings.tsx
@@ -222,9 +222,9 @@ export class PostListings extends Component<PostListingsProps, never> {
 function postListingModeCols(mode: PostListingMode): string {
   switch (mode) {
     case "list":
-    case "card":
       return "col-12";
+    case "card":
     case "small_card":
-      return "col-12 col-md-6";
+      return "col-12 col-xl-6";
   }
 }


### PR DESCRIPTION
This seems better to view full-size images on desktop, without separately expanding each image.

<img width="1138" height="1019" alt="Screenshot_20260519_143024" src="https://github.com/user-attachments/assets/9c131300-8513-45ad-b13e-63042a47e210" />
