### PR TITLE
Minor OAuth bug fixes

### DIFF
--- a/src/shared/components/home/oauth/oauth-callback.tsx
+++ b/src/shared/components/home/oauth/oauth-callback.tsx
@@ -268,7 +268,7 @@ function handleSubmit(i: OAuthCallback) {
     handleLoginWithProvider(
       provider,
       i.state.username,
-      decodeURIComponent(local_oauth_state.redirect_uri),
+      local_oauth_state.prev,
       i.state.answer,
       i.state.show_nsfw,
       i.state.stay_logged_in,

--- a/src/shared/components/home/oauth/oauth-login.tsx
+++ b/src/shared/components/home/oauth/oauth-login.tsx
@@ -53,7 +53,6 @@ export function handleLoginWithProvider(
       `scope=${encodeURIComponent(oauth_provider.scopes)}`,
       `redirect_uri=${encodeURIComponent(redirectUri)}`,
       `state=${state}`,
-      `answer = ${answer}`,
     ].join("&");
 
   const oauth_state: LocalOauthState = {


### PR DESCRIPTION
- third param of handleLoginWithProvider is `prev`, so passing `redirect_uri` is wrong
- `answer` should not be sent to oauth provider at all (it is stored in localstorage to be used later)