### PR TITLE
[0.19] Add `referrerpolicy` to video iframe

### DIFF
--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -267,7 +267,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             src={post.embed_video_url}
             sandbox="allow-same-origin allow-scripts"
             allowFullScreen={true}
-            referrerpolicy="strict-origin-when-cross-origin"
+            referrerPolicy="strict-origin-when-cross-origin"
           ></iframe>
         </div>
       );

--- a/src/shared/components/post/post-listing.tsx
+++ b/src/shared/components/post/post-listing.tsx
@@ -267,6 +267,7 @@ export class PostListing extends Component<PostListingProps, PostListingState> {
             src={post.embed_video_url}
             sandbox="allow-same-origin allow-scripts"
             allowFullScreen={true}
+            referrerpolicy="strict-origin-when-cross-origin"
           ></iframe>
         </div>
       );


### PR DESCRIPTION
## Description

This change makes it so that YouTube video embeds are actually playable. According to MDN, `strict-origin-when-cross-origin` is suppose to be the default, so I'm not sure why this change fixes this but it does.

Before: https://slrpnk.net/post/41462932  
After: https://feddit.uk/post/53830092