### PR TITLE
Community tag colors

### DIFF
--- a/src/shared/components/common/tag-color-dropdown.tsx
+++ b/src/shared/components/common/tag-color-dropdown.tsx
@@ -1,0 +1,64 @@
+import { TagColor } from "lemmy-js-client";
+import { FilterChipDropdown, FilterOption } from "./filter-chip-dropdown";
+
+// There are actually 10 color options in the back end, but squash these down
+const tagColorOptions: FilterOption<TagColor>[] = [
+  { noI18n: "1", value: "color01" },
+  { noI18n: "2", value: "color02" },
+  { noI18n: "3", value: "color03" },
+  { noI18n: "4", value: "color04" },
+  { noI18n: "5", value: "color05" },
+  { noI18n: "6", value: "color06" },
+];
+
+type TagColorDropdownProps = {
+  currentOption: TagColor;
+  onSelect: (val: TagColor) => void;
+  className?: string;
+};
+
+export function tagColorToColorClass(tagColor: TagColor): string {
+  switch (tagColor) {
+    case "color01":
+      return "light";
+    case "color02":
+      return "primary";
+    case "color03":
+      return "info";
+    case "color04":
+      return "success";
+    case "color05":
+      return "warning";
+    case "color06":
+      return "danger";
+    case "color07":
+    case "color08":
+    case "color09":
+    case "color10":
+      return "light";
+  }
+}
+
+function tagColorToBtnClasses(tagColor: TagColor): string {
+  const colorClass = tagColorToColorClass(tagColor);
+
+  return `btn btn-sm bg-${colorClass}-subtle border-${colorClass}-subtle`;
+}
+
+export function TagColorDropdown({
+  currentOption,
+  onSelect,
+  className,
+}: TagColorDropdownProps) {
+  const classes = `${className} ${tagColorToBtnClasses(currentOption)}`;
+
+  return (
+    <FilterChipDropdown
+      allOptions={tagColorOptions}
+      label={"color"}
+      currentOption={tagColorOptions.find(t => t.value === currentOption)}
+      onSelect={onSelect}
+      className={classes}
+    />
+  );
+}

