### PR TITLE
Stricter CSP without style-src unsafe-inline

### DIFF
--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -18,7 +18,7 @@ export function setDefaultCsp({
      connect-src *;
      img-src * data: blob:;
      script-src 'self' 'nonce-${res.locals.cspNonce}';
-     style-src 'self' 'unsafe-inline';
+     style-src 'self' 'nonce-${res.locals.cspNonce}';
      form-action 'self';
      base-uri 'self';
      frame-src *;

--- a/src/server/utils/create-ssr-html.tsx
+++ b/src/server/utils/create-ssr-html.tsx
@@ -129,7 +129,7 @@ export async function createSsrHtml(
     ${helmetTitle}
     ${helmetMeta}
   
-    <style>
+    <style nonce="${cspNonce}">
     #app[data-adult-consent] {
       filter: blur(10px);
       -webkit-filter: blur(10px);
@@ -153,8 +153,8 @@ export async function createSsrHtml(
   
     <!-- Web app manifest -->
     <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="apple-touch-icon" href=${appleTouchIcon} />
-    <link rel="apple-touch-startup-image" href=${appleTouchIcon} />
+    <link rel="apple-touch-icon" href="${appleTouchIcon}" />
+    <link rel="apple-touch-startup-image" href="${appleTouchIcon}" />
   
     <!-- Styles -->
     <link rel="stylesheet" type="text/css" href="${getStaticDir()}/styles/styles.css" />


### PR DESCRIPTION
Tested manually by changing `setDefaultCsp` to be called always, and disabling eruda (which tries to add inline styles and breaks the site). Works as expected, the blurred background with adult-consent also works.