### PR TITLE
Fix OAuth login by prompting for username if needed (fixes #4108)

### DIFF
--- a/src/shared/components/home/oauth/oauth-callback.tsx
+++ b/src/shared/components/home/oauth/oauth-callback.tsx
@@ -1,5 +1,5 @@
 import { setIsoData, updateMyUserInfo } from "@utils/app";
-import { Component } from "inferno";
+import { Component, FormEvent } from "inferno";
 import { refreshTheme } from "@utils/browser";
 import { GetSiteResponse, LoginResponse } from "lemmy-js-client";
 import { Spinner } from "../../common/icon";
@@ -41,6 +41,8 @@ export type OAuthCallbackConfig = IRoutePropsWithFetch<
 
 interface State {
   siteRes: GetSiteResponse;
+  username_required: boolean;
+  username?: string;
 }
 
 export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
@@ -48,10 +50,15 @@ export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
 
   state: State = {
     siteRes: this.isoData.siteRes,
+    username_required: false,
   };
 
   async componentDidMount() {
-    // store state in local storage
+    await this.doLogin();
+  }
+
+  async doLogin() {
+    // restore state from local storage
     const local_oauth_state = JSON.parse(
       localStorage.getItem("oauth_state") || "{}",
     ) as LocalOauthState;
@@ -75,7 +82,7 @@ export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
         oauth_provider_id: local_oauth_state.oauth_provider_id,
         redirect_uri: local_oauth_state.redirect_uri,
         show_nsfw: local_oauth_state.show_nsfw,
-        username: local_oauth_state.username,
+        username: this.state.username,
         answer: local_oauth_state.answer,
       });
 
@@ -102,6 +109,8 @@ export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
           let err_redirect = "/login";
           switch (loginRes.err.name) {
             case "registration_username_required":
+              this.setState({ username_required: true });
+              return;
             case "registration_application_answer_required":
               err_redirect = `/signup?sso_provider_id=${local_oauth_state.oauth_provider_id}`;
               toast(I18NextService.i18n.t(loginRes.err.name), "danger");
@@ -130,7 +139,6 @@ export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
       }
     }
   }
