### PR TITLE
Bind correct `this` handles in modal mixin

### DIFF
--- a/src/shared/components/mixins/modal-mixin.ts
+++ b/src/shared/components/mixins/modal-mixin.ts
@@ -26,6 +26,9 @@ export function modalMixin<
     }
 
     async componentDidMount() {
+      this.handleHide = this.handleHide?.bind(this) as (() => void) | undefined;
+      this.handleShow = this.handleShow?.bind(this) as (() => void) | undefined;
+
       // Keeping this sync to allow the super implementation to be sync
       await import("bootstrap/js/dist/modal").then(
         (res: { default: typeof Modal }) => {


### PR DESCRIPTION
`this` in the existing code refers to the DOM element instead of the components, which means the handlers were not called properly, and there was a console error.