### PR TITLE
Only clear local storage markdown for success responses

### DIFF
--- a/src/shared/components/common/markdown-textarea.tsx
+++ b/src/shared/components/common/markdown-textarea.tsx
@@ -639,7 +639,6 @@ function handleLanguageChange(i: MarkdownTextArea, val: number[]) {
 function handleSubmit(i: MarkdownTextArea, event: KeyboardEvent) {
   event.preventDefault();
   if (i.state.content) {
-    removeLocalStorageMarkdown();
     i.props.onSubmit?.(i.state.content, i.state.languageId);
   }
 }

--- a/src/shared/components/common/registration-application.tsx
+++ b/src/shared/components/common/registration-application.tsx
@@ -9,10 +9,7 @@ import { mdToHtml } from "@utils/markdown";
 import { I18NextService } from "../../services";
 import { PersonListing } from "../person/person-listing";
 import { Spinner } from "./icon";
-import {
-  MarkdownTextArea,
-  removeLocalStorageMarkdown,
-} from "./markdown-textarea";
+import { MarkdownTextArea } from "./markdown-textarea";
 import { MomentTime } from "./moment-time";
 
 interface RegistrationApplicationProps {
@@ -175,7 +172,6 @@ function handleApprove(i: RegistrationApplication) {
 
 function handleDeny(i: RegistrationApplication) {
   if (i.state.denyExpanded) {
-    removeLocalStorageMarkdown();
     i.setState({ denyExpanded: false });
     i.props.onApproveApplication({
       id: i.props.application.registration_application.id,

--- a/src/shared/components/community/community-form.tsx
+++ b/src/shared/components/community/community-form.tsx
@@ -13,10 +13,7 @@ import { I18NextService } from "../../services";
 import { Icon, Spinner } from "../common/icon";
 import { ImageUploadForm } from "../common/image-upload-form";
 import { LanguageSelect } from "../common/language-select";
-import {
-  MarkdownTextArea,
-  removeLocalStorageMarkdown,
-} from "../common/markdown-textarea";
+import { MarkdownTextArea } from "../common/markdown-textarea";
 import { tippyMixin } from "../mixins/tippy-mixin";
 import { validActorRegexPattern } from "@utils/config";
 import { userNotLoggedInOrBanned } from "@utils/app";
@@ -376,7 +373,6 @@ function handleCommunitySubmit(
   event.preventDefault();
   i.setState({ submitted: true });
   const cForm = i.state.form;
-  removeLocalStorageMarkdown();
 
   const cv = i.props.communityView;
 

--- a/src/shared/components/community/community-settings.tsx
+++ b/src/shared/components/community/community-settings.tsx
@@ -70,6 +70,7 @@ import { CommunityTagForm } from "./community-tag-form";
 import { NoOptionI18nKeys } from "i18next";
 import { CommunityLink } from "./community-link";
 import { FilterChipSelect } from "@components/common/filter-chip-select";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 type CommunitySettingsData = RouteDataResponse<{
   communityRes: GetCommunityResponse;
@@ -621,6 +622,7 @@ async function handleEditCommunity(i: CommunitySettings, form: EditCommunity) {
 
   if (i.state.editCommunityRes.state === "success") {
     i.updateCommunity(i.state.editCommunityRes);
+    removeLocalStorageMarkdown();
     toast(I18NextService.i18n.t("saved"));
   }
 }

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -134,6 +134,7 @@ import {
   ExpandChipCheckbox,
   FilterChipCheckbox,
 } from "@components/common/filter-chip-checkbox";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 type CommunityData = RouteDataResponse<{
   communityRes: GetCommunityResponse;
@@ -1410,6 +1411,7 @@ function createAndUpdateComments(
 function findAndUpdatePost(i: Community, res: RequestState<PostResponse>) {
   i.setState(s => {
     if (s.postsRes.state === "success" && res.state === "success") {
+      removeLocalStorageMarkdown();
       s.postsRes.data.items = editPost(
         res.data.post_view,
         s.postsRes.data.items,

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -1372,6 +1372,7 @@ function findAndUpdateCommentEdit(
 ) {
   i.setState(s => {
     if (s.commentsRes.state === "success" && res.state === "success") {
+      removeLocalStorageMarkdown();
       s.commentsRes.data.items = editComment(
         res.data.comment_view,
         s.commentsRes.data.items,
@@ -1402,6 +1403,7 @@ function createAndUpdateComments(
 ) {
   i.setState(s => {
     if (s.commentsRes.state === "success" && res.state === "success") {
+      removeLocalStorageMarkdown();
       s.commentsRes.data.items.unshift(res.data.comment_view);
     }
     return s;

--- a/src/shared/components/community/create-community.tsx
+++ b/src/shared/components/community/create-community.tsx
@@ -17,6 +17,7 @@ import {
   LOADING_REQUEST,
   RequestState,
 } from "@services/HttpService";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 interface CreateCommunityState {
   createCommunityRes: RequestState<CommunityResponse>;
@@ -88,6 +89,7 @@ async function handleCommunityCreate(
       moderator: myUserInfo.local_user_view.person,
     });
     const name = res.data.community_view.community.name;
+    removeLocalStorageMarkdown();
     i.props.history.replace(`/c/${name}`);
   } else if (res.state === "failed") {
     toast(I18NextService.i18n.t(res.err.name as NoOptionI18nKeys), "danger");

--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -1068,6 +1068,7 @@ async function handleCreateTagline(i: AdminSettings, form: CreateTagline) {
   const res = await HttpService.client.createTagline(form);
 
   if (res.state === "success") {
+    removeLocalStorageMarkdown();
     toast(I18NextService.i18n.t("tagline_created"));
     await i.fetchTaglinesOnly();
   } else {
@@ -1095,6 +1096,7 @@ async function handleEditTagline(i: AdminSettings, form: EditTagline) {
   const res = await HttpService.client.editTagline(form);
 
   if (res.state === "success") {
+    removeLocalStorageMarkdown();
     toast(I18NextService.i18n.t("tagline_updated"));
   } else {
     toast(I18NextService.i18n.t("couldnt_update_tagline"), "danger");

--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -68,6 +68,7 @@ import {
   AllOrBannedDropdown,
 } from "@components/common/all-or-banned-dropdown";
 import { InstancesKindDropdown } from "@components/common/instances-kind-dropdown";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 type AdminSettingsData = RouteDataResponse<{
   usersRes: PagedResponse<LocalUserView>;
@@ -902,6 +903,7 @@ async function handleEditSite(i: AdminSettings, form: EditSite) {
   const editRes = await HttpService.client.editSite(form);
 
   if (editRes.state === "success") {
+    removeLocalStorageMarkdown();
     i.forceUpdate();
     toast(I18NextService.i18n.t("site_saved"));
 

--- a/src/shared/components/home/authenticate/signup.tsx
+++ b/src/shared/components/home/authenticate/signup.tsx
@@ -20,7 +20,6 @@ import {
 import { toast } from "@utils/app";
 import { HtmlTags } from "../../common/html-tags";
 import { Icon, Spinner } from "../../common/icon";
-import { removeLocalStorageMarkdown } from "../../common/markdown-textarea";
 import PasswordInput from "../../common/password-input";
 import { scrollMixin } from "@components/mixins/scroll-mixin";
 import { RouteData } from "@utils/types";
@@ -30,6 +29,7 @@ import { OAuthLogin } from "../oauth/oauth-login";
 import { RegistrationApplicationInput } from "./registration-application-input";
 import { RegistrationLegalInfo } from "./registration-legal-info";
 import { RegistrationCheckboxes } from "./registration-checkboxes";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 interface State {
   registerRes: RequestState<LoginResponse>;
@@ -304,7 +304,6 @@ async function handleRegisterSubmit(
   event: FormEvent<HTMLFormElement>,
 ) {
   event.preventDefault();
-  removeLocalStorageMarkdown();
   const {
     show_nsfw,
     answer,
@@ -343,7 +342,6 @@ async function handleRegisterSubmit(
 
       case "success": {
         const data = registerRes.data;
-
         // Only log them in if a jwt was set
         if (data.jwt) {
           UserService.Instance.login({ res: data });
@@ -351,6 +349,8 @@ async function handleRegisterSubmit(
           const myUserRes = await HttpService.client.getMyUser();
 
           if (myUserRes.state === "success") {
+            removeLocalStorageMarkdown();
+
             updateMyUserInfo(myUserRes.data);
             refreshTheme();
             await I18NextService.reconfigure(

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -132,6 +132,7 @@ import {
   secondsToLargestInterval,
   TimeIntervalFilter,
 } from "@components/common/time-interval-filter";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 interface HomeState {
   postsRes: RequestState<PagedResponse<PostView>>;
@@ -1122,6 +1123,7 @@ export class Home extends Component<HomeRouteProps, HomeState> {
   findAndUpdatePost(res: RequestState<PostResponse>) {
     this.setState(s => {
       if (s.postsRes.state === "success" && res.state === "success") {
+        removeLocalStorageMarkdown();
         s.postsRes.data.items = editPost(
           res.data.post_view,
           s.postsRes.data.items,

--- a/src/shared/components/home/home.tsx
+++ b/src/shared/components/home/home.tsx
@@ -1090,6 +1090,7 @@ export class Home extends Component<HomeRouteProps, HomeState> {
   findAndUpdateCommentEdit(res: RequestState<CommentResponse>) {
     this.setState(s => {
       if (s.commentsRes.state === "success" && res.state === "success") {
+        removeLocalStorageMarkdown();
         s.commentsRes.data.items = editComment(
           res.data.comment_view,
           s.commentsRes.data.items,
@@ -1102,6 +1103,7 @@ export class Home extends Component<HomeRouteProps, HomeState> {
   findAndUpdateComment(res: RequestState<CommentResponse>) {
     this.setState(s => {
       if (s.commentsRes.state === "success" && res.state === "success") {
+        removeLocalStorageMarkdown();
         s.commentsRes.data.items = editComment(
           res.data.comment_view,
           s.commentsRes.data.items,
@@ -1114,6 +1116,7 @@ export class Home extends Component<HomeRouteProps, HomeState> {
   createAndUpdateComments(res: RequestState<CommentResponse>) {
     this.setState(s => {
       if (s.commentsRes.state === "success" && res.state === "success") {
+        removeLocalStorageMarkdown();
         s.commentsRes.data.items.unshift(res.data.comment_view);
       }
       return s;

--- a/src/shared/components/home/setup.tsx
+++ b/src/shared/components/home/setup.tsx
@@ -15,6 +15,7 @@ import { SiteForm } from "./site-form";
 import { simpleScrollMixin } from "../mixins/scroll-mixin";
 import { RouteComponentProps } from "inferno-router";
 import { isBrowser } from "@utils/browser";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 interface State {
   form: {
@@ -204,6 +205,7 @@ async function handleRegisterSubmit(
 async function handleCreateSite(i: Setup, form: CreateSite) {
   const createRes = await HttpService.client.createSite(form);
   if (createRes.state === "success") {
+    removeLocalStorageMarkdown();
     i.props.history.replace("/");
     location.reload();
   }

--- a/src/shared/components/home/site-form.tsx
+++ b/src/shared/components/home/site-form.tsx
@@ -19,10 +19,7 @@ import { I18NextService } from "../../services";
 import { Icon, Spinner } from "../common/icon";
 import { ImageUploadForm } from "../common/image-upload-form";
 import { LanguageSelect } from "../common/language-select";
-import {
-  MarkdownTextArea,
-  removeLocalStorageMarkdown,
-} from "../common/markdown-textarea";
+import { MarkdownTextArea } from "../common/markdown-textarea";
 import UrlListTextarea from "../common/url-list-textarea";
 import { FormEvent } from "inferno";
 import { FederationModeDropdown } from "./federation-mode-dropdown";
@@ -757,7 +754,6 @@ export class SiteForm extends Component<SiteFormProps, SiteFormState> {
 
 function handleSubmit(i: SiteForm, event: FormEvent<HTMLFormElement>) {
   event.preventDefault();
-  removeLocalStorageMarkdown();
   i.setState({ submitted: true });
 
   const stateSiteForm = i.state.siteForm;

--- a/src/shared/components/home/tagline-form.tsx
+++ b/src/shared/components/home/tagline-form.tsx
@@ -7,10 +7,7 @@ import {
   EditTagline,
 } from "lemmy-js-client";
 import { I18NextService } from "../../services";
-import {
-  MarkdownTextArea,
-  removeLocalStorageMarkdown,
-} from "../common/markdown-textarea";
+import { MarkdownTextArea } from "../common/markdown-textarea";
 import { tippyMixin } from "../mixins/tippy-mixin";
 import { Prompt } from "inferno-router";
 
@@ -112,7 +109,6 @@ export class TaglineForm extends Component<TaglineFormProps, TaglineFormState> {
     event: InfernoMouseEvent<HTMLButtonElement>,
   ) {
     event.preventDefault();
-    removeLocalStorageMarkdown();
 
     const content = i.state.content ?? "";
 

--- a/src/shared/components/multi-community/multi-community.tsx
+++ b/src/shared/components/multi-community/multi-community.tsx
@@ -98,6 +98,7 @@ import { MultiCommunityLink } from "./multi-community-link";
 import { PostListingModeDropdown } from "@components/common/post-listing-mode-dropdown";
 import { MultiCommunityEntryList } from "./multi-community-entry-form";
 import { FilterChipCheckbox } from "@components/common/filter-chip-checkbox";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 type MultiCommunityData = RouteDataResponse<{
   multiCommunityRes: GetMultiCommunityResponse;
@@ -892,6 +893,7 @@ function purgeItem(i: MultiCommunity, purgeRes: RequestState<SuccessResponse>) {
 function findAndUpdatePost(i: MultiCommunity, res: RequestState<PostResponse>) {
   i.setState(s => {
     if (s.postsRes.state === "success" && res.state === "success") {
+      removeLocalStorageMarkdown();
       s.postsRes.data.items = editPost(
         res.data.post_view,
         s.postsRes.data.items,

--- a/src/shared/components/person/notifications.tsx
+++ b/src/shared/components/person/notifications.tsx
@@ -87,6 +87,7 @@ import {
   FilterOption,
 } from "@components/common/filter-chip-dropdown";
 import { FilterChipCheckbox } from "@components/common/filter-chip-checkbox";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 const messageTypeOptions: FilterOption<NotificationTypeFilter>[] = [
   { value: "all", i18n: "all" },
@@ -717,6 +718,7 @@ async function handleCreateComment(i: Notifications, form: CreateComment) {
   });
 
   if (res.state === "success") {
+    removeLocalStorageMarkdown();
     toast(I18NextService.i18n.t("reply_sent"));
     // The reply just disappears. Only replies to private messages appear in the notifs.
   }

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -1361,6 +1361,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
 
   findAndUpdateComment(res: RequestState<CommentResponse>) {
     if (res.state === "success") {
+      removeLocalStorageMarkdown();
       this.editCombinedCurrent(
         commentViewToPersonContentCombinedView(res.data.comment_view),
       );
@@ -1370,6 +1371,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
   createAndUpdateComments(res: RequestState<CommentResponse>) {
     this.setState(s => {
       if (s.personContentRes.state === "success" && res.state === "success") {
+        removeLocalStorageMarkdown();
         s.personContentRes.data.items.unshift(
           commentViewToPersonContentCombinedView(res.data.comment_view),
         );

--- a/src/shared/components/person/profile.tsx
+++ b/src/shared/components/person/profile.tsx
@@ -120,6 +120,7 @@ import {
   FilterChipDropdown,
   FilterOption,
 } from "@components/common/filter-chip-dropdown";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 type ProfileData = RouteDataResponse<{
   personRes: GetPersonDetailsResponse;
@@ -1379,6 +1380,7 @@ export class Profile extends Component<ProfileRouteProps, ProfileState> {
 
   findAndUpdatePost(res: RequestState<PostResponse>) {
     if (res.state === "success") {
+      removeLocalStorageMarkdown();
       this.editCombinedCurrent(
         postViewToPersonContentCombinedView(res.data.post_view),
       );

--- a/src/shared/components/person/registration-applications.tsx
+++ b/src/shared/components/person/registration-applications.tsx
@@ -44,6 +44,7 @@ import {
   RegistrationState,
   RegistrationStateDropdown,
 } from "@components/common/registration-state-dropdown";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 type RegistrationApplicationsData = RouteDataResponse<{
   listRegistrationApplicationsResponse: PagedResponse<RegistrationApplicationView>;
@@ -313,6 +314,7 @@ async function handleApproveApplication(
 
   i.setState(s => {
     if (s.appsRes.state === "success" && res.state === "success") {
+      removeLocalStorageMarkdown();
       s.appsRes.data.items = editRegistrationApplication(
         res.data.registration_application,
         s.appsRes.data.items,

--- a/src/shared/components/person/settings.tsx
+++ b/src/shared/components/person/settings.tsx
@@ -1880,7 +1880,6 @@ async function handleSaveSettingsSubmit(
   event: FormEvent<HTMLFormElement>,
 ) {
   event.preventDefault();
-  removeLocalStorageMarkdown();
   i.setState({ saveRes: LOADING_REQUEST });
 
   const saveRes = await HttpService.client.saveUserSettings({
@@ -1888,6 +1887,7 @@ async function handleSaveSettingsSubmit(
   });
 
   if (saveRes.state === "success") {
+    removeLocalStorageMarkdown();
     const [siteRes, userRes] = await Promise.all([
       HttpService.client.getSite(),
       HttpService.client.getMyUser(),

--- a/src/shared/components/post/create-post.tsx
+++ b/src/shared/components/post/create-post.tsx
@@ -48,6 +48,7 @@ import { isBrowser } from "@utils/browser";
 import { NoOptionI18nKeys } from "i18next";
 import { CommunitySidebar } from "@components/community/community-sidebar";
 import { Icon } from "@components/common/icon";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 export interface CreatePostProps {
   communityId?: number;
@@ -474,6 +475,7 @@ async function handlePostCreate(
   if (res.state === "success") {
     const postId = res.data.post_view.post.id;
     bypassNavWarning();
+    removeLocalStorageMarkdown();
     i.props.history.replace(`/post/${postId}`);
   } else if (res.state === "failed") {
     toast(I18NextService.i18n.t(res.err.name as NoOptionI18nKeys), "danger");

--- a/src/shared/components/post/post-form.tsx
+++ b/src/shared/components/post/post-form.tsx
@@ -58,10 +58,7 @@ import {
 import { toast } from "@utils/app";
 import { Icon, Spinner } from "../common/icon";
 import { LanguageSelect } from "../common/language-select";
-import {
-  MarkdownTextArea,
-  removeLocalStorageMarkdown,
-} from "../common/markdown-textarea";
+import { MarkdownTextArea } from "../common/markdown-textarea";
 import { PostListings } from "./post-listings";
 import { isBrowser } from "@utils/browser";
 import { isMagnetLink, extractMagnetLinkDownloadName } from "@utils/media";
@@ -801,7 +798,6 @@ function updateUrl(i: PostForm, update: () => void) {
 
 function handlePostSubmit(i: PostForm, event: FormEvent<HTMLFormElement>) {
   event.preventDefault();
-  removeLocalStorageMarkdown();
 
   const pForm = i.state.form;
   const pv = i.props.post_view;

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -1051,6 +1051,7 @@ export class Post extends Component<PostRouteProps, PostState> {
   createAndUpdateComments(res: RequestState<CommentResponse>) {
     this.setState(s => {
       if (s.commentsRes.state === "success" && res.state === "success") {
+        removeLocalStorageMarkdown();
         // The comment must be inserted not at the very beginning of the list,
         // because the buildCommentsTree needs a correct path ordering.
         // It should be inserted right after its parent is found
@@ -1074,6 +1075,7 @@ export class Post extends Component<PostRouteProps, PostState> {
   findAndUpdateCommentEdit(res: RequestState<CommentResponse>) {
     this.setState(s => {
       if (s.commentsRes.state === "success" && res.state === "success") {
+        removeLocalStorageMarkdown();
         s.commentsRes.data.items = editCommentSlim(
           res.data.comment_view,
           s.commentsRes.data.items,
@@ -1271,6 +1273,7 @@ async function handleEditCommunityNotifs(form: EditCommunityNotifications) {
 async function handleCreateToplevelComment(i: Post, form: CreateComment) {
   const res = await handleCreateComment(i, form);
   if (res.state === "success") {
+    removeLocalStorageMarkdown();
     i.setState({ lastCreatedCommentId: res.data.comment_view.comment.id });
   }
   return res;

--- a/src/shared/components/post/post.tsx
+++ b/src/shared/components/post/post.tsx
@@ -123,6 +123,7 @@ import { Link } from "inferno-router";
 import { Action } from "history";
 import { CommentSortDropdown } from "@components/common/sort-dropdown";
 import { CommentViewTypeDropdown } from "@components/common/comment-view-type-dropdown";
+import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
 
 const commentsShownInterval = 15;
 
@@ -1438,6 +1439,7 @@ async function handlePostEdit(i: Post, form: EditPost) {
 
   i.updatePost(res);
   if (res.state === "success") {
+    removeLocalStorageMarkdown();
     toast(I18NextService.i18n.t("edited_post"));
   }
   return res;


### PR DESCRIPTION
- This moves the markdown storage clearing out of the form submits, and into the top level page's success responses. IE It only clears them after a successful response.
- Fixes #4168