### PR TITLE
Fix sidebar spacing and registration applications unread counter

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -314,14 +314,6 @@ hr {
   -ms-transform: scale(1.2);
 }
 
-/**
- * TODO: Fix this in markup rather than this overly specific selector:
- * https://getbootstrap.com/docs/5.3/components/buttons/#block-buttons
- */
-.btn.d-block + .btn.d-block {
-  margin-top: 0.5rem;
-}
-
 .mini-overlay {
   display: block;
   height: 1.5em;

--- a/src/shared/components/common/badges.tsx
+++ b/src/shared/components/common/badges.tsx
@@ -15,7 +15,7 @@ export function CommunityBadges({
   className,
 }: CommunityBadgesProps) {
   return (
-    <ul className={classNames("badges my-1 list-inline", className)}>
+    <div className={classNames("badges d-flex flex-wrap gap-1", className)}>
       <LocalSiteCommunityCommonBadges
         subject={community}
         lessBadges={lessBadges}
@@ -24,7 +24,7 @@ export function CommunityBadges({
         subject={community}
         lessBadges={lessBadges}
       />
-    </ul>
+    </div>
   );
 }
 
@@ -40,20 +40,20 @@ export function MultiCommunityBadges({
   className,
 }: MultiCommunityBadgesProps) {
   return (
-    <ul className={classNames("badges my-1 list-inline", className)}>
+    <div className={classNames("badges d-flex flex-wrap gap-1", className)}>
       <MultiCommunityCommunityCommonBadges
         subject={multiCommunity}
         lessBadges={lessBadges}
       />
       {!lessBadges && (
-        <li className="list-inline-item badge text-bg-light">
+        <span className="badge text-bg-light">
           {I18NextService.i18n.t("number_of_communities", {
             count: Number(multiCommunity.communities),
             formattedCount: numToSI(multiCommunity.communities),
           })}
-        </li>
+        </span>
       )}
-    </ul>
+    </div>
   );
 }
 
@@ -69,28 +69,28 @@ export function LocalSiteBadges({
   className,
 }: LocalSiteBadgesProps) {
   return (
-    <ul className={classNames("badges my-1 list-inline", className)}>
+    <div className={classNames("badges d-flex flex-wrap gap-1", className)}>
       <LocalSiteCommunityCommonBadges
         subject={localSite}
         lessBadges={lessBadges}
       />
       {!lessBadges && (
         <>
-          <li className="list-inline-item badge text-bg-light">
+          <span className="badge text-bg-light">
             {I18NextService.i18n.t("number_of_users", {
               count: Number(localSite.users),
               formattedCount: numToSI(localSite.users),
             })}
-          </li>
-          <li className="list-inline-item badge text-bg-light">
+          </span>
+          <span className="badge text-bg-light">
             {I18NextService.i18n.t("number_of_communities", {
               count: Number(localSite.communities),
               formattedCount: numToSI(localSite.communities),
             })}
-          </li>
+          </span>
         </>
       )}
-    </ul>
+    </div>
   );
 }
 
@@ -105,8 +105,8 @@ function LocalSiteCommunityCommonBadges({
   return (
     !lessBadges && (
       <>
-        <li
-          className="list-inline-item badge text-bg-light pointer"
+        <span
+          className="badge text-bg-light pointer"
           data-tippy-content={I18NextService.i18n.t(
             "active_users_in_the_last_day",
             {
@@ -120,9 +120,9 @@ function LocalSiteCommunityCommonBadges({
             formattedCount: numToSI(subject.users_active_day),
           })}{" "}
           / {I18NextService.i18n.t("day")}
-        </li>
-        <li
-          className="list-inline-item badge text-bg-light pointer"
+        </span>
+        <span
+          className="badge text-bg-light pointer"
           data-tippy-content={I18NextService.i18n.t(
             "active_users_in_the_last_week",
             {
@@ -136,9 +136,9 @@ function LocalSiteCommunityCommonBadges({
             formattedCount: numToSI(subject.users_active_week),
           })}{" "}
           / {I18NextService.i18n.t("week")}
-        </li>
-        <li
-          className="list-inline-item badge text-bg-light pointer"
+        </span>
+        <span
+          className="badge text-bg-light pointer"
           data-tippy-content={I18NextService.i18n.t(
             "active_users_in_the_last_month",
             {
@@ -152,9 +152,9 @@ function LocalSiteCommunityCommonBadges({
             formattedCount: numToSI(subject.users_active_month),
           })}{" "}
           / {I18NextService.i18n.t("month")}
-        </li>
-        <li
-          className="list-inline-item badge text-bg-light pointer"
+        </span>
+        <span
+          className="badge text-bg-light pointer"
           data-tippy-content={I18NextService.i18n.t(
             "active_users_in_the_last_six_months",
             {
@@ -172,19 +172,19 @@ function LocalSiteCommunityCommonBadges({
             count: 6,
             formattedCount: 6,
           })}
-        </li>
-        <li className="list-inline-item badge text-bg-light">
+        </span>
+        <span className="badge text-bg-light">
           {I18NextService.i18n.t("number_of_posts", {
             count: Number(subject.posts),
             formattedCount: numToSI(subject.posts),
           })}
-        </li>
-        <li className="list-inline-item badge text-bg-light">
+        </span>
+        <span className="badge text-bg-light">
           {I18NextService.i18n.t("number_of_comments", {
             count: Number(subject.comments),
             formattedCount: numToSI(subject.comments),
           })}
-        </li>
+        </span>
       </>
     )
   );
@@ -201,18 +201,18 @@ function MultiCommunityCommunityCommonBadges({
   return (
     !lessBadges && (
       <>
-        <li className="list-inline-item badge text-bg-light">
+        <span className="badge text-bg-light">
           {I18NextService.i18n.t("number_of_local_subscribers", {
             count: Number(subject.subscribers_local),
             formattedCount: numToSI(subject.subscribers_local),
           })}
-        </li>
-        <li className="list-inline-item badge text-bg-light">
+        </span>
+        <span className="badge text-bg-light">
           {I18NextService.i18n.t("number_of_subscribers", {
             count: Number(subject.subscribers),
             formattedCount: numToSI(subject.subscribers),
           })}
-        </li>
+        </span>
       </>
     )
   );

--- a/src/shared/components/common/content-actions/create-item-buttons.tsx
+++ b/src/shared/components/common/content-actions/create-item-buttons.tsx
@@ -37,7 +37,7 @@ export function CreatePostButton({
   myUserInfo,
 }: CreatePostButtonProps) {
   const classes = classNames(
-    "btn btn-light border-light-subtle d-block mb-2 w-100",
+    "btn btn-light border-light-subtle d-block w-100",
     {
       "no-click":
         communityView?.community.deleted ||
@@ -70,7 +70,7 @@ export function CreateCommunityButton({
 }: CreateCommunityButtonProps) {
   const classes = classNames({
     "no-click": !(localSite && canCreateCommunity(localSite, myUserInfo)),
-    "btn btn-light border-light-subtle d-block mb-2 w-100": blockButton,
+    "btn btn-light border-light-subtle d-block w-100": blockButton,
     "btn btn-sm btn-light border-light-subtle": !blockButton,
   });
 
@@ -91,7 +91,7 @@ export function CreateMultiCommunityButton({
 }: CreateMultiCommunityButtonProps) {
   const classes = classNames({
     "no-click": userNotLoggedInOrBanned(myUserInfo),
-    "btn btn-light border-light-subtle d-block mb-2 w-100": blockButton,
+    "btn btn-light border-light-subtle d-block w-100": blockButton,
     "btn btn-sm btn-light border-light-subtle": !blockButton,
   });
 

--- a/src/shared/components/common/subscribe-button.tsx
+++ b/src/shared/components/common/subscribe-button.tsx
@@ -30,7 +30,7 @@ export function SubscribeButton({
 }: SubscribeButtonProps) {
   const buttonClass = classNames("btn", {
     "btn-link p-0": isLink,
-    [`btn-light border-light-subtle d-block mb-2 w-100 btn-${followState === "pending" ? "warning" : "secondary"}`]:
+    [`btn-${followState === "pending" ? "warning" : "secondary"} border-light-subtle d-block w-100`]:
       !isLink,
   });
 

--- a/src/shared/components/community/community-sidebar.tsx
+++ b/src/shared/components/community/community-sidebar.tsx
@@ -99,12 +99,12 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
           <div id="sidebarContainer">
             {!this.props.hideButtons && (
               <section id="sidebarMain" className="card mb-3">
-                <div className="card-body">
+                <div className="card-body d-flex flex-column gap-2">
                   {this.communityTitle()}
                   {summary && <h6>{summary}</h6>}
                   {received_ban_at && (
                     <div
-                      className="alert alert-danger text-sm-start text-xs-center mt-2"
+                      className="alert alert-danger text-sm-start text-xs-center"
                       role="alert"
                     >
                       <Icon
@@ -141,7 +141,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                     </>
                   )}
                   <button
-                    className="btn btn-light border-light-subtle d-block mb-2 w-100"
+                    className="btn btn-light border-light-subtle d-block w-100"
                     onClick={() => handleShowReportModal(this)}
                   >
                     {I18NextService.i18n.t("create_report")}
@@ -152,7 +152,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                     show={this.state.showReportModal}
                   />
                   <Link
-                    className="btn btn-light border-light-subtle d-block mb-2 w-100"
+                    className="btn btn-light border-light-subtle d-block w-100"
                     to={`/modlog?communityId=${community.id}`}
                   >
                     {I18NextService.i18n.t("modlog")}
@@ -163,7 +163,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                   {amAdmin(myUserInfo) && (
                     <>
                       <button
-                        className="btn btn-light border-light-subtle d-block mb-2 w-100"
+                        className="btn btn-light border-light-subtle d-block w-100"
                         onClick={() => handleShowRemoveDialog(this)}
                       >
                         {I18NextService.i18n.t(
@@ -181,7 +181,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                         loading={false}
                       />
                       <button
-                        className="btn btn-light border-light-subtle d-block mb-2 w-100"
+                        className="btn btn-light border-light-subtle d-block w-100"
                         onClick={() => handleShowPurgeDialog(this)}
                         aria-label={I18NextService.i18n.t("purge_community")}
                       >
@@ -201,7 +201,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                     {this.props.myUserInfo && this.blockCommunity()}
                     {canViewCommunity_ && (
                       <>
-                        <div className="d-block mb-2">
+                        <div className="d-block">
                           <CommunityNotificationsDropdown
                             currentOption={this.state.notifications}
                             onSelect={val =>
@@ -235,7 +235,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                     )}
                   </>
                   {!this.props.myUserInfo && (
-                    <div className="alert alert-info" role="alert">
+                    <div className="alert alert-info mb-0" role="alert">
                       <T
                         i18nKey="community_not_logged_in_alert"
                         interpolation={{
@@ -251,7 +251,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
               </section>
             )}
             <section id="sidebarInfo" className="card mb-3">
-              <div className="card-body">
+              <div className="card-body d-flex flex-column gap-2">
                 {posting_restricted_to_mods && (
                   <div
                     className="alert alert-warning text-sm-start text-xs-center"
@@ -268,8 +268,8 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                   </div>
                 )}
                 {this.sidebarMarkdown()}
-                <div>
-                  <div className="fw-semibold mb-1">
+                <div className="d-flex flex-column gap-1">
+                  <div className="fw-semibold">
                     <span className="align-middle">
                       {I18NextService.i18n.t("community_visibility")}:&nbsp;
                     </span>
@@ -277,7 +277,9 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
                       {I18NextService.i18n.t(visibilityLabel)}
                     </span>
                   </div>
-                  <p>{I18NextService.i18n.t(visibilityDescription)}</p>
+                  <p className="mb-0">
+                    {I18NextService.i18n.t(visibilityDescription)}
+                  </p>
                 </div>
                 <LanguageList
                   allLanguages={this.props.allLanguages}
@@ -344,19 +346,19 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
     }
 
     return (
-      <ul className="list-inline small">
-        <li className="list-inline-item">{I18NextService.i18n.t("mods")}: </li>
+      <div className="d-flex flex-wrap gap-1 small">
+        <span>{I18NextService.i18n.t("mods")}: </span>
         {this.props.moderators.map(mod => (
-          <li key={mod.moderator.id} className="list-inline-item">
+          <span key={mod.moderator.id}>
             <PersonListing
               person={mod.moderator}
               banned={false}
               myUserInfo={this.props.myUserInfo}
               muted={false}
             />
-          </li>
+          </span>
         ))}
-      </ul>
+      </div>
     );
   }
 
@@ -367,7 +369,7 @@ export class CommunitySidebar extends Component<SidebarProps, SidebarState> {
     return (
       !subscribed && (
         <button
-          className="btn btn-danger d-block mb-2 w-100"
+          className="btn btn-danger d-block w-100"
           onClick={() => handleBlock(this)}
         >
           {I18NextService.i18n.t(

--- a/src/shared/components/home/site-sidebar.tsx
+++ b/src/shared/components/home/site-sidebar.tsx
@@ -105,11 +105,11 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
     const { site, activePlugins, myUserInfo } = this.props;
 
     return (
-      <div>
+      <div className="d-flex flex-column gap-2">
         {site.summary && <h6>{site.summary}</h6>}
         {site.sidebar && (
           <div
-            className="md-div mb-2"
+            className="md-div"
             dangerouslySetInnerHTML={mdToHtml(site.sidebar, () =>
               this.forceUpdate(),
             )}
@@ -127,14 +127,14 @@ export class SiteSidebar extends Component<SiteSidebarProps, SiteSidebarState> {
         />
         <CreateMultiCommunityButton myUserInfo={myUserInfo} blockButton />
         <Link
-          className="btn btn-light border-light-subtle d-block mb-2 w-100"
+          className="btn btn-light border-light-subtle d-block w-100"
           to="/modlog"
         >
           {I18NextService.i18n.t("modlog")}
         </Link>
         {amAdmin(myUserInfo) && (
           <Link
-            className="btn btn-light border-light-subtle d-block mb-2 w-100"
+            className="btn btn-light border-light-subtle d-block w-100"
             to="/admin"
           >
             {I18NextService.i18n.t("settings")}

--- a/src/shared/components/person/registration-applications.tsx
+++ b/src/shared/components/person/registration-applications.tsx
@@ -1,4 +1,4 @@
-import { editRegistrationApplication, setIsoData } from "@utils/app";
+import { setIsoData } from "@utils/app";
 import {
   getQueryParams,
   getQueryString,
@@ -23,7 +23,11 @@ import {
 } from "lemmy-js-client";
 import { fetchLimit } from "@utils/config";
 import { InitialFetchRequest } from "@utils/types";
-import { FirstLoadService, I18NextService } from "../../services";
+import {
+  FirstLoadService,
+  I18NextService,
+  UnreadCounterService,
+} from "../../services";
 import {
   EMPTY_REQUEST,
   HttpService,
@@ -251,7 +255,7 @@ export class RegistrationApplications extends Component<
     return {
       listRegistrationApplicationsResponse: headers["Authorization"]
         ? await client.listRegistrationApplications({
-            unread_only: view === "unread",
+            unread_only: registrationStateFromQuery(view) === "unread",
             page_cursor: cursor,
             limit: fetchLimit,
           })
@@ -312,14 +316,14 @@ async function handleApproveApplication(
   const res = await HttpService.client.approveRegistrationApplication(form);
   i.setState({ approveRes: { id: form.id, res } });
 
-  i.setState(s => {
-    if (s.appsRes.state === "success" && res.state === "success") {
-      removeLocalStorageMarkdown();
-      s.appsRes.data.items = editRegistrationApplication(
-        res.data.registration_application,
-        s.appsRes.data.items,
-      );
-    }
-    return s;
-  });
+  if (res.state === "success") {
+    removeLocalStorageMarkdown();
+    UnreadCounterService.Instance.unreadApplicationCount.next(
+      Math.max(
+        0,
+        UnreadCounterService.Instance.unreadApplicationCount.value - 1,
+      ),
+    );
+    await i.refetch(i.props);
+  }
 }


### PR DESCRIPTION
## Summary
- Replace `mb-2`/`my-1` margins with `d-flex flex-column gap-2` on sidebar containers for consistent spacing
- Remove redundant `.btn.d-block + .btn.d-block` margin-top CSS rule (was marked as TODO in main.css)
- Switch badges and mods list from `ul`/`li` to `div`/`span` with `d-flex flex-wrap gap-1` to avoid default list margins and padding
- Add `mb-0` to alert and `<p>` elements inside gap containers to prevent double spacing
- Fix registration applications `unread_only` filter to use `registrationStateFromQuery` instead of raw view string
- Decrement `UnreadCounterService` unread application count on approve instead of manually editing list state

#### Test plan
- [x] Sidebar buttons have consistent spacing with no double margins
- [x] Badges wrap correctly with `gap-1` spacing, no extra padding
- [x] Mods list renders without default list margins
- [x] Registration applications unread filter works correctly
- [x] Approving an application decrements the unread counter

Before:
<img width="1810" height="802" alt="screenshot-2026-08-05_03-41-50" src="https://github.com/user-attachments/assets/40f36f67-f2ca-4c7a-8ec9-b2fcfe460ebe" />
After:
<img width="1348" height="834" alt="screenshot-2026-08-05_17-31-37" src="https://github.com/user-attachments/assets/70cfd98b-23f5-4a8d-810d-51f5e0bb07f6" />

Video:
Before:
<img width="800" height="373" alt="screenrecording-2026-08-05_04-44-46-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/6155e64f-da44-4482-8cd5-362ca234710c" />
After:
<img width="800" height="379" alt="screenrecording-2026-08-05_04-53-33-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/ca486b29-93f0-4f97-9ad5-74a9bfe20b41" />