### PR TITLE
Fix for ViewerJS leak

### DIFF
--- a/src/shared/components/comment/comment-node.tsx
+++ b/src/shared/components/comment/comment-node.tsx
@@ -69,7 +69,6 @@ type CommentNodeState = {
   collapsed: boolean;
   viewSource: boolean;
   showAdvanced: boolean;
-  viewerjss: Viewer[];
 };
 
 type CommentNodeProps = {
@@ -132,7 +131,6 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     collapsed: this.initCommentCollapsed(),
     viewSource: false,
     showAdvanced: false,
-    viewerjss: [],
   };
 
   componentWillReceiveProps(
@@ -197,27 +195,28 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
     }
   }
 
-  loadViewerJsForImages(setState: boolean = true) {
-    // Load the viewer for every image in the comment
+  viewerjss: Viewer[] = [];
+
+  loadViewerJsForImages() {
+    this.unloadViewerJs();
     const id = this.commentView.comment.id;
     const images = document.querySelectorAll(
       `#comment-${id} > div > div.comment-content > div > p > img`,
     );
-    const viewerjss: Viewer[] = [];
+    // Load the viewer for every image in the comment
     images.forEach((i: HTMLElement) => {
-      const viewer = new Viewer(i, {
-        url: (image: { src: string }) => viewerJsFullSizeImageUrl(image),
-        toolbar: false,
-      });
-      viewerjss.push(viewer);
+      this.viewerjss.push(
+        new Viewer(i, {
+          url: (image: { src: string }) => viewerJsFullSizeImageUrl(image),
+          toolbar: false,
+        }),
+      );
     });
-    if (setState) {
-      this.setState({ viewerjss });
-    }
   }
 
   unloadViewerJs() {
-    this.state.viewerjss.forEach(v => v.destroy());
+    this.viewerjss.forEach(v => v.destroy());
+    this.viewerjss = [];
   }
 
   componentWillUnmount() {
@@ -229,7 +228,7 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
   }
 
   componentDidUpdate() {
-    this.loadViewerJsForImages(false);
+    this.loadViewerJsForImages();
   }
 
   render() {

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -46,7 +46,6 @@ import { viewerJsFullSizeImageUrl } from "@components/common/pictrs-image";
 
 type PostListingState = {
   showEdit: boolean;
-  viewerjss: Viewer[];
 };
 
 type PostListingProps = {
@@ -105,7 +104,6 @@ type PostListingProps = {
 export class PostListing extends Component<PostListingProps, PostListingState> {
   state: PostListingState = {
     showEdit: false,
-    viewerjss: [],
   };
 
   unlisten = () => {};
@@ -134,28 +132,28 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
     }
   }
 
-  loadViewerJsForImages(setState: boolean = true) {
-    // Load the image viewer for every image in the post body
+  viewerjss: Viewer[] = [];
+
+  loadViewerJsForImages() {
+    this.unloadViewerJs();
     const id = this.props.postView.post.id;
     const images = document.querySelectorAll(
       `#post-listing-${id} > div > article > div > article > div > div > p > img`,
     );
-    const viewerjss: Viewer[] = [];
+    // Load the image viewer for every image in the post body
     images.forEach((i: HTMLElement) => {
-      const viewer = new Viewer(i, {
-        url: (image: { src: string }) => viewerJsFullSizeImageUrl(image),
-        toolbar: false,
-      });
-      viewerjss.push(viewer);
+      this.viewerjss.push(
+        new Viewer(i, {
+          url: (image: { src: string }) => viewerJsFullSizeImageUrl(image),
+          toolbar: false,
+        }),
+      );
     });
-
-    if (setState) {
-      this.setState({ viewerjss });
-    }
   }
 
   unloadViewerJs() {
-    this.state.viewerjss.forEach(v => v.destroy());
+    this.viewerjss.forEach(v => v.destroy());
+    this.viewerjss = [];
   }
 
   componentDidMount() {
@@ -163,7 +161,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
   }
 
   componentDidUpdate() {
-    this.loadViewerJsForImages(false);
+    this.loadViewerJsForImages();
   }
 
   render() {


### PR DESCRIPTION
The existing code recreates viewers on every render (which is correct), but on rerender never destroys the previous viewers which leads to memory leak. Also viewers should not be stored in state because changing them should not cause extra render.