### PR TITLE
Adding ability to filter community page by tag dropdown filter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "inferno-router": "^9.1.0",
     "inferno-server": "^9.1.0",
     "jwt-decode": "^4.0.0",
-    "lemmy-js-client": "1.0.0-tag-id.0",
+    "lemmy-js-client": "1.0.0-tag-id.1",
     "markdown-it": "^14.1.0",
     "markdown-it-bidi": "^0.2.0",
     "markdown-it-container": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "inferno-router": "^9.1.0",
     "inferno-server": "^9.1.0",
     "jwt-decode": "^4.0.0",
-    "lemmy-js-client": "1.0.0-modlog-child-count.1",
+    "lemmy-js-client": "1.0.0-tag-id.0",
     "markdown-it": "^14.1.0",
     "markdown-it-bidi": "^0.2.0",
     "markdown-it-container": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       lemmy-js-client:
-        specifier: 1.0.0-tag-id.0
-        version: 1.0.0-tag-id.0
+        specifier: 1.0.0-tag-id.1
+        version: 1.0.0-tag-id.1
       markdown-it:
         specifier: ^14.1.0
         version: 14.2.0
@@ -3410,8 +3410,8 @@ packages:
   leac@0.7.0:
     resolution: {integrity: sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==}
 
-  lemmy-js-client@1.0.0-tag-id.0:
-    resolution: {integrity: sha512-lGVc6Nku37BUhb+jnnBlu9/ISNhaxp1oNtPycJ0HvS8u6XrsinmyH2tlXmAW4tFPH36Wy/EMlXlpi7F60Iu3GQ==}
+  lemmy-js-client@1.0.0-tag-id.1:
+    resolution: {integrity: sha512-HVVb8DyR7DiYEMkar7Q3x85vphDXCckWOIuqSntUL/3jw/r6EWWzyDhSSw0SwrPecrmO6gw/Ji4EqhGMkyXXAQ==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -8766,7 +8766,7 @@ snapshots:
 
   leac@0.7.0: {}
 
-  lemmy-js-client@1.0.0-tag-id.0:
+  lemmy-js-client@1.0.0-tag-id.1:
     dependencies:
       '@tsoa/runtime': 6.6.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       lemmy-js-client:
-        specifier: 1.0.0-modlog-child-count.1
-        version: 1.0.0-modlog-child-count.1
+        specifier: 1.0.0-tag-id.0
+        version: 1.0.0-tag-id.0
       markdown-it:
         specifier: ^14.1.0
         version: 14.2.0
@@ -3410,8 +3410,8 @@ packages:
   leac@0.7.0:
     resolution: {integrity: sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==}
 
-  lemmy-js-client@1.0.0-modlog-child-count.1:
-    resolution: {integrity: sha512-yDjnKS0/erBITCVESbPicqZW7T1PbO+ZjcjI5fTFgG/QNiFwa3x81ZoU/21OJ5g/h38c9IY+txnvn03giW2fwg==}
+  lemmy-js-client@1.0.0-tag-id.0:
+    resolution: {integrity: sha512-lGVc6Nku37BUhb+jnnBlu9/ISNhaxp1oNtPycJ0HvS8u6XrsinmyH2tlXmAW4tFPH36Wy/EMlXlpi7F60Iu3GQ==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -8766,7 +8766,7 @@ snapshots:
 
   leac@0.7.0: {}
 
-  lemmy-js-client@1.0.0-modlog-child-count.1:
+  lemmy-js-client@1.0.0-tag-id.0:
     dependencies:
       '@tsoa/runtime': 6.6.0
     transitivePeerDependencies:

--- a/src/shared/components/common/community-tag-dropdown.tsx
+++ b/src/shared/components/common/community-tag-dropdown.tsx
@@ -1,0 +1,36 @@
+import { CommunityTag } from "lemmy-js-client";
+import { FilterChipDropdown, FilterOption } from "./filter-chip-dropdown";
+import { communityTagName } from "@components/community/community-tag";
+
+type CommunityTagDropdownProps = {
+  tags: CommunityTag[];
+  currentOption: string;
+  onSelect: (id: string) => void;
+  className?: string;
+};
+/**
+ * Since the FilterChipDropdown must use strings, this means that the currentOption is the communityId as a string, and a "0" represents an "all" or clearing the filter.
+ **/
+export function CommunityTagDropdown({
+  tags,
+  currentOption,
+  onSelect,
+  className,
+}: CommunityTagDropdownProps) {
+  const options: FilterOption<string>[] = [{ value: "0", i18n: "all" }];
+  options.push(
+    ...tags.map(t => {
+      return { value: t.id.toString(), noI18n: communityTagName(t) };
+    }),
+  );
+
+  return (
+    <FilterChipDropdown
+      label={"tags"}
+      allOptions={options}
+      currentOption={options.find(t => t.value === currentOption)}
+      onSelect={onSelect}
+      className={className}
+    />
+  );
+}

--- a/src/shared/components/community/community.tsx
+++ b/src/shared/components/community/community.tsx
@@ -87,6 +87,7 @@ import {
   CommentId,
   PostId,
   ModEditPost,
+  CommunityTagId,
 } from "lemmy-js-client";
 import { relTags } from "@utils/config";
 import { PostOrCommentType, InitialFetchRequest } from "@utils/types";
@@ -135,6 +136,7 @@ import {
   FilterChipCheckbox,
 } from "@components/common/filter-chip-checkbox";
 import { removeLocalStorageMarkdown } from "@components/common/markdown-textarea";
+import { CommunityTagDropdown } from "@components/common/community-tag-dropdown";
 
 type CommunityData = RouteDataResponse<{
   communityRes: GetCommunityResponse;
@@ -166,6 +168,7 @@ interface CommunityProps {
   postOrCommentType: PostOrCommentType;
   sort: PostSortType | CommentSortType;
   time: Interval;
+  tagId?: CommunityTagId;
   cursor?: PaginationCursor;
   showHidden?: boolean;
   showRead?: boolean;
@@ -187,6 +190,7 @@ export function getCommunityQueryParams(
   return getQueryParams<CommunityProps, Fallbacks>(
     {
       postOrCommentType: getPostOrCommentTypeFromQuery,
+      tagId: getTagIdFromQuery,
       cursor: (cursor?: string) => cursor,
       sort: getSortTypeFromQuery,
       time: intervalFromQuery,
@@ -207,6 +211,10 @@ export function getCommunityQueryParams(
 
 function getPostOrCommentTypeFromQuery(type?: string): PostOrCommentType {
   return type ? (type as PostOrCommentType) : "post";
+}
+
+function getTagIdFromQuery(tag?: string): CommunityTagId | undefined {
+  return tag ? Number(tag) : undefined;
 }
 
 function getSortTypeFromQuery(
@@ -324,7 +332,15 @@ export class Community extends Component<CommunityRouteProps, State> {
 
   static fetchInitialData = async ({
     headers,
-    query: { postOrCommentType, cursor, sort, time, showHidden, showRead },
+    query: {
+      postOrCommentType,
+      cursor,
+      sort,
+      time,
+      showHidden,
+      showRead,
+      tagId,
+    },
     match: { params: props },
   }: InitialFetchRequest<
     CommunityPathProps,
@@ -352,6 +368,7 @@ export class Community extends Component<CommunityRouteProps, State> {
         type_: "all",
         show_hidden: showHidden,
         show_read: showRead,
+        tag_id: tagId,
         page_cursor: cursor,
       };
 
@@ -386,6 +403,7 @@ export class Community extends Component<CommunityRouteProps, State> {
   updateUrl(props: Partial<CommunityProps>) {
     const {
       postOrCommentType,
+      tagId,
       cursor,
       sort,
       showHidden,
@@ -405,6 +423,7 @@ export class Community extends Component<CommunityRouteProps, State> {
       sort,
       showHidden: showHidden?.toString(),
       showRead: showRead?.toString(),
+      tagId: tagId?.toString(),
       time: intervalToQuery(time),
     };
 
@@ -414,8 +433,15 @@ export class Community extends Component<CommunityRouteProps, State> {
   fetchDataToken?: symbol;
   async fetchData(props: CommunityRouteProps) {
     const token = (this.fetchDataToken = Symbol());
-    const { postOrCommentType, cursor, sort, time, showHidden, showRead } =
-      props;
+    const {
+      postOrCommentType,
+      cursor,
+      sort,
+      time,
+      showHidden,
+      showRead,
+      tagId,
+    } = props;
     const name = decodeURIComponent(props.match.params.name);
 
     if (postOrCommentType === "post") {
@@ -428,6 +454,7 @@ export class Community extends Component<CommunityRouteProps, State> {
         community_name: name,
         show_hidden: showHidden,
         show_read: showRead,
+        tag_id: tagId,
       });
       if (token === this.fetchDataToken) {
         this.setState({ postsRes });
@@ -762,7 +789,8 @@ export class Community extends Component<CommunityRouteProps, State> {
     const res =
       this.state.communityRes.state === "success" &&
       this.state.communityRes.data;
-    const { postOrCommentType, sort, time, showHidden, showRead } = this.props;
+    const { postOrCommentType, sort, time, showHidden, showRead, tagId } =
+      this.props;
     const communityRss = res
       ? communityRSSUrl(res.community_view.community, sort)
       : undefined;
@@ -770,6 +798,7 @@ export class Community extends Component<CommunityRouteProps, State> {
 
     const myUserInfo = this.isoData.myUserInfo;
     const hideTimeSelect = sort === "new" || sort === "old";
+    const tags = res && res.community_view.tags;
 
     return (
       <>
@@ -805,6 +834,15 @@ export class Community extends Component<CommunityRouteProps, State> {
                   showLabel
                 />
               </div>
+              {tags && tags.length > 0 && (
+                <div className="col">
+                  <CommunityTagDropdown
+                    tags={tags}
+                    currentOption={tagId?.toString() ?? "0"}
+                    onSelect={val => handleCommunityTagFilterChange(this, val)}
+                  />
+                </div>
+              )}
               {!hideTimeSelect && (
                 <div className="col">
                   <TimeIntervalFilter
@@ -928,6 +966,13 @@ function handlePostOrCommentTypeChange(
   postOrCommentType: PostOrCommentType,
 ) {
   i.updateUrl({ postOrCommentType, cursor: undefined });
+}
+
+function handleCommunityTagFilterChange(i: Community, tag: string) {
+  // A zero is an "All" / undefined
+  const tagId = tag === "0" ? undefined : Number(tag);
+
+  i.updateUrl({ tagId, cursor: undefined });
 }
 
 async function handlePostListingModeChange(


### PR DESCRIPTION
- Fixes #4120 
- Dependent on #4215 due to api changes.

Shows a working tag filter (two separate ones), as well as a page refresh after a tag has been selected.


https://github.com/user-attachments/assets/aada019c-7bbf-48d4-a08e-767fdb64309c

