### PR TITLE
Clear markdown from local storage when submitting post and others

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -636,7 +636,7 @@ function handleLanguageChange(i: MarkdownTextArea, val: number[]) {
 function handleSubmit(i: MarkdownTextArea, event: KeyboardEvent) {
   event.preventDefault();
   if (i.state.content) {
-    localStorage.removeItem(LOCAL_STORAGE_KEY);
+    removeLocalStorageMarkdown();
     i.props.onSubmit?.(i.state.content, i.state.languageId);
   }
 }
@@ -819,4 +819,8 @@ function handleQuoteInsert(i: MarkdownTextArea) {
     // Not sure why this needs a delay
     setTimeout(() => autosize.update(textarea), 10);
   }
+}
+
+export function removeLocalStorageMarkdown() {
+  localStorage.removeItem(LOCAL_STORAGE_KEY);
 }

--- a/src/shared/components/common/registration-application.tsx
+++ b/src/shared/components/common/registration-application.tsx
@@ -9,7 +9,10 @@ import { mdToHtml } from "@utils/markdown";
 import { I18NextService } from "../../services";
 import { PersonListing } from "../person/person-listing";
 import { Spinner } from "./icon";
-import { MarkdownTextArea } from "./markdown-textarea";
+import {
+  MarkdownTextArea,
+  removeLocalStorageMarkdown,
+} from "./markdown-textarea";
 import { MomentTime } from "./moment-time";
 
 interface RegistrationApplicationProps {
@@ -172,6 +175,7 @@ function handleApprove(i: RegistrationApplication) {
 
 function handleDeny(i: RegistrationApplication) {
   if (i.state.denyExpanded) {
+    removeLocalStorageMarkdown();
     i.setState({ denyExpanded: false });
     i.props.onApproveApplication({
       id: i.props.application.registration_application.id,

--- a/src/shared/components/community/community-form.tsx
+++ b/src/shared/components/community/community-form.tsx
@@ -13,7 +13,10 @@ import { I18NextService } from "../../services";
 import { Icon, Spinner } from "../common/icon";
 import { ImageUploadForm } from "../common/image-upload-form";
 import { LanguageSelect } from "../common/language-select";
-import { MarkdownTextArea } from "../common/markdown-textarea";
+import {
+  MarkdownTextArea,
+  removeLocalStorageMarkdown,
+} from "../common/markdown-textarea";
 import { tippyMixin } from "../mixins/tippy-mixin";
 import { validActorRegexPattern } from "@utils/config";
 import { userNotLoggedInOrBanned } from "@utils/app";
@@ -362,6 +365,7 @@ function handleCommunitySubmit(
   event.preventDefault();
   i.setState({ submitted: true });
   const cForm = i.state.form;
+  removeLocalStorageMarkdown();
 
   const cv = i.props.communityView;
 

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -20,7 +20,10 @@ import {
 import { toast } from "@utils/app";
 import { HtmlTags } from "../common/html-tags";
 import { Icon, Spinner } from "../common/icon";
-import { MarkdownTextArea } from "../common/markdown-textarea";
+import {
+  MarkdownTextArea,
+  removeLocalStorageMarkdown,
+} from "../common/markdown-textarea";
 import PasswordInput from "../common/password-input";
 import { secondsDurationToAlertClass, secondsDurationToStr } from "@utils/date";
 import { scrollMixin } from "@components/mixins/scroll-mixin";
@@ -425,6 +428,7 @@ async function handleRegisterSubmit(
   event: FormEvent<HTMLFormElement>,
 ) {
   event.preventDefault();
+  removeLocalStorageMarkdown();
   const {
     show_nsfw,
     answer,

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -19,7 +19,10 @@ import { I18NextService } from "../../services";
 import { Icon, Spinner } from "../common/icon";
 import { ImageUploadForm } from "../common/image-upload-form";
 import { LanguageSelect } from "../common/language-select";
-import { MarkdownTextArea } from "../common/markdown-textarea";
+import {
+  MarkdownTextArea,
+  removeLocalStorageMarkdown,
+} from "../common/markdown-textarea";
 import UrlListTextarea from "../common/url-list-textarea";
 import { FormEvent } from "inferno";
 import { FederationModeDropdown } from "./federation-mode-dropdown";
@@ -754,6 +757,7 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
 
 function handleSubmit(i: SiteForm, event: FormEvent<HTMLFormElement>) {
   event.preventDefault();
+  removeLocalStorageMarkdown();
   i.setState({ submitted: true });
 
   const stateSiteForm = i.state.siteForm;

--- a/src/shared/components/home/tagline-form.tsx
+++ b/src/shared/components/home/tagline-form.tsx
@@ -7,7 +7,10 @@ import {
   EditTagline,
 } from "lemmy-js-client";
 import { I18NextService } from "../../services";
-import { MarkdownTextArea } from "../common/markdown-textarea";
+import {
+  MarkdownTextArea,
+  removeLocalStorageMarkdown,
+} from "../common/markdown-textarea";
 import { tippyMixin } from "../mixins/tippy-mixin";
 import { Prompt } from "inferno-router";
 
@@ -109,6 +112,7 @@ export class TaglineForm extends Component<TaglineFormProps, TaglineFormState> {
     event: InfernoMouseEvent<HTMLButtonElement>,
   ) {
     event.preventDefault();
+    removeLocalStorageMarkdown();
 
     const content = i.state.content ?? "";
 

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -62,7 +62,10 @@ import { HtmlTags } from "../common/html-tags";
 import { Icon, Spinner } from "../common/icon";
 import { ImageUploadForm } from "../common/image-upload-form";
 import { LanguageSelect } from "../common/language-select";
-import { MarkdownTextArea } from "../common/markdown-textarea";
+import {
+  MarkdownTextArea,
+  removeLocalStorageMarkdown,
+} from "../common/markdown-textarea";
 import PasswordInput from "../common/password-input";
 import { PostSortDropdown, CommentSortDropdown } from "../common/sort-dropdown";
 import Tabs from "../common/tabs";
@@ -1876,6 +1879,7 @@ async function handleSaveSettingsSubmit(
   event: FormEvent<HTMLFormElement>,
 ) {
   event.preventDefault();
+  removeLocalStorageMarkdown();
   i.setState({ saveRes: LOADING_REQUEST });
 
   const saveRes = await HttpService.client.saveUserSettings({

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -58,7 +58,10 @@ import {
 import { toast } from "@utils/app";
 import { Icon, Spinner } from "../common/icon";
 import { LanguageSelect } from "../common/language-select";
-import { MarkdownTextArea } from "../common/markdown-textarea";
+import {
+  MarkdownTextArea,
+  removeLocalStorageMarkdown,
+} from "../common/markdown-textarea";
 import { PostListings } from "./post-listings";
 import { isBrowser } from "@utils/browser";
 import { isMagnetLink, extractMagnetLinkDownloadName } from "@utils/media";
@@ -793,6 +796,7 @@ function updateUrl(i: PostForm, update: () => void) {
 
 function handlePostSubmit(i: PostForm, event: FormEvent<HTMLFormElement>) {
   event.preventDefault();
+  removeLocalStorageMarkdown();
 
   const pForm = i.state.form;
   const pv = i.props.post_view;


### PR DESCRIPTION
Some of the markdown forms dont use the Textarea's onSubmit function, so they are not clearing the markdown in localstorage when submitted. You can reproduce this by creating a new post with body text, the body text will be prefilled in the comment form.

Means we need to clear it explicitly in every handler.