### PR TITLE
Don't write spoiler text into meta description. (#3670)

### DIFF
--- a/src/shared/components/common/html-tags.tsx
+++ b/src/shared/components/common/html-tags.tsx
@@ -52,7 +52,14 @@ export class HtmlTags extends Component<HtmlTagsProps, never> {
               <meta
                 key={n}
                 name={n}
-                content={htmlToText(md.renderInline(desc))}
+                content={htmlToText(
+                  md.renderInline(
+                    desc.replace(
+                      /::: spoiler [^]*?:::/g,
+                      I18NextService.i18n.t("spoiler"),
+                    ),
+                  ),
+                )}
               />
             ),
         )}

--- a/src/shared/components/common/html-tags.tsx
+++ b/src/shared/components/common/html-tags.tsx
@@ -2,7 +2,7 @@ import { httpFrontendUrl } from "@utils/env";
 import { htmlToText } from "html-to-text";
 import { Component } from "inferno";
 import { Helmet } from "inferno-helmet";
-import { md } from "@utils/markdown";
+import { md, stripSpoilers } from "@utils/markdown";
 import { I18NextService } from "../../services";
 import { setIsoData } from "@utils/app";
 import { RouterContext } from "inferno-router";
@@ -54,10 +54,7 @@ export class HtmlTags extends Component<HtmlTagsProps, never> {
                 name={n}
                 content={htmlToText(
                   md.renderInline(
-                    desc.replace(
-                      /::: spoiler [^]*?:::/g,
-                      I18NextService.i18n.t("spoiler"),
-                    ),
+                    stripSpoilers(desc, I18NextService.i18n.t("spoiler")),
                   ),
                 )}
               />

--- a/src/shared/utils/markdown.ts
+++ b/src/shared/utils/markdown.ts
@@ -59,6 +59,11 @@ export function mdToHtmlInline(text: string) {
   return { __html: mdLimited.renderInline(text) };
 }
 
+/** Replace spoiler blocks with a placeholder to prevent leaking into meta tags. */
+export function stripSpoilers(text: string, replacement: string): string {
+  return text.replace(/::: spoiler [^]*?:::/g, replacement);
+}
+
 const spoilerConfig = {
   validate: (params: string) => {
     return params.trim().match(/^spoiler\s+(.*)$/);


### PR DESCRIPTION
Replaces spoiler content with the word "spoiler" in og:description and twitter:description meta tags.
<img width="1189" height="844" alt="screenshot-2026-08-04_20-03-51" src="https://github.com/user-attachments/assets/520051fb-4970-4d79-a59c-6d2e3bde58f5" />