### PR TITLE
[0.19] Fix for wrong link previews (fixes #2808)

### DIFF
--- a/src/server/handlers/catch-all-handler.tsx
+++ b/src/server/handlers/catch-all-handler.tsx
@@ -5,6 +5,7 @@ import type { Request, Response } from "express";
 import { StaticRouter, matchPath } from "inferno-router";
 import { Match } from "inferno-router/dist/Route";
 import { renderToString } from "inferno-server";
+import { Helmet } from "inferno-helmet";
 import { GetSiteResponse, LemmyHttp } from "lemmy-js-client";
 import App from "../../shared/components/app/app";
 import {
@@ -156,10 +157,12 @@ export default async (req: Request, res: Response) => {
     LanguageService.updateLanguages(languages);
 
     const root = renderToString(wrapper);
+    const helmet = Helmet.renderStatic();
 
     res.send(
       await createSsrHtml(
         root,
+        helmet,
         isoData,
         res.locals.cspNonce,
         LanguageService.userLanguages,

--- a/src/server/utils/create-ssr-html.tsx
+++ b/src/server/utils/create-ssr-html.tsx
@@ -1,5 +1,4 @@
 import { getStaticDir } from "@utils/env";
-import { Helmet } from "inferno-helmet";
 import { renderToString } from "inferno-server";
 import serialize from "serialize-javascript";
 import sharp from "sharp";
@@ -16,6 +15,7 @@ let appleTouchIcon: string | undefined = undefined;
 
 export async function createSsrHtml(
   root: string,
+  helmet: any,
   isoData: IsoDataOptionalSite,
   cspNonce: string,
   userLanguages: readonly string[],
@@ -70,8 +70,6 @@ export async function createSsrHtml(
           </>,
         )
       : "";
-
-  const helmet = Helmet.renderStatic();
 
   const lazyScripts = [
     ...findTranslationChunkNames(userLanguages),


### PR DESCRIPTION
Used an LLM to analyze the issue and relevant code. In conclusion its actually related to `Helmet` like I suspected. Specifically, helmet tags are pushed in `renderToString` (catch-all-handler.tsx:161), and then read out with `Helmet.renderStatic()` (create-ssr-html.tsx:74). The problem is that there are `await` points between these two calls. So if two HTTP requests enter this section at the same time, Helmet metadata can be mixed up. 

The problem is fixed by moving helmet logic next to each other, without any await in between. I will also make a fix for 1.0 later.