### PR TITLE
Don't show thumbnails for text posts.

### DIFF
--- a/src/shared/components/person/person-listing.tsx
+++ b/src/shared/components/person/person-listing.tsx
@@ -104,13 +104,13 @@ function AvatarAndName({
     !showAvatars(myUserInfo);
 
   return (
-    <>
+    <span className="overflow-wrap-anywhere">
       {!hideAvatar_ && !banned && avatar && (
         <PictrsImage src={avatar} type="icon" />
       )}
       <span className={nameClasses}>{name}</span>
       {serverStr && <small className="text-muted">{serverStr}</small>}
-    </>
+    </span>
   );
 }
 

--- a/src/shared/components/post/common.tsx
+++ b/src/shared/components/post/common.tsx
@@ -259,7 +259,7 @@ export function UrlLine(
         !localUrl && (
           <>
             <a
-              className="fst-italic text-body link-opacity-75 link-opacity-100-hover"
+              className="fst-italic text-body link-opacity-75 link-opacity-100-hover overflow-wrap-anywhere"
               href={url}
               title={url}
               rel={relTags}

--- a/src/shared/components/post/post-listing-list.tsx
+++ b/src/shared/components/post/post-listing-list.tsx
@@ -60,7 +60,7 @@ export function PostListingList({
             />
           </div>
         )}
-        <div className="col flex-grow-1">
+        <div className="col">
           <PostName post={postView.post} showBody="hidden" />
           <PostCreatedLine
             postView={postView}

--- a/src/shared/components/post/post-thumbnail.tsx
+++ b/src/shared/components/post/post-thumbnail.tsx
@@ -1,11 +1,9 @@
 import { Icon } from "@components/common/icon";
 import { PictrsImage } from "@components/common/pictrs-image";
-import { I18NextService } from "@services/index";
 import { hideAnimatedImage, hideImages, linkTarget } from "@utils/app";
 import { relTags } from "@utils/config";
 import { isImage, isVideo } from "@utils/media";
 import classNames from "classnames";
-import { Link } from "inferno-router";
 import { PostView, MyUserInfo } from "lemmy-js-client";
 
 type Props = {
@@ -106,22 +104,8 @@ export function PostThumbnail({ postView, hideImage, myUserInfo }: Props) {
       );
     }
   } else {
-    return (
-      <Link
-        className="text-body"
-        to={`/post/${post.id}`}
-        title={I18NextService.i18n.t("comments")}
-        target={linkTarget(myUserInfo)}
-      >
-        <div className="thumbnail rounded bg-light d-flex justify-content-center">
-          <Icon
-            icon="message-square"
-            small
-            classes="d-flex align-items-center"
-          />
-        </div>
-      </Link>
-    );
+    // Don't show thumbnails for text posts
+    return;
   }
 }
 

--- a/src/shared/components/post/post-thumbnail.tsx
+++ b/src/shared/components/post/post-thumbnail.tsx
@@ -106,9 +106,10 @@ export function PostThumbnail({ postView, hideImage, myUserInfo }: Props) {
       );
     }
   } else {
+    // Don't show on screens smaller than md
     return (
       <Link
-        className="text-body"
+        className="text-body d-none d-md-block"
         to={`/post/${post.id}`}
         title={I18NextService.i18n.t("comments")}
         target={linkTarget(myUserInfo)}

--- a/src/shared/components/post/post-thumbnail.tsx
+++ b/src/shared/components/post/post-thumbnail.tsx
@@ -1,9 +1,11 @@
 import { Icon } from "@components/common/icon";
 import { PictrsImage } from "@components/common/pictrs-image";
+import { I18NextService } from "@services/index";
 import { hideAnimatedImage, hideImages, linkTarget } from "@utils/app";
 import { relTags } from "@utils/config";
 import { isImage, isVideo } from "@utils/media";
 import classNames from "classnames";
+import { Link } from "inferno-router";
 import { PostView, MyUserInfo } from "lemmy-js-client";
 
 type Props = {
@@ -104,8 +106,22 @@ export function PostThumbnail({ postView, hideImage, myUserInfo }: Props) {
       );
     }
   } else {
-    // Don't show thumbnails for text posts
-    return;
+    return (
+      <Link
+        className="text-body"
+        to={`/post/${post.id}`}
+        title={I18NextService.i18n.t("comments")}
+        target={linkTarget(myUserInfo)}
+      >
+        <div className="thumbnail rounded bg-light d-flex justify-content-center">
+          <Icon
+            icon="message-square"
+            small
+            classes="d-flex align-items-center"
+          />
+        </div>
+      </Link>
+    );
   }
 }
 


### PR DESCRIPTION
- This removes the pointless message-square thumbnail for text-only posts.
- #4131

## Screenshots

### Before

<img width="300" alt="Screenshot_2026-05-25-13-25-58-425_mark via" src="https://github.com/user-attachments/assets/0b9339e0-57d9-48df-a5aa-a6e9e8279b4a" />

### After

<img width="300" alt="Screenshot_2026-05-25-13-26-18-912_mark via" src="https://github.com/user-attachments/assets/a01f5403-98e5-4c1a-b057-e4c31319308d" />