-
   get documentTitle(): string {
     return `${I18NextService.i18n.t("login")} - ${
       this.state.siteRes.site_view.site.name
@@ -140,7 +148,19 @@ export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
   render() {
     return (
       <div className="container-lg">
-        <Spinner />
+        {this.state.username_required ? (
+          <div>
+            <input
+              type="text"
+              onInput={e => handleInputUsername(this, e)}
+            ></input>
+            <button type="submit" onClick={_e => handleSubmitUsername(this)}>
+              Submit
+            </button>
+          </div>
+        ) : (
+          <Spinner />
+        )}
       </div>
     );
   }
@@ -173,4 +193,20 @@ async function handleOAuthLoginSuccess(
   }
 
   await UnreadCounterService.Instance.updateUnreadCounts();
+}
+
+function handleInputUsername(
+  i: OAuthCallback,
+  event: FormEvent<HTMLInputElement>,
+) {
+  i.setState({
+    username: event.target.value,
+  });
+}
+
+async function handleSubmitUsername(i: OAuthCallback) {
+  i.setState({
+    username_required: false,
+  });
+  await i.doLogin();
 }

--- a/src/shared/components/home/oauth/oauth-callback.tsx
+++ b/src/shared/components/home/oauth/oauth-callback.tsx
@@ -12,7 +12,8 @@ import { UnreadCounterService } from "../../../services";
 import { HttpService } from "../../../services/HttpService";
 import { toast } from "@utils/app";
 import { Action } from "history";
-import { LocalOauthState } from "./oauth-login";
+import { handleLoginWithProvider, LocalOauthState } from "./oauth-login";
+import { NoOptionI18nKeys } from "i18next";
 
 interface OAuthCallbackProps {
   code?: string;
@@ -46,7 +47,7 @@ interface State {
 }
 
 export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
-  isoData = setIsoData(this.context);
+  public isoData = setIsoData(this.context);
 
   state: State = {
     siteRes: this.isoData.siteRes,
@@ -82,7 +83,7 @@ export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
         oauth_provider_id: local_oauth_state.oauth_provider_id,
         redirect_uri: local_oauth_state.redirect_uri,
         show_nsfw: local_oauth_state.show_nsfw,
-        username: this.state.username,
+        username: local_oauth_state.username,
         answer: local_oauth_state.answer,
       });
 
@@ -106,32 +107,16 @@ export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
           break;
         }
         case "failed": {
-          let err_redirect = "/login";
+          const err_redirect = "/login";
           switch (loginRes.err.name) {
             case "registration_username_required":
               this.setState({ username_required: true });
               return;
-            case "registration_application_answer_required":
-              err_redirect = `/signup?sso_provider_id=${local_oauth_state.oauth_provider_id}`;
-              toast(I18NextService.i18n.t(loginRes.err.name), "danger");
-              break;
-            case "registration_application_is_pending":
+            default:
               toast(
-                I18NextService.i18n.t("registration_application_pending"),
+                I18NextService.i18n.t(loginRes.err.name as NoOptionI18nKeys),
                 "danger",
               );
-              break;
-            case "registration_denied":
-            case "oauth_authorization_invalid":
-            case "oauth_login_failed":
-            case "oauth_registration_closed":
-            case "email_already_exists":
-            case "username_already_exists":
-            case "no_email_setup":
-              toast(I18NextService.i18n.t(loginRes.err.name), "danger");
-              break;
-            default:
-              toast(I18NextService.i18n.t("incorrect_login"), "danger");
               break;
           }
           this.props.history.push(err_redirect);
@@ -149,13 +134,22 @@ export class OAuthCallback extends Component<OAuthCallbackRouteProps, State> {
     return (
       <div className="container-lg">
         {this.state.username_required ? (
-          <div>
+          <div className="col-6 align-self-center">
+            <label htmlFor="username">
+              {I18NextService.i18n.t("username")}
+            </label>
             <input
+              id="username"
               type="text"
+              className="form-control w-50 inline"
               onInput={e => handleInputUsername(this, e)}
             ></input>
-            <button type="submit" onClick={_e => handleSubmitUsername(this)}>
-              Submit
+            <button
+              type="submit"
+              className="btn btn-light border-light-subtle mt-2"
+              onClick={_e => handleSubmitUsername(this)}
+            >
+              {I18NextService.i18n.t("submit")}
             </button>
           </div>
         ) : (
@@ -204,9 +198,20 @@ function handleInputUsername(
   });
 }
 
-async function handleSubmitUsername(i: OAuthCallback) {
+function handleSubmitUsername(i: OAuthCallback) {
   i.setState({
     username_required: false,
   });
-  await i.doLogin();
+  const local_oauth_state = JSON.parse(
+    localStorage.getItem("oauth_state") || "{}",
+  ) as LocalOauthState;
+
+  const provider = i.isoData.siteRes.oauth_providers.find(
+    p => p.id === local_oauth_state.oauth_provider_id,
+  );
+  if (provider) {
+    handleLoginWithProvider(provider, i.state.username);
+  } else {
+    i.props.history.push("/login");
+  }
 }

--- a/src/shared/components/home/oauth/oauth-login.tsx
+++ b/src/shared/components/home/oauth/oauth-login.tsx
@@ -37,7 +37,6 @@ export class OAuthLogin extends Component<OAuthLoginProps, object> {
 function handleLoginWithProvider(
   oauth_provider: PublicOAuthProvider,
   prev?: string,
-  username?: string,
   answer?: string,
   show_nsfw?: boolean,
 ) {

--- a/src/shared/components/home/oauth/oauth-login.tsx
+++ b/src/shared/components/home/oauth/oauth-login.tsx
@@ -59,7 +59,6 @@ function handleLoginWithProvider(
     oauth_provider_id: oauth_provider.id,
     redirect_uri: redirectUri,
     prev: prev ?? "/",
-    username: username,
     answer: answer,
     show_nsfw: show_nsfw,
     expires_at: Date.now() + 5 * 60_000,
@@ -75,7 +74,6 @@ export interface LocalOauthState {
   oauth_provider_id: number;
   redirect_uri: string;
   prev: string;
-  username?: string;
   answer?: string;
   show_nsfw?: boolean;
   expires_at?: number;

--- a/src/shared/components/home/oauth/oauth-login.tsx
+++ b/src/shared/components/home/oauth/oauth-login.tsx
@@ -34,8 +34,9 @@ export class OAuthLogin extends Component<OAuthLoginProps, object> {
   }
 }
 
-function handleLoginWithProvider(
+export function handleLoginWithProvider(
   oauth_provider: PublicOAuthProvider,
+  username?: string,
   prev?: string,
   answer?: string,
   show_nsfw?: boolean,
@@ -58,6 +59,7 @@ function handleLoginWithProvider(
     oauth_provider_id: oauth_provider.id,
     redirect_uri: redirectUri,
     prev: prev ?? "/",
+    username: username,
     answer: answer,
     show_nsfw: show_nsfw,
     expires_at: Date.now() + 5 * 60_000,
@@ -75,5 +77,6 @@ export interface LocalOauthState {
   prev: string;
   answer?: string;
   show_nsfw?: boolean;
+  username?: string;
   expires_at?: number;
 }


### PR DESCRIPTION
Testing this locally by temporarily changing the "Authorization callback URL" in Github. Correctly prompts for username now, but in the end it returns "https://voyager.lemmy.ml/api/v4/oauth/authenticate". Server logs show this:
```
lemmy-1  | 2026-05-21T11:20:05.210051Z DEBUG HTTP request{http.method=POST http.route=/api/v4/oauth/authenticate http.flavor=1.1 http.scheme=http http.host=voyager.lemmy.ml http.client_ip=88.13.133.212 http.user_agent=Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0 http.target=/api/v4/oauth/authenticate otel.name=POST /api/v4/oauth/authenticate otel.kind="server" request_id=4ff4cfc8-2539-453a-8dd0-a3587af9e84e}: actix_web::middleware::logger: Error in response: LemmyError { message: OauthLoginFailed, caller: crates/utils/src/error.rs:278:20, inner: error decoding response body
lemmy-1  |
lemmy-1  | Caused by:
lemmy-1  |     missing field `access_token` at line 1 column 236
lemmy-1  |
lemmy-1  | Stack backtrace:
lemmy-1  |    0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
lemmy-1  |    1: <core::result::Result<T,E> as lemmy_utils::error::LemmyErrorExt<T,E>>::with_lemmy_type::{{closure}}
lemmy-1  |    2: lemmy_api_crud::user::create::authenticate_with_oauth::{{closure}}
lemmy-1  |    3: actix_web::handler::handler_service::{{closure}}::{{closure}}
```