### PR TITLE
Adding stacked mobile tables

### DIFF
--- a/src/shared/components/common/media-uploads.tsx
+++ b/src/shared/components/common/media-uploads.tsx
@@ -13,6 +13,7 @@ import { PictrsImage } from "./pictrs-image";
 import { httpBackendUrl } from "@utils/env";
 import { toast } from "@utils/app";
 import { ResponsiveTableRowHeader, TableHr } from "./tables";
+import classNames from "classnames";
 
 interface Props {
   uploads: PagedResponse<LocalImageView>;
@@ -26,6 +27,7 @@ export class MediaUploads extends Component<Props, never> {
     const images = this.props.uploads.items;
 
     const cols = "col-6 col-md-3";
+    const imageCols = "col-12 col-md-3";
 
     return (
       <div className="media-uploads">
@@ -62,13 +64,15 @@ export class MediaUploads extends Component<Props, never> {
               <div className={cols}>
                 <MomentTime published={i.local_image.published_at} />
               </div>
-              <div className={cols}>
+              <div className={imageCols}>
                 <PictrsImage
                   src={buildImageUrl(i.local_image.pictrs_alias)}
                   type="large_thumbnail"
                 />
               </div>
-              <div className={cols}>{this.deleteImageBtn(i.local_image)}</div>
+              <div className={classNames(imageCols, "my-2 my-md-0")}>
+                {this.deleteImageBtn(i.local_image)}
+              </div>
               <hr />
             </div>
           </>
@@ -79,12 +83,14 @@ export class MediaUploads extends Component<Props, never> {
 
   deleteImageBtn(image: LocalImage) {
     return (
-      <button
-        onClick={() => this.handleDeleteImage(image)}
-        className="btn btn-danger"
-      >
-        {I18NextService.i18n.t("delete")}
-      </button>
+      <div className="d-grid gap-2 d-md-block">
+        <button
+          onClick={() => this.handleDeleteImage(image)}
+          className="btn btn-danger"
+        >
+          {I18NextService.i18n.t("delete")}
+        </button>
+      </div>
     );
   }
 

--- a/src/shared/components/common/media-uploads.tsx
+++ b/src/shared/components/common/media-uploads.tsx
@@ -12,7 +12,7 @@ import { MomentTime } from "./moment-time";
 import { PictrsImage } from "./pictrs-image";
 import { httpBackendUrl } from "@utils/env";
 import { toast } from "@utils/app";
-import { TableHr } from "./tables";
+import { ResponsiveTableRowHeader, TableHr } from "./tables";
 
 interface Props {
   uploads: PagedResponse<LocalImageView>;
@@ -29,30 +29,36 @@ export class MediaUploads extends Component<Props, never> {
 
     return (
       <div className="media-uploads">
-        <div className="row">
-          {this.props.showUploader && (
+        <div className="d-none d-md-block">
+          <div className="row">
+            {this.props.showUploader && (
+              <div className={`${cols} fw-bold`}>
+                {I18NextService.i18n.t("uploader")}
+              </div>
+            )}
             <div className={`${cols} fw-bold`}>
-              {I18NextService.i18n.t("uploader")}
+              {I18NextService.i18n.t("time")}
             </div>
-          )}
-          <div className={`${cols} fw-bold`}>
-            {I18NextService.i18n.t("time")}
           </div>
+          <TableHr />
         </div>
-        <TableHr />
         {images.map(i => (
           <>
             <div className="row" key={i.local_image.pictrs_alias}>
               {this.props.showUploader && (
-                <div className={cols}>
-                  <PersonListing
-                    person={i.person}
-                    banned={false}
-                    myUserInfo={this.props.myUserInfo}
-                    muted={false}
-                  />
-                </div>
+                <>
+                  <ResponsiveTableRowHeader title={"uploader"} />
+                  <div className={cols}>
+                    <PersonListing
+                      person={i.person}
+                      banned={false}
+                      myUserInfo={this.props.myUserInfo}
+                      muted={false}
+                    />
+                  </div>
+                </>
               )}
+              <ResponsiveTableRowHeader title={"time"} />
               <div className={cols}>
                 <MomentTime published={i.local_image.published_at} />
               </div>

--- a/src/shared/components/common/tables.tsx
+++ b/src/shared/components/common/tables.tsx
@@ -1,1 +1,18 @@
+import { I18NextService } from "@services/I18NextService";
+import { NoOptionI18nKeys } from "i18next";
+
 export const TableHr = () => <hr className="border border-secondary" />;
+
+type ResponsiveTableRowHeaderProps = {
+  title: NoOptionI18nKeys;
+};
+
+export function ResponsiveTableRowHeader({
+  title,
+}: ResponsiveTableRowHeaderProps) {
+  return (
+    <div className="d-md-none col-6">
+      <div className="fw-bold">{I18NextService.i18n.t(title)}</div>
+    </div>
+  );
+}

--- a/src/shared/components/community/communities.tsx
+++ b/src/shared/components/community/communities.tsx
@@ -43,7 +43,7 @@ import { RouteComponentProps, RouterContext } from "inferno-router";
 import { scrollMixin } from "../mixins/scroll-mixin";
 import { isBrowser } from "@utils/browser";
 import { PaginatorCursor } from "@components/common/paginator-cursor";
-import { TableHr } from "@components/common/tables";
+import { ResponsiveTableRowHeader, TableHr } from "@components/common/tables";
 import { CreateCommunityButton } from "@components/common/content-actions/create-item-buttons";
 import { ListingTypeDropdown } from "@components/common/listing-type-dropdown";
 
@@ -139,7 +139,7 @@ export class Communities extends Component<
   }
 
   renderListingsTable(): InfernoNode | void {
-    const nameCols = "col-12 col-md-7";
+    const nameCols = "col-6 col-md-7";
     const countCols = "col-6 col-md-1";
 
     switch (this.state.listCommunitiesResponse.state) {
@@ -152,28 +152,31 @@ export class Communities extends Component<
       case "success": {
         return (
           <div id="community_table">
-            <div className="row">
-              <div className={`${nameCols} fw-bold`}>
-                {I18NextService.i18n.t("name")}
+            <div className="d-none d-md-block">
+              <div className="row">
+                <div className={`${nameCols} fw-bold`}>
+                  {I18NextService.i18n.t("name")}
+                </div>
+                <div className={`${countCols} fw-bold`}>
+                  {I18NextService.i18n.t("community_visibility")}
+                </div>
+                <div className={`${countCols} fw-bold`}>
+                  {I18NextService.i18n.t("users")} /{" "}
+                  {I18NextService.i18n.t("month")}
+                </div>
+                <div className={`${countCols} fw-bold`}>
+                  {I18NextService.i18n.t("posts")}
+                </div>
+                <div className={`${countCols} fw-bold`}>
+                  {I18NextService.i18n.t("comments")}
+                </div>
               </div>
-              <div className={`${countCols} fw-bold`}>
-                {I18NextService.i18n.t("community_visibility")}
-              </div>
-              <div className={`${countCols} fw-bold`}>
-                {I18NextService.i18n.t("users")} /{" "}
-                {I18NextService.i18n.t("month")}
-              </div>
-              <div className={`${countCols} fw-bold`}>
-                {I18NextService.i18n.t("posts")}
-              </div>
-              <div className={`${countCols} fw-bold`}>
-                {I18NextService.i18n.t("comments")}
-              </div>
+              <TableHr />
             </div>
-            <TableHr />
             {this.state.listCommunitiesResponse.data.items.map(cv => (
               <>
                 <div className="row">
+                  <ResponsiveTableRowHeader title={"name"} />
                   <div className={nameCols}>
                     <CommunityLink
                       community={cv.community}
@@ -181,15 +184,19 @@ export class Communities extends Component<
                       muted={false}
                     />
                   </div>
+                  <ResponsiveTableRowHeader title={"community_visibility"} />
                   <div className={countCols}>
                     {I18NextService.i18n.t(
                       `community_visibility_${cv.community.visibility}`,
                     )}
                   </div>
+                  <ResponsiveTableRowHeader title={"users"} />
                   <div className={countCols}>
                     {numToSI(cv.community.users_active_month)}
                   </div>
+                  <ResponsiveTableRowHeader title={"posts"} />
                   <div className={countCols}>{numToSI(cv.community.posts)}</div>
+                  <ResponsiveTableRowHeader title={"comments"} />
                   <div className={countCols}>
                     {numToSI(cv.community.comments)}
                   </div>

--- a/src/shared/components/community/community-settings.tsx
+++ b/src/shared/components/community/community-settings.tsx
@@ -59,7 +59,7 @@ import classNames from "classnames";
 import { HtmlTags } from "@components/common/html-tags";
 import Tabs from "@components/common/tabs";
 import { CommunityForm } from "./community-form";
-import { TableHr } from "@components/common/tables";
+import { ResponsiveTableRowHeader, TableHr } from "@components/common/tables";
 import { PersonListing } from "@components/person/person-listing";
 import { MomentTime } from "@components/common/moment-time";
 import ConfirmationModal from "@components/common/modal/confirmation-modal";
@@ -358,8 +358,8 @@ export class CommunitySettings extends Component<RouteProps, State> {
 
     const myUserInfo = this.isoData.myUserInfo;
 
-    const nameCols = "col-12 col-md-6";
-    const dataCols = "col-4 col-md-2";
+    const nameCols = "col-6 col-md-6";
+    const dataCols = "col-6 col-md-2";
 
     return (
       <>
@@ -367,24 +367,27 @@ export class CommunitySettings extends Component<RouteProps, State> {
           {capitalizeFirstLetter(I18NextService.i18n.t("mods"))}
         </h1>
         <div id="mods-table">
-          <div className="row">
-            <div className={`${nameCols} fw-bold`}>
-              {I18NextService.i18n.t("username")}
+          <div className="d-none d-md-block">
+            <div className="row">
+              <div className={`${nameCols} fw-bold`}>
+                {I18NextService.i18n.t("username")}
+              </div>
+              <div className={`${dataCols} fw-bold`}>
+                {I18NextService.i18n.t("registered_date_title")}
+              </div>
+              <div className={`${dataCols} fw-bold`}>
+                {I18NextService.i18n.t("posts")}
+              </div>
+              <div className={`${dataCols} fw-bold`}>
+                {I18NextService.i18n.t("comments")}
+              </div>
             </div>
-            <div className={`${dataCols} fw-bold`}>
-              {I18NextService.i18n.t("registered_date_title")}
-            </div>
-            <div className={`${dataCols} fw-bold`}>
-              {I18NextService.i18n.t("posts")}
-            </div>
-            <div className={`${dataCols} fw-bold`}>
-              {I18NextService.i18n.t("comments")}
-            </div>
+            <TableHr />
           </div>
-          <TableHr />
           {res &&
             res.moderators.map(m => (
               <div className="row" key={m.moderator.id}>
+                <ResponsiveTableRowHeader title={"username"} />
                 <div className={nameCols}>
                   <PersonListing
                     person={m.moderator}
@@ -485,10 +488,13 @@ export class CommunitySettings extends Component<RouteProps, State> {
                     </>
                   )}
                 </div>
+                <ResponsiveTableRowHeader title={"registered_date_title"} />
                 <div className={dataCols}>
                   <MomentTime published={m.moderator.published_at} />
                 </div>
+                <ResponsiveTableRowHeader title={"posts"} />
                 <div className={dataCols}>{m.moderator.post_count}</div>
+                <ResponsiveTableRowHeader title={"comments"} />
                 <div className={dataCols}>{m.moderator.comment_count}</div>
               </div>
             ))}

--- a/src/shared/components/home/admin-settings.tsx
+++ b/src/shared/components/home/admin-settings.tsx
@@ -59,7 +59,7 @@ import { PaginatorCursor } from "@components/common/paginator-cursor";
 import { fetchLimit } from "@utils/config";
 import { UserBadges } from "@components/common/user-badges";
 import { MomentTime } from "@components/common/moment-time";
-import { TableHr } from "@components/common/tables";
+import { ResponsiveTableRowHeader, TableHr } from "@components/common/tables";
 import { NoOptionI18nKeys } from "i18next";
 import { InstanceList } from "./instances";
 import { InstanceAllowForm } from "./instance-allow-form";
@@ -462,8 +462,8 @@ export class AdminSettings extends Component<
   admins() {
     const admins = this.isoData.siteRes.admins;
 
-    const nameCols = "col-12 col-md-6";
-    const dataCols = "col-4 col-md-2";
+    const nameCols = "col-6 col-md-6";
+    const dataCols = "col-6 col-md-2";
 
     return (
       <>
@@ -471,24 +471,27 @@ export class AdminSettings extends Component<
           {capitalizeFirstLetter(I18NextService.i18n.t("admins"))}
         </h1>
         <div id="admins-table">
-          <div className="row">
-            <div className={`${nameCols} fw-bold`}>
-              {I18NextService.i18n.t("username")}
+          <div className="d-none d-md-block">
+            <div className="row">
+              <div className={`${nameCols} fw-bold`}>
+                {I18NextService.i18n.t("username")}
+              </div>
+              <div className={`${dataCols} fw-bold`}>
+                {I18NextService.i18n.t("registered_date_title")}
+              </div>
+              <div className={`${dataCols} fw-bold`}>
+                {I18NextService.i18n.t("posts")}
+              </div>
+              <div className={`${dataCols} fw-bold`}>
+                {I18NextService.i18n.t("comments")}
+              </div>
             </div>
-            <div className={`${dataCols} fw-bold`}>
-              {I18NextService.i18n.t("registered_date_title")}
-            </div>
-            <div className={`${dataCols} fw-bold`}>
-              {I18NextService.i18n.t("posts")}
-            </div>
-            <div className={`${dataCols} fw-bold`}>
-              {I18NextService.i18n.t("comments")}
-            </div>
+            <TableHr />
           </div>
-          <TableHr />
           {admins.map(admin => (
             <>
               <div className="row" key={admin.person.id}>
+                <ResponsiveTableRowHeader title={"username"} />
                 <div className={nameCols}>
                   <PersonListing
                     person={admin.person}
@@ -504,13 +507,16 @@ export class AdminSettings extends Component<
                     creator={admin.person}
                   />
                 </div>
+                <ResponsiveTableRowHeader title={"registered_date_title"} />
                 <div className={dataCols}>
                   <MomentTime published={admin.person.published_at} />
                 </div>
+                <ResponsiveTableRowHeader title={"posts"} />
                 <div className={dataCols}>{admin.person.post_count}</div>
+                <ResponsiveTableRowHeader title={"comments"} />
                 <div className={dataCols}>{admin.person.comment_count}</div>
-                <hr />
               </div>
+              <hr key={admin.person.id + "hr"} />
             </>
           ))}
         </div>
@@ -567,32 +573,35 @@ export class AdminSettings extends Component<
         );
       case "success": {
         const local_users = this.state.usersRes.data.items;
-        const nameCols = "col-12 col-md-3";
-        const dataCols = "col-4 col-md-2";
+        const nameCols = "col-6 col-md-3";
+        const dataCols = "col-6 col-md-2";
 
         return (
           <div id="users-table">
-            <div className="row">
-              <div className={`${nameCols} fw-bold`}>
-                {I18NextService.i18n.t("username")}
+            <div className="d-none d-md-block">
+              <div className="row">
+                <div className={`${nameCols} fw-bold`}>
+                  {I18NextService.i18n.t("username")}
+                </div>
+                <div className={`${nameCols} fw-bold`}>
+                  {I18NextService.i18n.t("email")}
+                </div>
+                <div className={`${dataCols} fw-bold`}>
+                  {I18NextService.i18n.t("registered_date_title")}
+                </div>
+                <div className={`${dataCols} fw-bold`}>
+                  {I18NextService.i18n.t("posts")}
+                </div>
+                <div className={`${dataCols} fw-bold`}>
+                  {I18NextService.i18n.t("comments")}
+                </div>
               </div>
-              <div className={`${nameCols} fw-bold`}>
-                {I18NextService.i18n.t("email")}
-              </div>
-              <div className={`${dataCols} fw-bold`}>
-                {I18NextService.i18n.t("registered_date_title")}
-              </div>
-              <div className={`${dataCols} fw-bold`}>
-                {I18NextService.i18n.t("posts")}
-              </div>
-              <div className={`${dataCols} fw-bold`}>
-                {I18NextService.i18n.t("comments")}
-              </div>
+              <TableHr />
             </div>
-            <TableHr />
             {local_users.map(local_user => (
               <>
                 <div className="row" key={local_user.person.id}>
+                  <ResponsiveTableRowHeader title={"username"} />
                   <div className={nameCols}>
                     <PersonListing
                       person={local_user.person}
@@ -608,16 +617,22 @@ export class AdminSettings extends Component<
                       creator={local_user.person}
                     />
                   </div>
-                  <div className={nameCols}>{local_user.local_user.email}</div>
+                  <ResponsiveTableRowHeader title={"email"} />
+                  <div className={classNames(nameCols, "text-break")}>
+                    {local_user.local_user.email}
+                  </div>
+                  <ResponsiveTableRowHeader title={"registered_date_title"} />
                   <div className={dataCols}>
                     <MomentTime published={local_user.person.published_at} />
                   </div>
+                  <ResponsiveTableRowHeader title={"posts"} />
                   <div className={dataCols}>{local_user.person.post_count}</div>
+                  <ResponsiveTableRowHeader title={"comments"} />
                   <div className={dataCols}>
                     {local_user.person.comment_count}
                   </div>
-                  <hr />
                 </div>
+                <hr key={local_user.person.id + "hr"} />
               </>
             ))}
             <PaginatorCursor

--- a/src/shared/components/home/instances.tsx
+++ b/src/shared/components/home/instances.tsx
@@ -32,10 +32,11 @@ import {
 import { scrollMixin } from "../mixins/scroll-mixin";
 import { isBrowser } from "@utils/browser";
 import { formatRelativeDate, isWeekOld } from "@utils/date";
-import { TableHr } from "@components/common/tables";
+import { ResponsiveTableRowHeader, TableHr } from "@components/common/tables";
 import { PaginatorCursor } from "@components/common/paginator-cursor";
 import { Action } from "history";
 import { InstancesKindDropdown } from "@components/common/instances-kind-dropdown";
+import classNames from "classnames";
 
 function getKindFromQuery(kind?: string): GetFederatedInstancesKind {
   return kind ? (kind as GetFederatedInstancesKind) : "all";
@@ -261,30 +262,33 @@ export function InstanceList({
   onRemove,
   showRemove,
 }: InstanceListProps) {
-  const nameCols = "col-12 col-md-6";
-  const otherCols = "col-4 col-md-2";
+  const nameCols = "col-6 col-md-6";
+  const otherCols = "col-6 col-md-2";
 
   return instances.length > 0 ? (
     <div id="instances-table">
-      <div className="row">
-        <div className={`${nameCols} fw-bold`}>
-          {I18NextService.i18n.t("name")}
+      <div className="d-none d-md-block">
+        <div className="row">
+          <div className={`${nameCols} fw-bold`}>
+            {I18NextService.i18n.t("name")}
+          </div>
+          <div className={`${otherCols} fw-bold`}>
+            {I18NextService.i18n.t("software")}
+          </div>
+          <div className={`${otherCols} fw-bold`}>
+            {I18NextService.i18n.t("version")}
+          </div>
+          <div className={`${otherCols} fw-bold`}>
+            {I18NextService.i18n.t("last_updated")}
+          </div>
         </div>
-        <div className={`${otherCols} fw-bold`}>
-          {I18NextService.i18n.t("software")}
-        </div>
-        <div className={`${otherCols} fw-bold`}>
-          {I18NextService.i18n.t("version")}
-        </div>
-        <div className={`${otherCols} fw-bold`}>
-          {I18NextService.i18n.t("last_updated")}
-        </div>
+        <TableHr />
       </div>
-      <TableHr />
       {instances.map(i => (
         <>
           <div key={i.instance.domain} className="row">
-            <div className={nameCols}>
+            <ResponsiveTableRowHeader title={"name"} />
+            <div className={classNames(nameCols, "text-break")}>
               {!i.blocked ? (
                 <a href={`https://${i.instance.domain}`} rel={relTags}>
                   {i.instance.domain}{" "}
@@ -301,8 +305,11 @@ export function InstanceList({
                 </button>
               )}
             </div>
+            <ResponsiveTableRowHeader title={"software"} />
             <div className={otherCols}>{i.instance.software}</div>
+            <ResponsiveTableRowHeader title={"version"} />
             <div className={otherCols}>{i.instance.version}</div>
+            <ResponsiveTableRowHeader title={"last_updated"} />
             <div className={otherCols}>
               {formatRelativeDate(
                 i.instance.updated_at ?? i.instance.published_at,
@@ -311,8 +318,8 @@ export function InstanceList({
                 new Date(i.instance.updated_at ?? i.instance.published_at),
               ) && " 💀"}
             </div>
-            <hr />
           </div>
+          <hr key={i.instance.domain + "hr"} />
         </>
       ))}
     </div>

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -57,7 +57,7 @@ import { IRoutePropsWithFetch } from "@utils/routes";
 import { isBrowser } from "@utils/browser";
 import { LoadingEllipses } from "./common/loading-ellipses";
 import { PaginatorCursor } from "./common/paginator-cursor";
-import { TableHr } from "./common/tables";
+import { ResponsiveTableRowHeader, TableHr } from "./common/tables";
 import { NoOptionI18nKeys } from "i18next";
 import { ModlogKindFilterDropdown } from "./common/modlog-kind-filter-dropdown";
 import { FilterChipSelect } from "./common/filter-chip-select";
@@ -65,7 +65,7 @@ import { FilterChipCheckbox } from "./common/filter-chip-checkbox";
 
 const TIME_COLS = "col-6 col-md-2";
 const MOD_COLS = "col-6 col-md-4";
-const ACTION_COLS = "col-12 col-md-6";
+const ACTION_COLS = "col-6 col-md-6";
 
 type ModlogData = RouteDataResponse<{
   res: PagedResponse<ModlogView>;
@@ -836,9 +836,11 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
       return (
         <>
           <div className="row">
+            <ResponsiveTableRowHeader title={"time"} />
             <div className={TIME_COLS}>
               <MomentTime published={published_at} />
             </div>
+            <ResponsiveTableRowHeader title={"mod"} />
             <div className={MOD_COLS}>
               {this.amAdminOrMod && moderator ? (
                 <PersonListing
@@ -851,6 +853,7 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
                 <div>{this.modOrAdminText(moderator)}</div>
               )}
             </div>
+            <ResponsiveTableRowHeader title={"action"} />
             <div className={ACTION_COLS}>{data}</div>
           </div>
           <hr />
@@ -1005,18 +1008,20 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
         return (
           <>
             <div id="modlog_table">
-              <div className="row">
-                <div className={`${TIME_COLS} fw-bold`}>
-                  {I18NextService.i18n.t("time")}
+              <div className="d-none d-md-block">
+                <div className="row">
+                  <div className={`${TIME_COLS} fw-bold`}>
+                    {I18NextService.i18n.t("time")}
+                  </div>
+                  <div className={`${MOD_COLS} fw-bold`}>
+                    {I18NextService.i18n.t("mod")}
+                  </div>
+                  <div className={`${ACTION_COLS} fw-bold`}>
+                    {I18NextService.i18n.t("action")}
+                  </div>
                 </div>
-                <div className={`${MOD_COLS} fw-bold`}>
-                  {I18NextService.i18n.t("mod")}
-                </div>
-                <div className={`${ACTION_COLS} fw-bold`}>
-                  {I18NextService.i18n.t("action")}
-                </div>
+                <TableHr />
               </div>
-              <TableHr />
               {this.combined}
             </div>
             <PaginatorCursor

--- a/src/shared/components/modlog.tsx
+++ b/src/shared/components/modlog.tsx
@@ -836,10 +836,8 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
       return (
         <>
           <div className="row">
-            <ResponsiveTableRowHeader title={"time"} />
-            <div className={TIME_COLS}>
-              <MomentTime published={published_at} />
-            </div>
+            <ResponsiveTableRowHeader title={"action"} />
+            <div className={ACTION_COLS}>{data}</div>
             <ResponsiveTableRowHeader title={"mod"} />
             <div className={MOD_COLS}>
               {this.amAdminOrMod && moderator ? (
@@ -853,8 +851,10 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
                 <div>{this.modOrAdminText(moderator)}</div>
               )}
             </div>
-            <ResponsiveTableRowHeader title={"action"} />
-            <div className={ACTION_COLS}>{data}</div>
+            <ResponsiveTableRowHeader title={"time"} />
+            <div className={TIME_COLS}>
+              <MomentTime published={published_at} />
+            </div>
           </div>
           <hr />
         </>
@@ -1010,14 +1010,14 @@ export class Modlog extends Component<ModlogRouteProps, ModlogState> {
             <div id="modlog_table">
               <div className="d-none d-md-block">
                 <div className="row">
-                  <div className={`${TIME_COLS} fw-bold`}>
-                    {I18NextService.i18n.t("time")}
+                  <div className={`${ACTION_COLS} fw-bold`}>
+                    {I18NextService.i18n.t("action")}
                   </div>
                   <div className={`${MOD_COLS} fw-bold`}>
                     {I18NextService.i18n.t("mod")}
                   </div>
-                  <div className={`${ACTION_COLS} fw-bold`}>
-                    {I18NextService.i18n.t("action")}
+                  <div className={`${TIME_COLS} fw-bold`}>
+                    {I18NextService.i18n.t("time")}
                   </div>
                 </div>
                 <TableHr />

--- a/src/shared/components/multi-community/multi-communities.tsx
+++ b/src/shared/components/multi-community/multi-communities.tsx
@@ -41,7 +41,7 @@ import { RouteComponentProps, RouterContext } from "inferno-router";
 import { scrollMixin } from "../mixins/scroll-mixin";
 import { isBrowser } from "@utils/browser";
 import { PaginatorCursor } from "@components/common/paginator-cursor";
-import { TableHr } from "@components/common/tables";
+import { ResponsiveTableRowHeader, TableHr } from "@components/common/tables";
 import { MultiCommunityLink } from "./multi-community-link";
 import { MultiCommunityListingTypeDropdown } from "@components/common/multi-community-listing-type-dropdown";
 import { CreateMultiCommunityButton } from "@components/common/content-actions/create-item-buttons";
@@ -136,9 +136,9 @@ export class MultiCommunities extends Component<RouteProps, State> {
   }
 
   renderListingsTable(): InfernoNode | void {
-    const nameCols = "col-12 col-md-9";
+    const nameCols = "col-6 col-md-9";
     // 3 of these: subscribers, communities, subscribe
-    const countCols = "col-4 col-md-1";
+    const countCols = "col-6 col-md-1";
 
     switch (this.state.listMultiCommunitiesRes.state) {
       case "loading":
@@ -150,30 +150,35 @@ export class MultiCommunities extends Component<RouteProps, State> {
       case "success": {
         return (
           <div id="community_table">
-            <div className="row">
-              <div className={`${nameCols} fw-bold`}>
-                {I18NextService.i18n.t("name")}
+            <div className="d-none d-md-block">
+              <div className="row">
+                <div className={`${nameCols} fw-bold`}>
+                  {I18NextService.i18n.t("name")}
+                </div>
+                <div className={`${countCols} fw-bold`}>
+                  {I18NextService.i18n.t("subscribers")}
+                </div>
+                <div className={`${countCols} fw-bold`}>
+                  {I18NextService.i18n.t("communities")}
+                </div>
               </div>
-              <div className={`${countCols} fw-bold`}>
-                {I18NextService.i18n.t("subscribers")}
-              </div>
-              <div className={`${countCols} fw-bold`}>
-                {I18NextService.i18n.t("communities")}
-              </div>
+              <TableHr />
             </div>
-            <TableHr />
             {this.state.listMultiCommunitiesRes.data.items.map(v => (
               <>
                 <div className="row">
+                  <ResponsiveTableRowHeader title={"name"} />
                   <div className={nameCols}>
                     <MultiCommunityLink
                       multiCommunity={v.multi}
                       myUserInfo={this.isoData.myUserInfo}
                     />
                   </div>
+                  <ResponsiveTableRowHeader title={"subscribers"} />
                   <div className={countCols}>
                     {numToSI(v.multi.subscribers)}
                   </div>
+                  <ResponsiveTableRowHeader title={"communities"} />
                   <div className={countCols}>
                     {numToSI(v.multi.communities)}
                   </div>


### PR DESCRIPTION
- Replaces the weird tables in favor of a "stacked" method, where column name and data each take half the screen.
- I tried some sticky header alternatives but they all looked ugly.
- Wide / tables above `md` stay the same.
- Fixes #4226

# Examples

## Communities

<img width="300" alt="Screenshot_2026-06-10-19-49-31-90_e4424258c8b8649f6e67d283a50a2cbc" src="https://github.com/user-attachments/assets/d85b8a36-224e-4fa7-95f6-339a8caf98ac" />

## Instances

<img width="300" alt="Screenshot_2026-06-10-19-49-44-01_e4424258c8b8649f6e67d283a50a2cbc" src="https://github.com/user-attachments/assets/751fc5af-06ff-4ce5-87f1-1cc8e66e1e0f" />

## Modlog

<img width="300"  alt="Screenshot_2026-06-10-19-50-01-48_e4424258c8b8649f6e67d283a50a2cbc" src="https://github.com/user-attachments/assets/71067015-fc18-4aac-af87-993c46f76ca6" />