--- a/src/shared/components/community/community-link.tsx
+++ b/src/shared/components/community/community-link.tsx
@@ -27,7 +27,9 @@ export class CommunityLink extends Component<CommunityLinkProps, never> {
 
     const { link, serverStr } = communityLink(community, this.props.realLink);
 
-    const classes = `community-link ${this.props.muted ? "text-muted" : ""}`;
+    const classes = classNames(`community-link`, {
+      "text-muted": this.props.muted,
+    });
 
     return !this.props.realLink ? (
       <Link title={title} className={classes} to={link}>

--- a/src/shared/components/community/community-settings.tsx
+++ b/src/shared/components/community/community-settings.tsx
@@ -382,117 +382,115 @@ export class CommunitySettings extends Component<RouteProps, State> {
           <TableHr />
           {res &&
             res.moderators.map(m => (
-              <>
-                <div className="row" key={m.moderator.id}>
-                  <div className={nameCols}>
-                    <PersonListing
-                      person={m.moderator}
-                      banned={false}
-                      myUserInfo={myUserInfo}
-                    />
-                    <UserBadges
-                      classNames="ms-1"
-                      myUserInfo={myUserInfo}
-                      creator={m.moderator}
-                    />
-                    {amHigherModerator(res.moderators, m, myUserInfo) && (
-                      <>
-                        <button
-                          className="btn btn-link"
-                          onClick={() =>
-                            this.setState({
-                              showRemoveModDialog: m,
-                            })
-                          }
-                          data-tippy-content={I18NextService.i18n.t(
-                            "remove_as_mod",
-                          )}
-                        >
-                          <Icon icon="x" classes="icon-inline text-danger" />
-                        </button>
-                        <ConfirmationModal
-                          show={
-                            this.state.showRemoveModDialog?.moderator.id ===
-                            m.moderator.id
-                          }
-                          message={I18NextService.i18n.t(
-                            "remove_as_mod_are_you_sure",
-                            {
-                              user: getApubName(m.moderator),
-                              community: getApubName(m.community),
-                            },
-                          )}
-                          loadingMessage={I18NextService.i18n.t("removing_mod")}
-                          onNo={() =>
-                            this.setState({ showRemoveModDialog: undefined })
-                          }
-                          onYes={() =>
-                            handleAddMod(this, {
-                              community_id: res.community_view.community.id,
-                              person_id: m.moderator.id,
-                              added: false,
-                            })
-                          }
-                        />
-                      </>
-                    )}
-                    {amTopModExcludeMe(
-                      m.moderator.id,
-                      res.moderators,
-                      myUserInfo,
-                    ) && (
-                      <>
-                        <button
-                          className="btn btn-link"
-                          onClick={() =>
-                            this.setState({
-                              showTransferDialog: m,
-                            })
-                          }
-                          data-tippy-content={I18NextService.i18n.t(
-                            "transfer_community",
-                          )}
-                        >
-                          <Icon icon="transfer" classes="icon-inline" />
-                        </button>
-                        <ConfirmationModal
-                          show={
-                            this.state.showTransferDialog?.moderator.id ===
-                            m.moderator.id
-                          }
-                          message={I18NextService.i18n.t(
-                            "transfer_community_are_you_sure",
-                            {
-                              user: getApubName(m.moderator),
-                              community: getApubName(m.community),
-                            },
-                          )}
-                          loadingMessage={I18NextService.i18n.t(
-                            "transferring_community",
-                          )}
-                          onNo={() =>
-                            this.setState({ showTransferDialog: undefined })
-                          }
-                          onYes={() =>
-                            handleTransferCommunity(this, {
-                              community_id: res.community_view.community.id,
-                              person_id: m.moderator.id,
-                            })
-                          }
-                        />
-                      </>
-                    )}
-                  </div>
-                  <div className={dataCols}>
-                    <MomentTime published={m.moderator.published_at} />
-                  </div>
-                  <div className={dataCols}>{m.moderator.post_count}</div>
-                  <div className={dataCols}>{m.moderator.comment_count}</div>
+              <div className="row" key={m.moderator.id}>
+                <div className={nameCols}>
+                  <PersonListing
+                    person={m.moderator}
+                    banned={false}
+                    myUserInfo={myUserInfo}
+                  />
+                  <UserBadges
+                    classNames="ms-1"
+                    myUserInfo={myUserInfo}
+                    creator={m.moderator}
+                  />
+                  {amHigherModerator(res.moderators, m, myUserInfo) && (
+                    <>
+                      <button
+                        className="btn btn-link"
+                        onClick={() =>
+                          this.setState({
+                            showRemoveModDialog: m,
+                          })
+                        }
+                        data-tippy-content={I18NextService.i18n.t(
+                          "remove_as_mod",
+                        )}
+                      >
+                        <Icon icon="x" classes="icon-inline text-danger" />
+                      </button>
+                      <ConfirmationModal
+                        show={
+                          this.state.showRemoveModDialog?.moderator.id ===
+                          m.moderator.id
+                        }
+                        message={I18NextService.i18n.t(
+                          "remove_as_mod_are_you_sure",
+                          {
+                            user: getApubName(m.moderator),
+                            community: getApubName(m.community),
+                          },
+                        )}
+                        loadingMessage={I18NextService.i18n.t("removing_mod")}
+                        onNo={() =>
+                          this.setState({ showRemoveModDialog: undefined })
+                        }
+                        onYes={() =>
+                          handleAddMod(this, {
+                            community_id: res.community_view.community.id,
+                            person_id: m.moderator.id,
+                            added: false,
+                          })
+                        }
+                      />
+                    </>
+                  )}
+                  {amTopModExcludeMe(
+                    m.moderator.id,
+                    res.moderators,
+                    myUserInfo,
+                  ) && (
+                    <>
+                      <button
+                        className="btn btn-link"
+                        onClick={() =>
+                          this.setState({
+                            showTransferDialog: m,
+                          })
+                        }
+                        data-tippy-content={I18NextService.i18n.t(
+                          "transfer_community",
+                        )}
+                      >
+                        <Icon icon="transfer" classes="icon-inline" />
+                      </button>
+                      <ConfirmationModal
+                        show={
+                          this.state.showTransferDialog?.moderator.id ===
+                          m.moderator.id
+                        }
+                        message={I18NextService.i18n.t(
+                          "transfer_community_are_you_sure",
+                          {
+                            user: getApubName(m.moderator),
+                            community: getApubName(m.community),
+                          },
+                        )}
+                        loadingMessage={I18NextService.i18n.t(
+                          "transferring_community",
+                        )}
+                        onNo={() =>
+                          this.setState({ showTransferDialog: undefined })
+                        }
+                        onYes={() =>
+                          handleTransferCommunity(this, {
+                            community_id: res.community_view.community.id,
+                            person_id: m.moderator.id,
+                          })
+                        }
+                      />
+                    </>
+                  )}
                 </div>
-                <hr />
-              </>
+                <div className={dataCols}>
+                  <MomentTime published={m.moderator.published_at} />
+                </div>
+                <div className={dataCols}>{m.moderator.post_count}</div>
+                <div className={dataCols}>{m.moderator.comment_count}</div>
+              </div>
             ))}
         </div>
+        <hr />
         <div className="row mb-4">
           <div className="col-12 col-md-4">
             <FilterChipSelect

--- a/src/shared/components/community/community-settings.tsx
+++ b/src/shared/components/community/community-settings.tsx
@@ -666,6 +666,9 @@ async function handleEditTag(i: CommunitySettings, form: EditCommunityTag) {
     createOrEditTagRes: { id: form.tag_id, res },
   });
 
+  // Need to refetch community to update tags
+  await i.fetchCommunity(i.props);
+
   if (res.state === "success") {
     toast(I18NextService.i18n.t("community_tag_edited"));
   }

--- a/src/shared/components/community/community-tag-form.tsx
+++ b/src/shared/components/community/community-tag-form.tsx
@@ -8,6 +8,7 @@ import {
   CommunityTag as CommunityTagI,
   CommunityTagId,
   EditCommunityTag,
+  TagColor,
 } from "lemmy-js-client";
 import { I18NextService } from "../../services";
 import { tippyMixin } from "../mixins/tippy-mixin";
@@ -15,6 +16,7 @@ import { Prompt } from "inferno-router";
 import { Spinner } from "@components/common/icon";
 import { validActorRegexPattern } from "@utils/config";
 import { CommunityTag } from "./community-tag";
+import { TagColorDropdown } from "@components/common/tag-color-dropdown";
 
 type CommunityTagGenericForm = {
   tag_id?: CommunityTagId;
@@ -22,6 +24,7 @@ type CommunityTagGenericForm = {
   name?: string;
   display_name?: string;
   summary?: string;
+  color?: TagColor;
 };
 
 interface CommunityTagFormProps {
@@ -68,6 +71,7 @@ export class CommunityTagForm extends Component<
         name: tag.name,
         display_name: tag.display_name,
         summary: tag.summary,
+        color: tag.color,
       };
     } else {
       return { community_id: this.props.communityId };
@@ -151,6 +155,12 @@ export class CommunityTagForm extends Component<
             />
           </div>
           <div className="col-12">
+            <TagColorDropdown
+              currentOption={this.state.form.color ?? "color01"}
+              onSelect={val => handleTagColorChange(this, val)}
+            />
+          </div>
+          <div className="col-12">
             <button
               className="btn btn-light border-light-subtle me-2"
               type="submit"
@@ -199,6 +209,13 @@ function handleDisplayNameChange(
 ) {
   i.setState({
     form: { ...i.state.form, display_name: event.target.value },
+    bypassNavWarning: false,
+  });
+}
+
+function handleTagColorChange(i: CommunityTagForm, color: TagColor) {
+  i.setState({
+    form: { ...i.state.form, color },
     bypassNavWarning: false,
   });
 }

--- a/src/shared/components/community/community-tag.tsx
+++ b/src/shared/components/community/community-tag.tsx
@@ -1,3 +1,4 @@
+import { tagColorToColorClass } from "@components/common/tag-color-dropdown";
 import { CommunityTag as CommunityTagI } from "lemmy-js-client";
 
 type CommunityTagProps = {
@@ -5,15 +6,16 @@ type CommunityTagProps = {
   useName: boolean;
 };
 export function CommunityTag({ tag, useName }: CommunityTagProps) {
-  const { name, summary } = tag;
+  const { name, summary, color } = tag;
   const label = useName ? name : communityTagName(tag);
 
   const summaryStr = summary ? ` - ${summary}` : "";
   const tooltip = `${name}${summaryStr}`;
+  const colorClass = tagColorToColorClass(color);
 
   return (
     <span
-      className={`badge text-bg-light`}
+      className={`badge text-bg-${colorClass}`}
       aria-label={tooltip}
       data-tippy-content={tooltip}
       data-tippy-allowHTML

--- a/src/shared/components/post/common.tsx
+++ b/src/shared/components/post/common.tsx
@@ -59,7 +59,7 @@ type PostBadgesProps = {
 };
 export function PostBadges({ post, tags, allLanguages }: PostBadgesProps) {
   return (
-    <>
+    <span className="ms-1">
       {tags.map(tag => (
         <span className="me-1">
           <CommunityTag tag={tag} useName={false} />
@@ -71,7 +71,7 @@ export function PostBadges({ post, tags, allLanguages }: PostBadgesProps) {
         </span>
       )}{" "}
       {post.scheduled_publish_time_at && (
-        <span className="mx-1 badge text-bg-light">
+        <span className="me-1 badge text-bg-light">
           {I18NextService.i18n.t("publish_in_time", {
             time: formatRelativeDate(post.scheduled_publish_time_at, true),
           })}
@@ -121,7 +121,7 @@ export function PostBadges({ post, tags, allLanguages }: PostBadgesProps) {
           {I18NextService.i18n.t("nsfw")}
         </small>
       )}
-    </>
+    </span>
   );
 }
 


### PR DESCRIPTION
## Description

Adds 6 tag colors, as well as a mapping to the bootstrap ones.

I tried to make the badges more subtle (like the buttons), but it seemed a bit dangerous to mess with bootstraps contrasts. As you can see the badge text color changes based on the badge background color, and this is built in to the bootstrap badge class theme. Its better not to mess with it, and just do it the official way: https://getbootstrap.com/docs/5.3/components/badge/

https://github.com/user-attachments/assets/23048268-ea4e-49cc-8994-9fa64a3943e4

Fixes #4171

