### PR TITLE
Fix for restoring scroll position (fixes #4225)

### DIFF
--- a/src/shared/components/mixins/scroll-mixin.ts
+++ b/src/shared/components/mixins/scroll-mixin.ts
@@ -2,17 +2,32 @@ import { isBrowser, nextUserAction, snapToTop } from "../../utils/browser";
 import { Component, InfernoNode } from "inferno";
 import { Location, History, Action } from "history";
 
-function restoreScrollPosition(props: {
-  location: Location;
-}): number | undefined {
+function restoreScrollPosition(props: { location: Location }) {
   const key: string = props.location.key;
-  const y = sessionStorage.getItem(`scrollPosition_${key}`);
+  const scrollPosition = sessionStorage.getItem(`scrollPosition_${key}`);
 
-  if (y !== null) {
-    window.scrollTo({ left: 0, top: Number(y), behavior: "instant" });
-    return Number(y);
+  if (scrollPosition !== null) {
+    const y = Number(scrollPosition);
+    window.scrollTo({ left: 0, top: y, behavior: "instant" });
+    if (y > 0) {
+      // Browsers restore the scroll position they stored for the history
+      // entry shortly after a traversal. This happens asynchronously and can
+      // override the position restored above, e.g. by jumping back to the top.
+      // Re-apply the position if that happens.
+      const onScroll = () => {
+        if (window.scrollY === 0) {
+          window.scrollTo({ left: 0, top: y, behavior: "instant" });
+          cleanup();
+        }
+      };
+      const cleanup = () => {
+        window.removeEventListener("scroll", onScroll);
+        window.clearTimeout(timeoutId);
+      };
+      const timeoutId = window.setTimeout(cleanup, 500);
+      window.addEventListener("scroll", onScroll);
+    }
   }
-  return undefined;
 }
 
 function saveScrollPosition(props: { location: Location }) {
@@ -119,27 +134,8 @@ export function scrollMixin<
     }
 
     restore() {
-      const target = restoreScrollPosition(this.props);
+      restoreScrollPosition(this.props);
       this.preventRestore();
-
-      if (target !== undefined && target > 0) {
-        // Browsers restore the scroll position they stored for the history
-        // entry shortly after a traversal. This happens asynchronously and can
-        // override the position restored above, e.g. by jumping back to the top.
-        // Re-apply the position if that happens.
-        const onScroll = () => {
-          if (window.scrollY === 0) {
-            window.scrollTo({ left: 0, top: target, behavior: "instant" });
-            cleanup();
-          }
-        };
-        const cleanup = () => {
-          window.removeEventListener("scroll", onScroll);
-          window.clearTimeout(timeoutId);
-        };
-        const timeoutId = window.setTimeout(cleanup, 500);
-        window.addEventListener("scroll", onScroll);
-      }
     }
 
     restoreIfLoaded() {

--- a/src/shared/components/mixins/scroll-mixin.ts
+++ b/src/shared/components/mixins/scroll-mixin.ts
@@ -2,13 +2,17 @@ import { isBrowser, nextUserAction, snapToTop } from "../../utils/browser";
 import { Component, InfernoNode } from "inferno";
 import { Location, History, Action } from "history";
 
-function restoreScrollPosition(props: { location: Location }) {
+function restoreScrollPosition(props: {
+  location: Location;
+}): number | undefined {
   const key: string = props.location.key;
   const y = sessionStorage.getItem(`scrollPosition_${key}`);
 
   if (y !== null) {
     window.scrollTo({ left: 0, top: Number(y), behavior: "instant" });
+    return Number(y);
   }
+  return undefined;
 }
 
 function saveScrollPosition(props: { location: Location }) {
@@ -115,8 +119,27 @@ export function scrollMixin<
     }
 
     restore() {
-      restoreScrollPosition(this.props);
+      const target = restoreScrollPosition(this.props);
       this.preventRestore();
+
+      if (target !== undefined && target > 0) {
+        // Browsers restore the scroll position they stored for the history
+        // entry shortly after a traversal. This happens asynchronously and can
+        // override the position restored above, e.g. by jumping back to the top.
+        // Re-apply the position if that happens.
+        const onScroll = () => {
+          if (window.scrollY === 0) {
+            window.scrollTo({ left: 0, top: target, behavior: "instant" });
+            cleanup();
+          }
+        };
+        const cleanup = () => {
+          window.removeEventListener("scroll", onScroll);
+          window.clearTimeout(timeoutId);
+        };
+        const timeoutId = window.setTimeout(cleanup, 500);
+        window.addEventListener("scroll", onScroll);
+      }
     }
 
     restoreIfLoaded() {


### PR DESCRIPTION
Used LLM to resolve the bug. This involved checking changes from Lemmy 0.19, and changes in InfernoJS, and adding extra logging. Apparently the problem is caused by a race condition due to restructuring of code. Now scroll position is again restored correctly.

Heres the LLM summary:
> Problem: Navigating back restores the scroll position momentarily, but the browser then resets the page to the top. Save/restore logic itself works — the value is stored and read correctly.
> 
> Root cause: On same-document back/forward navigation, browsers asynchronously reset scroll to the top after the page renders, even with history.scrollRestoration = "manual". This race fires ~90ms after the app's restore (which runs in componentDidUpdate once data loads), overriding it.
> 
> Fix (scroll-mixin.ts): restore() now re-applies the saved position if the browser resets it to top within 500ms, detected via a scroll event with scrollY === 0. The listener cleans up after itself or when re-applied, so it never fights the user.